### PR TITLE
Rename `WithTarget` with `WithTargetFn`

### DIFF
--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -25,7 +25,7 @@ use ec_linear::mutator::umad::Umad;
 use num_traits::Float;
 use ordered_float::OrderedFloat;
 use push::{
-    evaluation::cases::{Case, Cases, WithTarget},
+    evaluation::cases::{Case, Cases, WithTargetFn},
     genome::plushy::{ConvertToGeneGenerator, Plushy},
     instruction::{variable_name::VariableName, FloatInstruction, PushInstruction},
     push_vm::{program::PushProgram, push_state::PushState, HasStack, State},
@@ -114,7 +114,7 @@ fn main() -> Result<()> {
     // Inputs from -4 (inclusive) to 4 (exclusive) in increments of 0.25.
     let training_cases = (-4 * 4..4 * 4)
         .map(|n| Of64::from(n) / 4.0)
-        .with_target(|&i| target_fn(i));
+        .with_target_fn(|&i| target_fn(i));
 
     // The range want is -4 1/8, -3 7/8, -3 5/8, ..., 3 7/8, 4 1/8.
     // I have to multiply that by 8 to get integer values, so:
@@ -122,7 +122,7 @@ fn main() -> Result<()> {
     let _testing_cases = (-33..=33)
         .step_by(2)
         .map(|n| Of64::from(n) / 8.0)
-        .with_target(|&i| target_fn(i));
+        .with_target_fn(|&i| target_fn(i));
 
     /*
      * The `scorer` will need to take an evolved program (sequence of

--- a/packages/push/examples/simple_regression/main.rs
+++ b/packages/push/examples/simple_regression/main.rs
@@ -28,7 +28,7 @@ use ec_linear::mutator::umad::Umad;
 use num_traits::Float;
 use ordered_float::OrderedFloat;
 use push::{
-    evaluation::cases::{Case, Cases, WithTarget},
+    evaluation::cases::{Case, Cases, WithTargetFn},
     genome::plushy::{ConvertToGeneGenerator, Plushy},
     instruction::{variable_name::VariableName, FloatInstruction, PushInstruction},
     push_vm::{program::PushProgram, push_state::PushState, HasStack, State},
@@ -114,7 +114,7 @@ fn main() -> Result<()> {
     // Inputs from -4 (inclusive) to 4 (exclusive) in increments of 0.25.
     let training_cases = (-4 * 4..4 * 4)
         .map(|n| Of64::from(n) / 4.0)
-        .with_target(|&i| target_fn(i));
+        .with_target_fn(|i| target_fn(*i));
 
     /*
      * The `scorer` will need to take an evolved program (sequence of

--- a/packages/push/src/evaluation/cases.rs
+++ b/packages/push/src/evaluation/cases.rs
@@ -78,17 +78,17 @@ impl<Input, Output> Cases<Input, Output> {
     }
 }
 
-pub trait WithTarget<Input> {
-    fn with_target<Output, F>(self, target_fn: F) -> Cases<Input, Output>
+pub trait WithTargetFn<Input> {
+    fn with_target_fn<Output, F>(self, target_fn: F) -> Cases<Input, Output>
     where
         F: Fn(&Input) -> Output;
 }
 
-impl<T, Input> WithTarget<Input> for T
+impl<T, Input> WithTargetFn<Input> for T
 where
     T: IntoIterator<Item = Input>,
 {
-    fn with_target<Output, F>(self, target_fn: F) -> Cases<Input, Output>
+    fn with_target_fn<Output, F>(self, target_fn: F) -> Cases<Input, Output>
     where
         F: Fn(&Input) -> Output,
     {

--- a/packages/push/tests/cases.rs
+++ b/packages/push/tests/cases.rs
@@ -4,7 +4,7 @@
 use std::ops::Not;
 
 use push::{
-    evaluation::cases::{Case, Cases, WithTarget},
+    evaluation::cases::{Case, Cases, WithTargetFn},
     vec_into,
 };
 
@@ -64,7 +64,7 @@ fn test_len() {
 #[test]
 fn test_with_target() {
     let inputs = 0..10;
-    let cases = inputs.with_target(|x| x * 2);
+    let cases = inputs.with_target_fn(|x| x * 2);
     assert_eq!(
         cases.into_iter().collect::<Vec<_>>(),
         (0..10).map(|x| Case::new(x, x * 2)).collect::<Vec<_>>()


### PR DESCRIPTION
I think this is more consistent with some other naming we've done, and it was what I imagined this would be called when I was trying to find it while doing some other refactoring.