### PR TITLE
Set GitHub Actions `fail-fast` to `false`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
     name: rust-ga - latest
     runs-on: ubuntu-latest
     strategy:
+      # This ensures that all three toolchains will run even if one of
+      # them fails. This, for example, prevents a `nightly` failure
+      # from blocking `stable` and `beta` from running.
+      fail-fast: false
       matrix:
         toolchain:
           - stable


### PR DESCRIPTION
This ensures that all three toolchains will run even if one of them fails. Currently if `nightly` fails, then that can prevent either `stable` or `beta` from running to completion.