### PR TITLE
 Gene generator creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -18,9 +18,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -111,12 +111,6 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
@@ -158,7 +152,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -218,7 +212,7 @@ dependencies = [
  "itertools 0.12.1",
  "macro_railroad_annotation",
  "num-traits",
- "rand",
+ "rand 0.9.0-alpha.0",
  "rayon",
 ]
 
@@ -230,14 +224,14 @@ dependencies = [
  "clap",
  "ec-core",
  "num-traits",
- "rand",
+ "rand 0.9.0-alpha.0",
 ]
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "embed-doc-image"
@@ -304,7 +298,7 @@ checksum = "6adcc45088fbcbe7963bdca7bda19ab4214ffd794c6ef88813a3cb983ba7d881"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -357,7 +351,7 @@ checksum = "9f265a449ea0f49d18453db0daa0f81d6859ffa5f92f6788ee4d9653532fc67c"
 dependencies = [
  "proc-macro2",
  "railroad",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -371,8 +365,8 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
- "rand",
- "syn 2.0.50",
+ "rand 0.8.5",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -384,7 +378,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -431,7 +425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -444,7 +438,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -475,11 +469,11 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.2",
+ "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -503,7 +497,7 @@ dependencies = [
  "ordered-float",
  "proptest",
  "push_macros",
- "rand",
+ "rand 0.9.0-alpha.0",
  "strum",
  "strum_macros",
  "thiserror",
@@ -521,7 +515,7 @@ dependencies = [
  "proc-macro-assertions",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -556,8 +550,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0-alpha.0"
+source = "git+https://github.com/JustusFluegel/rand.git#41b044a5491b39e65e37fc946fde6eb002ff8fd1"
+dependencies = [
+ "libc",
+ "rand_chacha 0.9.0-alpha.0",
+ "rand_core 0.9.0-alpha.0",
+ "zerocopy",
 ]
 
 [[package]]
@@ -567,7 +572,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0-alpha.0"
+source = "git+https://github.com/JustusFluegel/rand.git#41b044a5491b39e65e37fc946fde6eb002ff8fd1"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0-alpha.0",
 ]
 
 [[package]]
@@ -580,19 +594,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.0-alpha.0"
+source = "git+https://github.com/JustusFluegel/rand.git#41b044a5491b39e65e37fc946fde6eb002ff8fd1"
+dependencies = [
+ "getrandom",
+ "zerocopy",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -609,15 +632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,7 +643,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -663,7 +677,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -694,7 +708,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -710,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -721,13 +735,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys",
 ]
@@ -749,7 +762,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -802,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -817,42 +830,62 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd4a4b5a6b38e736bca19abe211abf0ba2552462555fc960d763fbbaff2b191"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157bd6b2f5a6f8e2b1b1e5b427aec8d2c085f9ab99c92eaa0ca79b9b84c11254"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
  "itertools 0.12.1",
  "macro_railroad_annotation",
  "num-traits",
- "rand 0.9.0-alpha.0",
+ "rand 0.9.0-alpha.1",
  "rayon",
 ]
 
@@ -224,7 +224,7 @@ dependencies = [
  "clap",
  "ec-core",
  "num-traits",
- "rand 0.9.0-alpha.0",
+ "rand 0.9.0-alpha.1",
 ]
 
 [[package]]
@@ -371,7 +371,7 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
- "rand",
+ "rand 0.8.5",
  "syn 2.0.58",
 ]
 
@@ -503,7 +503,7 @@ dependencies = [
  "ordered-float",
  "proptest",
  "push_macros",
- "rand 0.9.0-alpha.0",
+ "rand 0.9.0-alpha.1",
  "strum",
  "strum_macros",
  "thiserror",
@@ -562,12 +562,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0-alpha.0"
-source = "git+https://github.com/rust-random/rand.git#7ed92ee2781e6887799b8f455a4670a6bd1e46ab"
+version = "0.9.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31e63ea85be51c423e52ba8f2e68a3efd53eed30203ee029dd09947333693e"
 dependencies = [
- "libc",
- "rand_chacha 0.9.0-alpha.0",
- "rand_core 0.9.0-alpha.0",
+ "rand_chacha 0.9.0-alpha.1",
+ "rand_core 0.9.0-alpha.1",
  "zerocopy",
 ]
 
@@ -583,11 +583,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.9.0-alpha.0"
-source = "git+https://github.com/rust-random/rand.git#7ed92ee2781e6887799b8f455a4670a6bd1e46ab"
+version = "0.9.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78674ef918c19451dbd250f8201f8619b494f64c9aa6f3adb28fd8a0f1f6da46"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0-alpha.0",
+ "rand_core 0.9.0-alpha.1",
 ]
 
 [[package]]
@@ -601,8 +602,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0-alpha.0"
-source = "git+https://github.com/rust-random/rand.git#7ed92ee2781e6887799b8f455a4670a6bd1e46ab"
+version = "0.9.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc89dffba8377c5ec847d12bb41492bda235dba31a25e8b695cd0fe6589eb8c9"
 dependencies = [
  "getrandom",
  "zerocopy",
@@ -882,3 +884,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db678a6ee512bd06adf35c35be471cae2f9c82a5aed2b5d15e03628c98bddd57"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201585ea96d37ee69f2ac769925ca57160cef31acb137c16f38b02b76f4c1e62"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "rand"
 version = "0.9.0-alpha.0"
-source = "git+https://github.com/JustusFluegel/rand.git#41b044a5491b39e65e37fc946fde6eb002ff8fd1"
+source = "git+https://github.com/rust-random/rand.git#7ed92ee2781e6887799b8f455a4670a6bd1e46ab"
 dependencies = [
  "libc",
  "rand_chacha 0.9.0-alpha.0",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "rand_chacha"
 version = "0.9.0-alpha.0"
-source = "git+https://github.com/JustusFluegel/rand.git#41b044a5491b39e65e37fc946fde6eb002ff8fd1"
+source = "git+https://github.com/rust-random/rand.git#7ed92ee2781e6887799b8f455a4670a6bd1e46ab"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.0-alpha.0",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "rand_core"
 version = "0.9.0-alpha.0"
-source = "git+https://github.com/JustusFluegel/rand.git#41b044a5491b39e65e37fc946fde6eb002ff8fd1"
+source = "git+https://github.com/rust-random/rand.git#7ed92ee2781e6887799b8f455a4670a6bd1e46ab"
 dependencies = [
  "getrandom",
  "zerocopy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,6 @@ many_generations.arguments = [
 ]
 
 [patch.crates-io]
-rand = { git = "https://github.com/JustusFluegel/rand.git" }
+rand = { git = "https://github.com/rust-random/rand.git" }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ debug = true
 [workspace.dependencies]
 anyhow = "1.0.80"
 clap = "4.5.1"
-rand = "0.8.5"
+rand = "0.9.0-alpha.0"
 num-traits = "0.2.18"
 thiserror = "1.0.57"
 itertools = "0.12.1"
@@ -66,3 +66,8 @@ many_generations.arguments = [
   "--population-size",
   "10"
 ]
+
+[patch.crates-io]
+rand = { git = "https://github.com/JustusFluegel/rand.git" }
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ debug = true
 [workspace.dependencies]
 anyhow = "1.0.80"
 clap = "4.5.1"
-rand = "0.9.0-alpha.0"
+rand = "0.9.0-alpha.1"
 num-traits = "0.2.18"
 thiserror = "1.0.57"
 itertools = "0.12.1"
@@ -66,8 +66,3 @@ many_generations.arguments = [
   "--population-size",
   "10"
 ]
-
-[patch.crates-io]
-rand = { git = "https://github.com/rust-random/rand.git" }
-
-

--- a/packages/ec-core/src/distributions/choices.rs
+++ b/packages/ec-core/src/distributions/choices.rs
@@ -1,0 +1,33 @@
+use std::num::NonZeroUsize;
+
+use rand::distributions::Slice;
+
+/// A Distribution which knows how many choices are selcted from
+pub trait ChoicesDistribution {
+    /// The number of choices this distribution selects from
+    fn num_choices(&self) -> NonZeroUsize;
+}
+
+impl<'a, T> ChoicesDistribution for Slice<'a, T> {
+    fn num_choices(&self) -> NonZeroUsize {
+        self.num_choices()
+    }
+}
+
+impl<'a, T> ChoicesDistribution for &'a T
+where
+    T: ChoicesDistribution + ?Sized,
+{
+    fn num_choices(&self) -> NonZeroUsize {
+        (**self).num_choices()
+    }
+}
+
+impl<'a, T> ChoicesDistribution for &'a mut T
+where
+    T: ChoicesDistribution + ?Sized,
+{
+    fn num_choices(&self) -> NonZeroUsize {
+        (**self).num_choices()
+    }
+}

--- a/packages/ec-core/src/distributions/mod.rs
+++ b/packages/ec-core/src/distributions/mod.rs
@@ -1,3 +1,4 @@
+pub mod choices;
 pub mod collection;
 pub mod conversion;
 pub mod one_of_macro;

--- a/packages/ec-core/src/distributions/wrappers/owned.rs
+++ b/packages/ec-core/src/distributions/wrappers/owned.rs
@@ -6,6 +6,14 @@ use crate::distributions::{choices::ChoicesDistribution, wrappers::slice_cloning
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct OneOfCloning<T, U> {
+    // It is really important here that the fields `collection`, `range` and `num_choices` are
+    // never modified, since they all contain information about the length of the collection
+    // which need to be in sync for no panics to occur.
+    //
+    // Therefore, these fields may *never* be pub and no methods may be introduced which can modify
+    // fields without keeping this contract
+    //
+    // Currently these fields are *never* modified at all.
     collection: T,
     range: Uniform<usize>,
     num_choices: NonZeroUsize,

--- a/packages/ec-core/src/distributions/wrappers/owned.rs
+++ b/packages/ec-core/src/distributions/wrappers/owned.rs
@@ -16,6 +16,8 @@ pub struct OneOfCloning<T, U> {
     // Currently these fields are *never* modified at all.
     collection: T,
     range: Uniform<usize>,
+    // we store the NonZeroUsize in the struct here, since we need to check this invariant in the
+    // new anyways. As such it would make little sense to recompute that every time
     num_choices: NonZeroUsize,
     _p: PhantomData<U>,
 }

--- a/packages/ec-core/src/distributions/wrappers/owned.rs
+++ b/packages/ec-core/src/distributions/wrappers/owned.rs
@@ -2,12 +2,13 @@ use std::{borrow::Borrow, marker::PhantomData, num::NonZeroUsize};
 
 use rand::{distributions::Uniform, prelude::Distribution};
 
-use crate::distributions::wrappers::slice_cloning::EmptySlice;
+use crate::distributions::{choices::ChoicesDistribution, wrappers::slice_cloning::EmptySlice};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct OneOfCloning<T, U> {
     collection: T,
     range: Uniform<usize>,
+    num_choices: NonZeroUsize,
     _p: PhantomData<U>,
 }
 
@@ -22,31 +23,22 @@ where
     /// # Errors
     /// - [`EmptySlice`] if an empty collection is passed in, since then no
     ///   element can be selected from there
-    pub fn new(val: T) -> Result<Self, EmptySlice> {
-        match val.borrow().len() {
-            0 => Err(EmptySlice),
-            len => Ok(Self {
-                collection: val,
-                range: Uniform::new(0, len),
-                _p: PhantomData,
-            }),
-        }
-    }
-
+    #[allow(clippy::unwrap_used)]
     #[allow(clippy::missing_panics_doc)]
-    pub fn num_choices(&self) -> NonZeroUsize {
-        let choices = self.collection.borrow().len();
+    pub fn new(collection: T) -> Result<Self, EmptySlice> {
+        let num_choices = NonZeroUsize::new(collection.borrow().len()).ok_or(EmptySlice)?;
 
-        debug_assert_ne!(
-            choices, 0,
-            "This should never happen since the new method checks for this"
-        );
-        // FIXME: Check the performance of this
-        // // Safety: at construction time, it was ensured that the slice was
-        // // non-empty, as such the len is > 0.
-        // unsafe { NonZeroUsize::new_unchecked(self.collection.borrow().len()) }
-        #[allow(clippy::unwrap_used)]
-        NonZeroUsize::new(choices).unwrap()
+        Ok(Self {
+            collection,
+            range: Uniform::new(0, num_choices.get()).unwrap(),
+            num_choices,
+            _p: PhantomData,
+        })
+    }
+}
+impl<T, U> ChoicesDistribution for OneOfCloning<T, U> {
+    fn num_choices(&self) -> NonZeroUsize {
+        self.num_choices
     }
 }
 

--- a/packages/ec-core/src/distributions/wrappers/owned.rs
+++ b/packages/ec-core/src/distributions/wrappers/owned.rs
@@ -4,6 +4,10 @@ use rand::{distributions::Uniform, prelude::Distribution};
 
 use crate::distributions::{choices::ChoicesDistribution, wrappers::slice_cloning::EmptySlice};
 
+/// Generate a random element from a collection of options, cloning the chosen
+/// element. The [`OneOfCloning`] struct takes ownership of the collection; the
+/// [`SliceCloning`](super::slice_cloning::SliceCloning) struct allows one to
+/// borrow the collection.
 #[derive(Debug, PartialEq, Eq)]
 pub struct OneOfCloning<T, U> {
     // It is really important here that the fields `collection`, `range` and `num_choices` are
@@ -11,13 +15,13 @@ pub struct OneOfCloning<T, U> {
     // which need to be in sync for no panics to occur.
     //
     // Therefore, these fields may *never* be pub and no methods may be introduced which can modify
-    // fields without keeping this contract
+    // fields without keeping this contract.
     //
     // Currently these fields are *never* modified at all.
     collection: T,
     range: Uniform<usize>,
     // we store the NonZeroUsize in the struct here, since we need to check this invariant in the
-    // new anyways. As such it would make little sense to recompute that every time
+    // new anyways. As such it would make little sense to recompute that every time.
     num_choices: NonZeroUsize,
     _p: PhantomData<U>,
 }
@@ -29,6 +33,26 @@ where
     /// Create a new [`OneOfCloning`] distribution, which selects a
     /// value from a collection and then returns a new value by cloning the
     /// selected value.
+    ///
+    /// ```
+    /// # use rand::distributions::Distribution;
+    /// # use ec_core::distributions::{
+    /// #    choices::ChoicesDistribution,
+    /// #    wrappers::{
+    /// #       owned::OneOfCloning,
+    /// #       slice_cloning::EmptySlice,
+    /// #    },
+    /// # };
+    /// #
+    /// let options = [1, 2, 3];
+    /// let distr = OneOfCloning::new(options)?;
+    /// assert_eq!(options.len(), distr.num_choices().get());
+    ///
+    /// let val = distr.sample(&mut rand::thread_rng());
+    /// assert!(options.contains(&val));
+    ///
+    /// # Ok::<(), EmptySlice>(())
+    ///  ```
     ///
     /// # Errors
     /// - [`EmptySlice`] if an empty collection is passed in, since then no

--- a/packages/ec-core/src/distributions/wrappers/slice_cloning.rs
+++ b/packages/ec-core/src/distributions/wrappers/slice_cloning.rs
@@ -1,4 +1,8 @@
+use std::num::NonZeroUsize;
+
 use rand::{distributions::Slice, prelude::Distribution};
+
+use crate::distributions::choices::ChoicesDistribution;
 
 /// Generate a random element from an array of options, cloning the choosen
 /// element.
@@ -28,11 +32,12 @@ impl<'a, T> SliceCloning<'a, T> {
     pub fn new(slice: &'a [T]) -> Result<Self, EmptySlice> {
         Ok(Self(Slice::new(slice).map_err(|_| EmptySlice)?))
     }
+}
 
-    // This is waiting on https://github.com/rust-random/rand/pull/1402
-    // pub fn num_choices(&self) -> NonZeroUsize {
-    //     self.0.num_choices()
-    // }
+impl<'a, T> ChoicesDistribution for SliceCloning<'a, T> {
+    fn num_choices(&self) -> NonZeroUsize {
+        self.0.num_choices()
+    }
 }
 
 impl<'a, T> Distribution<T> for SliceCloning<'a, T>

--- a/packages/ec-core/src/operator/selector/random.rs
+++ b/packages/ec-core/src/operator/selector/random.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rand::{prelude::SliceRandom, rngs::ThreadRng};
+use rand::{prelude::IndexedRandom, rngs::ThreadRng};
 
 use super::Selector;
 use crate::population::Population;

--- a/packages/ec-core/src/operator/selector/tournament.rs
+++ b/packages/ec-core/src/operator/selector/tournament.rs
@@ -1,5 +1,5 @@
 use anyhow::{ensure, Context, Result};
-use rand::{prelude::SliceRandom, rngs::ThreadRng};
+use rand::{prelude::IndexedRandom, rngs::ThreadRng};
 
 use super::Selector;
 use crate::population::Population;

--- a/packages/ec-core/src/operator/selector/weighted.rs
+++ b/packages/ec-core/src/operator/selector/weighted.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rand::{rngs::ThreadRng, seq::SliceRandom};
+use rand::{rngs::ThreadRng, seq::IndexedRandom};
 
 use super::Selector;
 use crate::population::Population;

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -16,15 +16,15 @@ use ec_core::{
         Composable,
     },
     test_results::{self, TestResults},
+    uniform_distribution_of,
 };
 use ec_linear::mutator::umad::Umad;
 use ordered_float::OrderedFloat;
 use push::{
     evaluation::cases::{Case, Cases},
-    genome::plushy::{GeneGenerator, Plushy},
-    instruction::{variable_name::VariableName, FloatInstruction},
+    genome::plushy::{ConvertToGeneGenerator, Plushy},
+    instruction::{variable_name::VariableName, FloatInstruction, PushInstruction},
     push_vm::{program::PushProgram, push_state::PushState, HasStack, State},
-    vec_into,
 };
 use rand::{prelude::Distribution, thread_rng};
 
@@ -127,7 +127,7 @@ fn main() -> Result<()> {
 
     let mut rng = thread_rng();
 
-    let instruction_set = vec_into![
+    let gene_generator = uniform_distribution_of![<PushInstruction>
         FloatInstruction::Add,
         FloatInstruction::Subtract,
         FloatInstruction::Multiply,
@@ -136,9 +136,8 @@ fn main() -> Result<()> {
         FloatInstruction::Push(OrderedFloat(0.0)),
         FloatInstruction::Push(OrderedFloat(1.0)),
         VariableName::from("x")
-    ];
-
-    let gene_generator = GeneGenerator::with_uniform_close_probability(&instruction_set)?;
+    ]
+    .into_gene_generator_with_uniform_close_probability();
 
     let population = gene_generator
         .to_collection_generator(args.max_initial_instructions)

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -137,7 +137,7 @@ fn main() -> Result<()> {
         FloatInstruction::Push(OrderedFloat(1.0)),
         VariableName::from("x")
     ]
-    .into_gene_generator_with_uniform_close_probability();
+    .into_gene_generator();
 
     let population = gene_generator
         .to_collection_generator(args.max_initial_instructions)

--- a/packages/push/examples/simple_regression/main.rs
+++ b/packages/push/examples/simple_regression/main.rs
@@ -119,7 +119,7 @@ fn main() -> Result<()> {
         FloatInstruction::ProtectedDivide,
         VariableName::from("x")
     ]
-    .into_gene_generator_with_uniform_close_probability();
+    .into_gene_generator();
 
     let population = gene_generator
         .to_collection_generator(args.max_initial_instructions)

--- a/packages/push/examples/simple_regression/main.rs
+++ b/packages/push/examples/simple_regression/main.rs
@@ -22,14 +22,14 @@ use ec_core::{
         Composable,
     },
     test_results::{self, TestResults},
+    uniform_distribution_of,
 };
 use ec_linear::mutator::umad::Umad;
 use ordered_float::OrderedFloat;
 use push::{
-    genome::plushy::{GeneGenerator, Plushy},
-    instruction::{variable_name::VariableName, FloatInstruction},
+    genome::plushy::{ConvertToGeneGenerator, Plushy},
+    instruction::{variable_name::VariableName, FloatInstruction, PushInstruction},
     push_vm::{program::PushProgram, push_state::PushState, HasStack, State},
-    vec_into,
 };
 use rand::{distributions::Distribution, thread_rng};
 
@@ -112,15 +112,14 @@ fn main() -> Result<()> {
 
     let mut rng = thread_rng();
 
-    let instruction_set = vec_into![
+    let gene_generator = uniform_distribution_of![<PushInstruction>
         FloatInstruction::Add,
         FloatInstruction::Subtract,
         FloatInstruction::Multiply,
         FloatInstruction::ProtectedDivide,
         VariableName::from("x")
-    ];
-
-    let gene_generator = GeneGenerator::with_uniform_close_probability(&instruction_set)?;
+    ]
+    .into_gene_generator_with_uniform_close_probability();
 
     let population = gene_generator
         .to_collection_generator(args.max_initial_instructions)

--- a/packages/push/src/genome/plushy.rs
+++ b/packages/push/src/genome/plushy.rs
@@ -59,9 +59,6 @@ where
 {
     /// Create a generator where the close tag has the same likelihood of
     /// being chosen as any of the passed in instructions.
-    ///
-    /// # Errors
-    /// - [`EmptySlice`] if the passed in slice is empty
     pub fn with_uniform_close_probability(instructions_distribution: T) -> Self {
         Self::new(
             1.0 / f32::conv_approx(instructions_distribution.num_choices().get() + 1),

--- a/packages/push/src/genome/plushy.rs
+++ b/packages/push/src/genome/plushy.rs
@@ -86,11 +86,16 @@ where
         close_probability: f32,
     ) -> GeneGenerator<&Self>;
 
-    fn into_gene_generator_with_uniform_close_probability(self) -> GeneGenerator<Self>
+    /// This creates a new gene generator, defaulting to a close probability
+    /// that is uniform with the instructions distribution, eg. (1/(n+1)).
+    fn into_gene_generator(self) -> GeneGenerator<Self>
     where
         Self: Sized + ChoicesDistribution;
 
-    fn to_gene_generator_with_uniform_close_probability(&self) -> GeneGenerator<&Self>
+    /// This creates a new gene generator by borrowing from self, defaulting to
+    /// a close probability that is uniform with the instructions distribution,
+    /// eg. (1/(n+1)).
+    fn to_gene_generator(&self) -> GeneGenerator<&Self>
     where
         Self: ChoicesDistribution;
 }
@@ -116,14 +121,14 @@ where
         GeneGenerator::new(close_probability, self)
     }
 
-    fn into_gene_generator_with_uniform_close_probability(self) -> GeneGenerator<Self>
+    fn into_gene_generator(self) -> GeneGenerator<Self>
     where
         Self: Sized + ChoicesDistribution,
     {
         GeneGenerator::with_uniform_close_probability(self)
     }
 
-    fn to_gene_generator_with_uniform_close_probability(&self) -> GeneGenerator<&Self>
+    fn to_gene_generator(&self) -> GeneGenerator<&Self>
     where
         Self: ChoicesDistribution,
     {
@@ -237,7 +242,7 @@ mod test {
             IntInstruction::Multiply,
             IntInstruction::ProtectedDivide,
         ]
-        .into_gene_generator_with_uniform_close_probability()
+        .into_gene_generator()
         .into_collection_generator(10)
         .sample(&mut rng);
 


### PR DESCRIPTION
This is meant to implement the `.into_gene_generator(CloseProbability::Uniform)` and `.to_gene_generator(CloseProbability::Given(0.1))` methods, but is currently waiting on https://github.com/rust-random/rand/pull/1402

( oh and as this is based on #94 the changelog is quite messy, see [here](https://github.com/JustusFluegel/rust-ga/compare/rand_distrb_trait...JustusFluegel:rust-ga:gene_generator_creation) for the direct diff )