### PR TITLE
Make `push::error::stateful::new_boxed` const

### DIFF
--- a/packages/push/src/error/stateful.rs
+++ b/packages/push/src/error/stateful.rs
@@ -40,7 +40,7 @@ impl<S, E, Severity: ErrorSeverity> StatefulError<S, E, Severity> {
         Self::new_boxed(Box::new(state), error)
     }
 
-    pub fn new_boxed(state: Box<S>, error: E) -> Self {
+    pub const fn new_boxed(state: Box<S>, error: E) -> Self {
         Self {
             state,
             error,


### PR DESCRIPTION
Add `const` to `new_boxed`. This hopefully fixes a problem where `nightly` wasn't building successfully, but I'm not sure what's going to happen on `stable` and `beta` now.

I'm assuming (based on a suggestion by @JustusFluegel) that there's some change in `nightly` that now allows functions that take `Box` values to be `const`, although I can't find anything online that would explain this change.