### PR TITLE
Move from proptest!{} to test_strategy::proptest and update max_stack_size values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "rand 0.9.0-alpha.1",
  "strum",
  "strum_macros",
+ "test-strategy",
  "thiserror",
 ]
 
@@ -701,6 +702,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +775,18 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ num-traits = "0.2.18"
 thiserror = "1.0.59"
 itertools = "0.12.1"
 macro_railroad_annotation = "1.0.3"
+test-strategy = "0.3.1"
+proptest = "1.2.0"
 
 ec-core = { path = "packages/ec-core" }
 ec-linear = { path = "packages/ec-linear" }

--- a/packages/push/Cargo.toml
+++ b/packages/push/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = { workspace = true }
 ec-core = { workspace = true }
 ec-linear = { workspace = true }
 
-proptest = "1.2.0"
+proptest = { workspace = true }
 strum = "0.26.2"
 strum_macros = "0.26.2"
 embed-doc-image = "0.1.4"
@@ -27,7 +27,7 @@ collectable = "0.0.2"
 ordered-float = { version = "4.1.1", features = ["proptest"] }
 easy-cast = "0.5.2"
 macro_railroad_annotation = { workspace = true }
-test-strategy = "0.3.1"
+test-strategy = { workspace = true }
 
 [dev-dependencies]
 clap = { version = "4.5.1", features = ["derive"] }

--- a/packages/push/Cargo.toml
+++ b/packages/push/Cargo.toml
@@ -27,6 +27,7 @@ collectable = "0.0.2"
 ordered-float = { version = "4.1.1", features = ["proptest"] }
 easy-cast = "0.5.2"
 macro_railroad_annotation = { workspace = true }
+test-strategy = "0.3.1"
 
 [dev-dependencies]
 clap = { version = "4.5.1", features = ["derive"] }

--- a/packages/push/src/instruction/bool.rs
+++ b/packages/push/src/instruction/bool.rs
@@ -142,7 +142,7 @@ mod property_tests {
         #[any] i: i64,
     ) {
         let state = PushState::builder()
-            .with_max_stack_size(1000)
+            .with_max_stack_size(3)
             .with_no_program()
             .with_bool_values([x, y])
             .unwrap()
@@ -156,7 +156,7 @@ mod property_tests {
     #[proptest]
     fn and_is_correct(#[any] x: bool, #[any] y: bool) {
         let state = PushState::builder()
-            .with_max_stack_size(1000)
+            .with_max_stack_size(2)
             .with_no_program()
             .with_bool_values([x, y])
             .unwrap()
@@ -170,7 +170,7 @@ mod property_tests {
     #[proptest]
     fn implies_is_correct(#[any] x: bool, #[any] y: bool) {
         let state = PushState::builder()
-            .with_max_stack_size(1000)
+            .with_max_stack_size(2)
             .with_no_program()
             .with_bool_values([x, y])
             .unwrap()

--- a/packages/push/src/push_vm/program.rs
+++ b/packages/push/src/push_vm/program.rs
@@ -148,7 +148,7 @@ mod test {
         ];
         let block = dbg!(PushProgram::Block(instructions));
         let state = PushState::builder()
-            .with_max_stack_size(100)
+            .with_max_stack_size(3)
             .with_no_program()
             .build();
         let mut result = block.perform(state).unwrap();
@@ -170,7 +170,7 @@ mod test {
         let block = PushProgram::Block(instructions);
         let state = PushState::builder()
             // Set the max stack size to 2, so when we execute the block it overflows
-            .with_max_stack_size(2)
+            .with_max_stack_size(0)
             .with_no_program()
             .build();
         let Error::Fatal(_) = block.perform(state).unwrap_err() else {

--- a/packages/push/src/push_vm/push_state.rs
+++ b/packages/push/src/push_vm/push_state.rs
@@ -159,7 +159,7 @@ mod simple_check {
 
         let plushy = Plushy::new(genes);
         let state = PushState::builder()
-            .with_max_stack_size(1000)
+            .with_max_stack_size(16)
             .with_program(Vec::<PushProgram>::from(plushy))
             .unwrap()
             .with_bool_input("a", true)

--- a/packages/push/tests/float.rs
+++ b/packages/push/tests/float.rs
@@ -3,11 +3,12 @@
 #![allow(clippy::tuple_array_conversions)]
 
 use ordered_float::OrderedFloat;
-use proptest::{arbitrary::any, prop_assert_eq, proptest};
+use proptest::prop_assert_eq;
 use push::{
     instruction::{FloatInstruction, Instruction, PushInstruction},
     push_vm::{push_state::PushState, stack::StackError, HasStack},
 };
+use test_strategy::proptest;
 
 #[test]
 fn to_push_instruction() {
@@ -81,148 +82,142 @@ fn dup() {
     assert_eq!(b, x);
 }
 
-proptest! {
-    #[test]
-    fn add_prop(x in any::<OrderedFloat<f64>>(), y in any::<OrderedFloat<f64>>()) {
-        let expected_result = x + y;
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = FloatInstruction::Add.perform(state).unwrap();
-        let output = result.stack::<OrderedFloat<f64>>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn add_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = x + y;
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::Add.perform(state).unwrap();
+    let output = result.stack::<OrderedFloat<f64>>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
+}
 
-    #[test]
-    fn subtract_prop(x in any::<OrderedFloat<f64>>(), y in any::<OrderedFloat<f64>>()) {
-        let expected_result = x - y;
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = FloatInstruction::Subtract.perform(state).unwrap();
-        let output = result.stack::<OrderedFloat<f64>>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn subtract_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = x - y;
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::Subtract.perform(state).unwrap();
+    let output = result.stack::<OrderedFloat<f64>>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
+}
 
-    #[test]
-    fn multiply_prop(x in any::<OrderedFloat<f64>>(), y in any::<OrderedFloat<f64>>()) {
-        let expected_result = x * y;
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = FloatInstruction::Multiply.perform(state).unwrap();
-        let output = result.stack::<OrderedFloat<f64>>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn multiply_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = x * y;
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::Multiply.perform(state).unwrap();
+    let output = result.stack::<OrderedFloat<f64>>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
+}
 
-    #[test]
-    fn protected_divide_prop(x in any::<OrderedFloat<f64>>(), y in any::<OrderedFloat<f64>>()) {
-        let expected_result = if y == 0.0 { OrderedFloat(1.0) } else { x / y };
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = FloatInstruction::ProtectedDivide.perform(state).unwrap();
-        let output = result.stack::<OrderedFloat<f64>>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn protected_divide_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = if y == 0.0 { OrderedFloat(1.0) } else { x / y };
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::ProtectedDivide.perform(state).unwrap();
+    let output = result.stack::<OrderedFloat<f64>>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
+}
 
-    #[test]
-    fn equal_prop(x in any::<OrderedFloat<f64>>(), y in any::<OrderedFloat<f64>>()) {
-        let expected_result = x == y;
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = FloatInstruction::Equal.perform(state).unwrap();
-        let output = result.stack::<bool>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = x == y;
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::Equal.perform(state).unwrap();
+    let output = result.stack::<bool>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
+}
 
-    #[test]
-    fn not_equal_prop(x in any::<OrderedFloat<f64>>(), y in any::<OrderedFloat<f64>>()) {
-        let expected_result = x != y;
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = FloatInstruction::NotEqual.perform(state).unwrap();
-        let output = result.stack::<bool>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn not_equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = x != y;
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::NotEqual.perform(state).unwrap();
+    let output = result.stack::<bool>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
+}
 
-    #[test]
-    fn greater_than_prop(x in any::<OrderedFloat<f64>>(), y in any::<OrderedFloat<f64>>()) {
-        let expected_result = x > y;
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = FloatInstruction::GreaterThan.perform(state).unwrap();
-        let output = result.stack::<bool>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn greater_than_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = x > y;
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::GreaterThan.perform(state).unwrap();
+    let output = result.stack::<bool>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
+}
 
-    #[test]
-    fn less_than_prop(x in any::<OrderedFloat<f64>>(), y in any::<OrderedFloat<f64>>()) {
-        let expected_result = x < y;
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = FloatInstruction::LessThan.perform(state).unwrap();
-        let output = result.stack::<bool>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn less_than_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = x < y;
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::LessThan.perform(state).unwrap();
+    let output = result.stack::<bool>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
+}
 
-    #[test]
-    fn greater_than_or_equal_prop(
-        x in any::<OrderedFloat<f64>>(),
-        y in any::<OrderedFloat<f64>>()
-    ) {
-        let expected_result = x >= y;
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result =
-            FloatInstruction::GreaterThanOrEqual.perform(state).unwrap();
-        let output = result.stack::<bool>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn greater_than_or_equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = x >= y;
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::GreaterThanOrEqual.perform(state).unwrap();
+    let output = result.stack::<bool>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
+}
 
-    #[test]
-    fn less_than_or_equal_prop(x in any::<OrderedFloat<f64>>(), y in any::<OrderedFloat<f64>>()) {
-        let expected_result = x <= y;
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_float_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = FloatInstruction::LessThanOrEqual.perform(state).unwrap();
-        let output = result.stack::<bool>().top().unwrap();
-        prop_assert_eq!(*output, expected_result);
-    }
+#[proptest]
+fn less_than_or_equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
+    let expected_result = x <= y;
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_float_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = FloatInstruction::LessThanOrEqual.perform(state).unwrap();
+    let output = result.stack::<bool>().top().unwrap();
+    prop_assert_eq!(*output, expected_result);
 }

--- a/packages/push/tests/float.rs
+++ b/packages/push/tests/float.rs
@@ -21,7 +21,7 @@ fn to_push_instruction() {
 fn push_float() {
     let x = OrderedFloat(589.632);
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(1)
         .with_no_program()
         .build();
     let result = FloatInstruction::Push(x).perform(state).unwrap();
@@ -34,7 +34,7 @@ fn add() {
     let x = OrderedFloat(409.37);
     let y = OrderedFloat(512.825);
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values(vec![x, y])
         .unwrap()
         .with_no_program()
@@ -69,7 +69,7 @@ fn overflow_bool_stack() {
 fn dup() {
     let x = OrderedFloat(409.37);
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values(std::iter::once(x))
         .unwrap()
         .with_no_program()
@@ -86,7 +86,7 @@ fn dup() {
 fn add_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = x + y;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()
@@ -100,7 +100,7 @@ fn add_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
 fn subtract_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = x - y;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()
@@ -114,7 +114,7 @@ fn subtract_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
 fn multiply_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = x * y;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()
@@ -128,7 +128,7 @@ fn multiply_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
 fn protected_divide_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = if y == 0.0 { OrderedFloat(1.0) } else { x / y };
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()
@@ -142,7 +142,7 @@ fn protected_divide_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64
 fn equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = x == y;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()
@@ -156,7 +156,7 @@ fn equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
 fn not_equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = x != y;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()
@@ -170,7 +170,7 @@ fn not_equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
 fn greater_than_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = x > y;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()
@@ -184,7 +184,7 @@ fn greater_than_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
 fn less_than_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = x < y;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()
@@ -198,7 +198,7 @@ fn less_than_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
 fn greater_than_or_equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = x >= y;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()
@@ -212,7 +212,7 @@ fn greater_than_or_equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloa
 fn less_than_or_equal_prop(#[any] x: OrderedFloat<f64>, #[any] y: OrderedFloat<f64>) {
     let expected_result = x <= y;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_float_values([x, y])
         .unwrap()
         .with_no_program()

--- a/packages/push/tests/int.rs
+++ b/packages/push/tests/int.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::tuple_array_conversions)]
 
-use proptest::{arbitrary::any, prop_assert_eq, proptest};
+use proptest::prop_assert_eq;
 use push::{
     instruction::{
         instruction_error::PushInstructionError, Instruction, IntInstruction, IntInstructionError,
@@ -10,6 +10,7 @@ use push::{
     push_vm::{push_state::PushState, HasStack},
 };
 use strum::IntoEnumIterator;
+use test_strategy::proptest;
 
 #[test]
 fn add() {
@@ -97,296 +98,291 @@ fn all_instructions() -> Vec<IntInstruction> {
     IntInstruction::iter().collect()
 }
 
-proptest! {
-    #![proptest_config(proptest::prelude::ProptestConfig::with_cases(1_000))]
+#[proptest]
+fn negate(#[any] x: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values(std::iter::once(x))
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::Negate.perform(state).unwrap();
+    prop_assert_eq!(result.stack::<i64>().size(), 1);
+    prop_assert_eq!(*result.stack::<i64>().top().unwrap(), -x);
+}
 
-    #[test]
-    fn negate(x in any::<i64>()) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values(std::iter::once(x))
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::Negate.perform(state).unwrap();
+#[proptest]
+fn abs(#[any] x: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values(std::iter::once(x))
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::Abs.perform(state).unwrap();
+    prop_assert_eq!(result.stack::<i64>().size(), 1);
+    prop_assert_eq!(*result.stack::<i64>().top().unwrap(), x.abs());
+}
+
+#[proptest]
+fn sqr(#[any] x: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values(std::iter::once(x))
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::Square.perform(state);
+    if let Some(x_squared) = x.checked_mul(x) {
+        let result = result.unwrap();
         prop_assert_eq!(result.stack::<i64>().size(), 1);
-        prop_assert_eq!(*result.stack::<i64>().top().unwrap(), -x);
+        let output = *result.stack::<i64>().top().unwrap();
+        prop_assert_eq!(output, x_squared);
+    } else {
+        let result = result.unwrap_err();
+        assert_eq!(
+            result.error(),
+            &IntInstructionError::Overflow {
+                op: IntInstruction::Square
+            }
+            .into()
+        );
+        assert!(result.is_recoverable());
+        let top_int = result.state().stack::<i64>().top().unwrap();
+        prop_assert_eq!(*top_int, x);
     }
+}
 
-    #[test]
-    fn abs(x in any::<i64>()) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values(std::iter::once(x))
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::Abs.perform(state).unwrap();
-        prop_assert_eq!(result.stack::<i64>().size(), 1);
-        prop_assert_eq!(*result.stack::<i64>().top().unwrap(), x.abs());
-    }
+#[proptest]
+fn add_does_not_crash(#[any] x: i64, #[any] y: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let _ = IntInstruction::Add.perform(state);
+}
 
-    #[test]
-    fn sqr(x in any::<i64>()) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values(std::iter::once(x))
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::Square.perform(state);
-        if let Some(x_squared) = x.checked_mul(x) {
-            let result = result.unwrap();
-            prop_assert_eq!(result.stack::<i64>().size(), 1);
-            let output = *result.stack::<i64>().top().unwrap();
-            prop_assert_eq!(output, x_squared);
-        } else {
-            let result = result.unwrap_err();
-            assert_eq!(
-                result.error(),
-                &IntInstructionError::Overflow {
-                    op: IntInstruction::Square
-                }.into()
-            );
-            assert!(result.is_recoverable());
-            let top_int = result.state().stack::<i64>().top().unwrap();
-            prop_assert_eq!(*top_int, x);
-        }
-    }
-
-    #[test]
-    fn add_does_not_crash(x in any::<i64>(), y in any::<i64>()) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values([x,y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let _ = IntInstruction::Add.perform(state);
-    }
-
-    #[test]
-    fn add_adds_or_does_nothing(x in any::<i64>(), y in any::<i64>()) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::Add.perform(state);
-        #[allow(clippy::unwrap_used)]
-        if let Some(expected_result) = x.checked_add(y) {
-            let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
-            prop_assert_eq!(output, expected_result);
-        } else {
-            // This only checks that `x` is still on the top of the stack.
-            // We arguably want to confirm that the entire state of the system
-            // is unchanged, except that the `Add` instruction has been
-            // removed from the `exec` stack.
-            let result = result.unwrap_err();
-            assert_eq!(
-                result.error(),
-                &IntInstructionError::Overflow {
-                    op: IntInstruction::Add
-                }
-                .into()
-            );
-            assert!(result.is_recoverable());
-            let top_int = result.state().stack::<i64>().top().unwrap();
-            prop_assert_eq!(*top_int, x);
-        }
-    }
-
-    #[test]
-    fn subtract_subs_or_does_nothing(x in any::<i64>(), y in any::<i64>()) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::Subtract.perform(state);
-        #[allow(clippy::unwrap_used)]
-        if let Some(expected_result) = x.checked_sub(y) {
-            let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
-            prop_assert_eq!(output, expected_result);
-        } else {
-            // This only checks that `x` is still on the top of the stack.
-            // We arguably want to confirm that the entire state of the system
-            // is unchanged, except that the `Add` instruction has been
-            // removed from the `exec` stack.
-            let result = result.unwrap_err();
-            assert_eq!(
-                result.error(),
-                &IntInstructionError::Overflow {
-                    op: IntInstruction::Subtract
-                }
-                .into()
-            );
-            assert!(result.is_recoverable());
-            let top_int = result.state().stack::<i64>().top().unwrap();
-            prop_assert_eq!(*top_int, x);
-        }
-    }
-
-    #[test]
-    fn multiply_works_or_does_nothing(x in any::<i64>(), y in any::<i64>()) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::Multiply.perform(state);
-        #[allow(clippy::unwrap_used)]
-        if let Some(expected_result) = x.checked_mul(y) {
-            let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
-            prop_assert_eq!(output, expected_result);
-        } else {
-            // This only checks that `x` is still on the top of the stack.
-            // We arguably want to confirm that the entire state of the system
-            // is unchanged, except that the `Add` instruction has been
-            // removed from the `exec` stack.
-            let result = result.unwrap_err();
-            assert_eq!(
-                result.error(),
-                &IntInstructionError::Overflow {
-                    op: IntInstruction::Multiply
-                }
-                .into()
-            );
-            assert!(result.is_recoverable());
-            let top_int = result.state().stack::<i64>().top().unwrap();
-            prop_assert_eq!(*top_int, x);
-        }
-    }
-
-    #[test]
-    fn protected_divide_zero_denominator(x in any::<i64>()) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values([x, 0])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::ProtectedDivide.perform(state);
-        #[allow(clippy::unwrap_used)]
+#[proptest]
+fn add_adds_or_does_nothing(#[any] x: i64, #[any] y: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::Add.perform(state);
+    #[allow(clippy::unwrap_used)]
+    if let Some(expected_result) = x.checked_add(y) {
         let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
-        // Dividing by zero should always return 1.
-        prop_assert_eq!(output, 1);
+        prop_assert_eq!(output, expected_result);
+    } else {
+        // This only checks that `x` is still on the top of the stack.
+        // We arguably want to confirm that the entire state of the system
+        // is unchanged, except that the `Add` instruction has been
+        // removed from the `exec` stack.
+        let result = result.unwrap_err();
+        assert_eq!(
+            result.error(),
+            &IntInstructionError::Overflow {
+                op: IntInstruction::Add
+            }
+            .into()
+        );
+        assert!(result.is_recoverable());
+        let top_int = result.state().stack::<i64>().top().unwrap();
+        prop_assert_eq!(*top_int, x);
     }
+}
 
-    #[test]
-    fn protected_divide_works_or_does_nothing(
-        x in any::<i64>(),
-        y in any::<i64>()
-    ) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::ProtectedDivide.perform(state);
-        #[allow(clippy::unwrap_used)]
-        if let Some(expected_result) = x.checked_div(y) {
-            let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
-            prop_assert_eq!(output, expected_result);
-        } else {
-            // This only checks that `x` is still on the top of the stack.
-            // We arguably want to confirm that the entire state of the system
-            // is unchanged, except that the `Add` instruction has been
-            // removed from the `exec` stack.
-            let result = result.unwrap_err();
-            assert_eq!(
-                result.error(),
-                &IntInstructionError::Overflow {
-                    op: IntInstruction::ProtectedDivide
-                }
-                .into()
-            );
-            assert!(result.is_recoverable());
-            let top_int = result.state().stack::<i64>().top().unwrap();
-            prop_assert_eq!(*top_int, x);
-        }
-    }
-
-    #[test]
-    fn mod_zero_denominator(x in any::<i64>()) {
-        let state =PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values([0,x])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::Mod.perform(state);
-        #[allow(clippy::unwrap_used)]
+#[proptest]
+fn subtract_subs_or_does_nothing(#[any] x: i64, #[any] y: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::Subtract.perform(state);
+    #[allow(clippy::unwrap_used)]
+    if let Some(expected_result) = x.checked_sub(y) {
         let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
-        // Modding by zero should always return 0 since x % x = 0 for all x != 0.
+        prop_assert_eq!(output, expected_result);
+    } else {
+        // This only checks that `x` is still on the top of the stack.
+        // We arguably want to confirm that the entire state of the system
+        // is unchanged, except that the `Add` instruction has been
+        // removed from the `exec` stack.
+        let result = result.unwrap_err();
+        assert_eq!(
+            result.error(),
+            &IntInstructionError::Overflow {
+                op: IntInstruction::Subtract
+            }
+            .into()
+        );
+        assert!(result.is_recoverable());
+        let top_int = result.state().stack::<i64>().top().unwrap();
+        prop_assert_eq!(*top_int, x);
+    }
+}
+
+#[proptest]
+fn multiply_works_or_does_nothing(#[any] x: i64, #[any] y: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::Multiply.perform(state);
+    #[allow(clippy::unwrap_used)]
+    if let Some(expected_result) = x.checked_mul(y) {
+        let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
+        prop_assert_eq!(output, expected_result);
+    } else {
+        // This only checks that `x` is still on the top of the stack.
+        // We arguably want to confirm that the entire state of the system
+        // is unchanged, except that the `Add` instruction has been
+        // removed from the `exec` stack.
+        let result = result.unwrap_err();
+        assert_eq!(
+            result.error(),
+            &IntInstructionError::Overflow {
+                op: IntInstruction::Multiply
+            }
+            .into()
+        );
+        assert!(result.is_recoverable());
+        let top_int = result.state().stack::<i64>().top().unwrap();
+        prop_assert_eq!(*top_int, x);
+    }
+}
+
+#[proptest]
+fn protected_divide_zero_denominator(#[any] x: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values([x, 0])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::ProtectedDivide.perform(state);
+    #[allow(clippy::unwrap_used)]
+    let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
+    // Dividing by zero should always return 1.
+    prop_assert_eq!(output, 1);
+}
+
+#[proptest]
+fn protected_divide_works_or_does_nothing(#[any] x: i64, #[any] y: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::ProtectedDivide.perform(state);
+    #[allow(clippy::unwrap_used)]
+    if let Some(expected_result) = x.checked_div(y) {
+        let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
+        prop_assert_eq!(output, expected_result);
+    } else {
+        // This only checks that `x` is still on the top of the stack.
+        // We arguably want to confirm that the entire state of the system
+        // is unchanged, except that the `Add` instruction has been
+        // removed from the `exec` stack.
+        let result = result.unwrap_err();
+        assert_eq!(
+            result.error(),
+            &IntInstructionError::Overflow {
+                op: IntInstruction::ProtectedDivide
+            }
+            .into()
+        );
+        assert!(result.is_recoverable());
+        let top_int = result.state().stack::<i64>().top().unwrap();
+        prop_assert_eq!(*top_int, x);
+    }
+}
+
+#[proptest]
+fn mod_zero_denominator(#[any] x: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values([0, x])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::Mod.perform(state);
+    #[allow(clippy::unwrap_used)]
+    let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
+    // Modding by zero should always return 0 since x % x = 0 for all x != 0.
+    prop_assert_eq!(output, 0);
+}
+
+#[proptest]
+fn mod_rems_or_does_nothing(#[any] x: i64, #[any] y: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values([x, y])
+        .unwrap()
+        .with_no_program()
+        .build();
+    let result = IntInstruction::Mod.perform(state);
+    #[allow(clippy::unwrap_used)]
+    if let Some(expected_result) = x.checked_rem(y) {
+        let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
+        prop_assert_eq!(output, expected_result);
+    } else if y == 0 {
+        let output: i64 = *result.unwrap().stack_mut::<i64>().top().unwrap();
+        // Modding by zero should always return 0 since x % x == 0 for all x != 0.
         prop_assert_eq!(output, 0);
+    } else {
+        // This only checks that `x` is still on the top of the stack.
+        // We arguably want to confirm that the entire state of the system
+        // is unchanged, except that the `Add` instruction has been
+        // removed from the `exec` stack.
+        let result = result.unwrap_err();
+        assert_eq!(
+            result.error(),
+            &IntInstructionError::Overflow {
+                op: IntInstruction::Mod
+            }
+            .into()
+        );
+        assert!(result.is_recoverable());
+        let top_int = result.state().stack::<i64>().top().unwrap();
+        prop_assert_eq!(*top_int, x);
     }
+}
 
-    #[test]
-    fn mod_rems_or_does_nothing(x in any::<i64>(), y in any::<i64>()) {
-        let state =PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values([x, y])
-            .unwrap()
-            .with_no_program()
-            .build();
-        let result = IntInstruction::Mod.perform(state);
-        #[allow(clippy::unwrap_used)]
-        if let Some(expected_result) = x.checked_rem(y) {
-            let output = result.unwrap().stack_mut::<i64>().pop().unwrap();
-            prop_assert_eq!(output, expected_result);
-        } else if y == 0 {
-            let output: i64 = *result.unwrap().stack_mut::<i64>().top().unwrap();
-            // Modding by zero should always return 0 since x % x == 0 for all x != 0.
-            prop_assert_eq!(output, 0);
-        } else {
-            // This only checks that `x` is still on the top of the stack.
-            // We arguably want to confirm that the entire state of the system
-            // is unchanged, except that the `Add` instruction has been
-            // removed from the `exec` stack.
-            let result = result.unwrap_err();
-            assert_eq!(
-                result.error(),
-                &IntInstructionError::Overflow {
-                    op: IntInstruction::Mod
-                }
-                .into()
-            );
-            assert!(result.is_recoverable());
-            let top_int = result.state().stack::<i64>().top().unwrap();
-            prop_assert_eq!(*top_int, x);
-        }
-    }
+#[proptest]
+fn inc_does_not_crash(#[any] x: i64) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values(std::iter::once(x))
+        .unwrap()
+        .with_no_program()
+        .build();
+    let _ = IntInstruction::Inc.perform(state);
+}
 
-    #[test]
-    fn inc_does_not_crash(x in any::<i64>()) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values(std::iter::once(x))
-            .unwrap()
-            .with_no_program()
-            .build();
-        let _ = IntInstruction::Inc.perform(state);
-    }
-
-    #[test]
-    fn int_ops_do_not_crash(
-            instr in proptest::sample::select(all_instructions()),
-            x in any::<i64>(),
-            y in any::<i64>(),
-            b in proptest::bool::ANY) {
-        let state = PushState::builder()
-            .with_max_stack_size(100)
-            .with_int_values([x, y])
-            .unwrap()
-            .with_bool_values(std::iter::once(b))
-            .unwrap()
-            .with_no_program()
-            .build();
-        let _ = instr.perform(state);
-    }
+#[proptest]
+fn int_ops_do_not_crash(
+    #[strategy(proptest::sample::select(all_instructions()))] instr: IntInstruction,
+    #[any] x: i64,
+    #[any] y: i64,
+    #[any] b: bool,
+) {
+    let state = PushState::builder()
+        .with_max_stack_size(100)
+        .with_int_values([x, y])
+        .unwrap()
+        .with_bool_values(std::iter::once(b))
+        .unwrap()
+        .with_no_program()
+        .build();
+    let _ = instr.perform(state);
 }

--- a/packages/push/tests/int.rs
+++ b/packages/push/tests/int.rs
@@ -17,7 +17,7 @@ fn add() {
     let x = 409;
     let y = 512;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, y])
         .unwrap()
         .with_no_program()
@@ -32,7 +32,7 @@ fn add_overflows() {
     let x = 4_098_586_571_925_584_936;
     let y = 5_124_785_464_929_190_872;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, y])
         .unwrap()
         .with_no_program()
@@ -53,7 +53,7 @@ fn add_overflows() {
 fn inc_overflows() {
     let x = i64::MAX;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(1)
         .with_int_values(std::iter::once(x))
         .unwrap()
         .with_no_program()
@@ -76,7 +76,7 @@ fn inc_overflows() {
 fn dec_overflows() {
     let x = i64::MIN;
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(1)
         .with_int_values(std::iter::once(x))
         .unwrap()
         .with_no_program()
@@ -101,7 +101,7 @@ fn all_instructions() -> Vec<IntInstruction> {
 #[proptest]
 fn negate(#[any] x: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(1)
         .with_int_values(std::iter::once(x))
         .unwrap()
         .with_no_program()
@@ -114,7 +114,7 @@ fn negate(#[any] x: i64) {
 #[proptest]
 fn abs(#[any] x: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(1)
         .with_int_values(std::iter::once(x))
         .unwrap()
         .with_no_program()
@@ -127,7 +127,7 @@ fn abs(#[any] x: i64) {
 #[proptest]
 fn sqr(#[any] x: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(1)
         .with_int_values(std::iter::once(x))
         .unwrap()
         .with_no_program()
@@ -156,7 +156,7 @@ fn sqr(#[any] x: i64) {
 #[proptest]
 fn add_does_not_crash(#[any] x: i64, #[any] y: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, y])
         .unwrap()
         .with_no_program()
@@ -167,7 +167,7 @@ fn add_does_not_crash(#[any] x: i64, #[any] y: i64) {
 #[proptest]
 fn add_adds_or_does_nothing(#[any] x: i64, #[any] y: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, y])
         .unwrap()
         .with_no_program()
@@ -199,7 +199,7 @@ fn add_adds_or_does_nothing(#[any] x: i64, #[any] y: i64) {
 #[proptest]
 fn subtract_subs_or_does_nothing(#[any] x: i64, #[any] y: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, y])
         .unwrap()
         .with_no_program()
@@ -231,7 +231,7 @@ fn subtract_subs_or_does_nothing(#[any] x: i64, #[any] y: i64) {
 #[proptest]
 fn multiply_works_or_does_nothing(#[any] x: i64, #[any] y: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, y])
         .unwrap()
         .with_no_program()
@@ -263,7 +263,7 @@ fn multiply_works_or_does_nothing(#[any] x: i64, #[any] y: i64) {
 #[proptest]
 fn protected_divide_zero_denominator(#[any] x: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, 0])
         .unwrap()
         .with_no_program()
@@ -278,7 +278,7 @@ fn protected_divide_zero_denominator(#[any] x: i64) {
 #[proptest]
 fn protected_divide_works_or_does_nothing(#[any] x: i64, #[any] y: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, y])
         .unwrap()
         .with_no_program()
@@ -310,7 +310,7 @@ fn protected_divide_works_or_does_nothing(#[any] x: i64, #[any] y: i64) {
 #[proptest]
 fn mod_zero_denominator(#[any] x: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([0, x])
         .unwrap()
         .with_no_program()
@@ -325,7 +325,7 @@ fn mod_zero_denominator(#[any] x: i64) {
 #[proptest]
 fn mod_rems_or_does_nothing(#[any] x: i64, #[any] y: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, y])
         .unwrap()
         .with_no_program()
@@ -361,7 +361,7 @@ fn mod_rems_or_does_nothing(#[any] x: i64, #[any] y: i64) {
 #[proptest]
 fn inc_does_not_crash(#[any] x: i64) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(1)
         .with_int_values(std::iter::once(x))
         .unwrap()
         .with_no_program()
@@ -377,7 +377,7 @@ fn int_ops_do_not_crash(
     #[any] b: bool,
 ) {
     let state = PushState::builder()
-        .with_max_stack_size(100)
+        .with_max_stack_size(2)
         .with_int_values([x, y])
         .unwrap()
         .with_bool_values(std::iter::once(b))


### PR DESCRIPTION
Move all proptests from `proptest!{}` macros to using `#[test_strategy::proptest]`, this has several advantages:
- rustfmt works on attribute macros but not function-style macros: proptest can now be auto-formatted
- syn can parse attribute macros just fine where function-style macros need custom logic: allows us to use the same tools for minimizing max_stack_size without huge modifications to the tool

After moving to test_strategy I ran my capacity_optimizer script ( see the unhindered-ec org [here](https://github.com/unhindered-ec/capacity_optimizer)  ) and minimized the max_stack_sizes in the builder.