### PR TITLE
Derive `EnumIter` for `ExecInstruction`

### DIFF
--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -156,7 +156,7 @@ fn main() -> Result<()> {
     ensure!(population.is_empty().not());
 
     let best = Best.select(&population, &mut rng)?;
-    println!("Best initial individual is {best:?}");
+    println!("Best initial individual is {best}");
 
     let umad = Umad::new(0.1, 0.1, &gene_generator);
 
@@ -179,7 +179,7 @@ fn main() -> Result<()> {
         let best = Best.select(generation.population(), &mut rng)?;
         // TODO: Change 2 to be the smallest number of digits needed for
         // num_generations-1.
-        println!("Generation {generation_number:2} best is {best:#?}");
+        println!("Generation {generation_number:2} best is {best}");
 
         if best.test_results.total_result.error == OrderedFloat(0.0) {
             println!("SUCCESS");

--- a/packages/push/src/instruction/exec/dup_block.rs
+++ b/packages/push/src/instruction/exec/dup_block.rs
@@ -56,7 +56,7 @@ use crate::{
 /// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
 /// then this returns that as a [`Error::Fatal`](crate::error::Error::Fatal)
 /// error.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub struct DupBlock;
 
 impl NumOpens for DupBlock {

--- a/packages/push/src/instruction/exec/ifelse.rs
+++ b/packages/push/src/instruction/exec/ifelse.rs
@@ -70,7 +70,7 @@ use crate::{
 /// If either of the stack accesses returns any error other than a
 /// [`StackError::Underflow`] then this returns that as a [`Error::Fatal`]
 /// error.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub struct IfElse;
 
 impl NumOpens for IfElse {

--- a/packages/push/src/instruction/exec/mod.rs
+++ b/packages/push/src/instruction/exec/mod.rs
@@ -4,6 +4,8 @@ mod noop;
 mod unless;
 mod when;
 
+use strum_macros::EnumIter;
+
 use self::{dup_block::DupBlock, ifelse::IfElse, noop::Noop, unless::Unless, when::When};
 use super::{instruction_error::PushInstructionError, Instruction, NumOpens, PushInstruction};
 use crate::{
@@ -11,7 +13,7 @@ use crate::{
     push_vm::{program::PushProgram, HasStack},
 };
 
-#[derive(Debug, strum_macros::Display, Clone, Eq, PartialEq)]
+#[derive(Debug, strum_macros::Display, Clone, Eq, PartialEq, EnumIter)]
 #[must_use]
 pub enum ExecInstruction {
     Noop(Noop),

--- a/packages/push/src/instruction/exec/noop.rs
+++ b/packages/push/src/instruction/exec/noop.rs
@@ -10,7 +10,7 @@ use crate::instruction::{instruction_error::PushInstructionError, Instruction, N
 /// # Behavior
 ///
 /// This always succeeds and makes no changes to any of the stacks.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub struct Noop;
 
 impl NumOpens for Noop {

--- a/packages/push/src/instruction/exec/unless.rs
+++ b/packages/push/src/instruction/exec/unless.rs
@@ -61,7 +61,7 @@ use crate::{
 /// If either of the stack accesses returns any error other than a
 /// [`StackError::Underflow`] then this returns that as a [`Error::Fatal`]
 /// error.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub struct Unless;
 
 impl NumOpens for Unless {

--- a/packages/push/src/instruction/exec/when.rs
+++ b/packages/push/src/instruction/exec/when.rs
@@ -61,7 +61,7 @@ use crate::{
 /// If either of the stack accesses returns any error other than a
 /// [`StackError::Underflow`] then this returns that as a [`Error::Fatal`]
 /// error.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub struct When;
 
 impl NumOpens for When {


### PR DESCRIPTION
This derives `strum::EnumIter` for `ExecInstruction`. For this to work, though, I had to also derive `Default` all the "sub-types" (e.g., `When`). That arguably should be been done before. While I was there, I also derived `Copy` for those that didn't already have it.

I also switched `complex_regression/main.rs` to use the new `Display` for individuals instead of `Debug` as before.