### PR TITLE
Add explicit rust toolchain to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy && rustup component add rustfmt
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          components: clippy, rustfmt
+          toolchain: ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose
       - run: cargo clippy --all-targets


### PR DESCRIPTION
This adds the `rust-toolchain` GitHub Action to explicitly install the appropriate tooling for each pass through the matrix of toolchains.