### PR TITLE
Add associated `Error` type to `Operators`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +68,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -63,7 +78,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -77,6 +92,30 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "base64"
@@ -142,6 +181,12 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
 
 [[package]]
 name = "cfg-if"
@@ -309,9 +354,11 @@ dependencies = [
  "criterion",
  "itertools 0.12.1",
  "macro_railroad_annotation",
+ "miette",
  "num-traits",
  "rand 0.9.0-alpha.1",
  "rayon",
+ "thiserror",
 ]
 
 [[package]]
@@ -350,7 +397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -375,6 +422,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "half"
@@ -429,8 +482,14 @@ checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -566,6 +625,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.62",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +672,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "object"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -596,6 +704,12 @@ dependencies = [
  "num-traits",
  "proptest",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "plotters"
@@ -877,6 +991,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,7 +1006,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -972,6 +1092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1146,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,7 +1197,17 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1063,6 +1220,17 @@ dependencies = [
  "quote",
  "structmeta",
  "syn 2.0.62",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1106,6 +1274,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
@@ -1214,7 +1388,16 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1223,7 +1406,22 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1232,15 +1430,21 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1250,9 +1454,21 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1268,9 +1484,21 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1280,9 +1508,21 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ itertools = "0.12.1"
 macro_railroad_annotation = "1.0.3"
 test-strategy = "0.3.1"
 proptest = "1.2.0"
-criterion = { version = "0.5.1" }
-miette = { version = "7.2.0" }
+criterion = "0.5.1"
+miette = "7.2.0"
 
 ec-core = { path = "packages/ec-core" }
 ec-linear = { path = "packages/ec-linear" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ macro_railroad_annotation = "1.0.3"
 test-strategy = "0.3.1"
 proptest = "1.2.0"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+miette = { version = "7.2.0", features = ["fancy"] }
 
 ec-core = { path = "packages/ec-core" }
 ec-linear = { path = "packages/ec-linear" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ itertools = "0.12.1"
 macro_railroad_annotation = "1.0.3"
 test-strategy = "0.3.1"
 proptest = "1.2.0"
-criterion = { version = "0.5.1", features = ["html_reports"] }
-miette = { version = "7.2.0", features = ["fancy"] }
+criterion = { version = "0.5.1" }
+miette = { version = "7.2.0" }
 
 ec-core = { path = "packages/ec-core" }
 ec-linear = { path = "packages/ec-linear" }

--- a/packages/ec-core/Cargo.toml
+++ b/packages/ec-core/Cargo.toml
@@ -24,6 +24,8 @@ macro_railroad_annotation = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true, features = ["alloc", "small_rng"] }
 criterion = { workspace = true }
+miette = { workspace = true, features = ["fancy"] }
+thiserror = { workspace = true }
 
 [lints]
 workspace = true

--- a/packages/ec-core/src/operator/composable/and.rs
+++ b/packages/ec-core/src/operator/composable/and.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Context;
 use rand::rngs::ThreadRng;
 
 use super::{super::Operator, Composable};
@@ -22,12 +22,22 @@ where
     A: Clone,
     F: Operator<A>,
     G: Operator<A>,
+    anyhow::Error: From<F::Error> + From<G::Error>,
 {
     type Output = (F::Output, G::Output);
+    type Error = anyhow::Error;
 
-    fn apply(&self, x: A, rng: &mut ThreadRng) -> Result<Self::Output> {
-        let f_value = self.f.apply(x.clone(), rng).context("f in `And` failed")?;
-        let g_value = self.g.apply(x, rng).context("g in `And` failed")?;
+    fn apply(&self, x: A, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
+        let f_value = self
+            .f
+            .apply(x.clone(), rng)
+            .map_err(anyhow::Error::from)
+            .context("f in `And` failed")?;
+        let g_value = self
+            .g
+            .apply(x, rng)
+            .map_err(anyhow::Error::from)
+            .context("g in `And` failed")?;
         Ok((f_value, g_value))
     }
 }

--- a/packages/ec-core/src/operator/composable/map.rs
+++ b/packages/ec-core/src/operator/composable/map.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Context;
 
 use super::Composable;
 use crate::operator::Operator;
@@ -17,18 +17,26 @@ impl<F> Map<F> {
 impl<F, Input> Operator<[Input; 2]> for Map<F>
 where
     F: Operator<Input>,
+    anyhow::Error: From<F::Error>,
 {
     type Output = [F::Output; 2];
+    type Error = anyhow::Error;
 
-    fn apply(&self, [x, y]: [Input; 2], rng: &mut rand::rngs::ThreadRng) -> Result<Self::Output> {
+    fn apply(
+        &self,
+        [x, y]: [Input; 2],
+        rng: &mut rand::rngs::ThreadRng,
+    ) -> Result<Self::Output, Self::Error> {
         let first_result = self
             .f
             .apply(x, rng)
-            .with_context(|| "Calling f with {x} in `Map` failed")?;
+            .map_err(anyhow::Error::from)
+            .context("Calling f with {x} in `Map` failed")?;
         let second_result = self
             .f
             .apply(y, rng)
-            .with_context(|| "Calling f with {y} in `Map` failed")?;
+            .map_err(anyhow::Error::from)
+            .context("Calling f with {y} in `Map` failed")?;
         Ok([first_result, second_result])
     }
 }
@@ -36,22 +44,26 @@ where
 impl<F, Input> Operator<(Input, Input)> for Map<F>
 where
     F: Operator<Input>,
+    anyhow::Error: From<F::Error>,
 {
     type Output = (F::Output, F::Output);
+    type Error = anyhow::Error;
 
     fn apply(
         &self,
         (x, y): (Input, Input),
         rng: &mut rand::rngs::ThreadRng,
-    ) -> Result<Self::Output> {
+    ) -> Result<Self::Output, Self::Error> {
         let first_result = self
             .f
             .apply(x, rng)
-            .with_context(|| "Calling f with {x} in `Map` failed")?;
+            .map_err(anyhow::Error::from)
+            .context("Calling f with {x} in `Map` failed")?;
         let second_result = self
             .f
             .apply(y, rng)
-            .with_context(|| "Calling f with {y} in `Map` failed")?;
+            .map_err(anyhow::Error::from)
+            .context("Calling f with {y} in `Map` failed")?;
         Ok((first_result, second_result))
     }
 }
@@ -59,16 +71,23 @@ where
 impl<F, Input> Operator<Vec<Input>> for Map<F>
 where
     F: Operator<Input>,
+    anyhow::Error: From<F::Error>,
 {
     type Output = Vec<F::Output>;
+    type Error = anyhow::Error;
 
-    fn apply(&self, input: Vec<Input>, rng: &mut rand::rngs::ThreadRng) -> Result<Self::Output> {
+    fn apply(
+        &self,
+        input: Vec<Input>,
+        rng: &mut rand::rngs::ThreadRng,
+    ) -> Result<Self::Output, Self::Error> {
         input
             .into_iter()
             .map(|x| {
                 self.f
                     .apply(x, rng)
-                    .with_context(|| "Applying f to {x} in `Map` failed")
+                    .map_err(anyhow::Error::from)
+                    .context("Applying f to {x} in `Map` failed")
             })
             .collect()
     }

--- a/packages/ec-core/src/operator/composable/repeat_with.rs
+++ b/packages/ec-core/src/operator/composable/repeat_with.rs
@@ -1,6 +1,5 @@
 use std::iter;
 
-use anyhow::{anyhow, Result};
 use itertools::Itertools;
 
 use super::Composable;
@@ -23,21 +22,28 @@ impl<F, Input, const N: usize> Operator<Input> for RepeatWith<F, N>
 where
     Input: Clone,
     F: Operator<Input>,
+    anyhow::Error: From<F::Error>,
 {
     type Output = [F::Output; N];
+    type Error = anyhow::Error;
 
-    fn apply(&self, input: Input, rng: &mut rand::rngs::ThreadRng) -> Result<Self::Output> {
-        iter::repeat_with(|| self.f.apply(input.clone(), rng))
+    fn apply(
+        &self,
+        input: Input,
+        rng: &mut rand::rngs::ThreadRng,
+    ) -> Result<Self::Output, Self::Error> {
+        #[allow(clippy::panic)]
+        Ok(iter::repeat_with(|| self.f.apply(input.clone(), rng))
             .take(N)
-            .try_collect::<_, Vec<<F as Operator<Input>>::Output>, anyhow::Error>()?
+            .try_collect::<_, Vec<_>, _>()?
             .try_into()
-            .map_err(|v: Vec<<F as Operator<Input>>::Output>| {
-                anyhow!(
+            .unwrap_or_else(|v: Vec<_>| {
+                panic!(
                     "The vector had incorrect length; expected {} and got {}",
                     N,
                     v.len()
                 )
-            })
+            }))
     }
 }
 
@@ -46,7 +52,7 @@ impl<F, const N: usize> Composable for RepeatWith<F, N> {}
 #[cfg(test)]
 #[allow(clippy::arithmetic_side_effects)]
 mod tests {
-    use std::ops::Range;
+    use std::{convert::Infallible, ops::Range};
 
     use rand::{thread_rng, Rng};
 
@@ -55,8 +61,13 @@ mod tests {
     struct AddOne;
     impl Operator<i32> for AddOne {
         type Output = i32;
+        type Error = Infallible;
 
-        fn apply(&self, input: i32, _: &mut rand::rngs::ThreadRng) -> Result<Self::Output> {
+        fn apply(
+            &self,
+            input: i32,
+            _: &mut rand::rngs::ThreadRng,
+        ) -> Result<Self::Output, Self::Error> {
             Ok(input + 1)
         }
     }
@@ -77,12 +88,13 @@ mod tests {
     struct UniformRange;
     impl Operator<Range<i32>> for UniformRange {
         type Output = i32;
+        type Error = Infallible;
 
         fn apply(
             &self,
             range: Range<i32>,
             rng: &mut rand::rngs::ThreadRng,
-        ) -> Result<Self::Output> {
+        ) -> Result<Self::Output, Self::Error> {
             Ok(rng.gen_range(range))
         }
     }

--- a/packages/ec-core/src/operator/composable/repeat_with.rs
+++ b/packages/ec-core/src/operator/composable/repeat_with.rs
@@ -1,7 +1,5 @@
 use std::iter;
 
-use itertools::Itertools;
-
 use super::Composable;
 use crate::operator::Operator;
 
@@ -35,7 +33,7 @@ where
         #[allow(clippy::panic)]
         Ok(iter::repeat_with(|| self.f.apply(input.clone(), rng))
             .take(N)
-            .try_collect::<_, Vec<_>, _>()?
+            .collect::<Result<Vec<_>, _>>()?
             .try_into()
             .unwrap_or_else(|v: Vec<_>| {
                 panic!(

--- a/packages/ec-core/src/operator/genome_extractor.rs
+++ b/packages/ec-core/src/operator/genome_extractor.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-
 use super::{Composable, Operator};
 use crate::individual::Individual;
 
@@ -16,8 +14,13 @@ where
     <I as Individual>::Genome: Clone,
 {
     type Output = I::Genome;
+    type Error = anyhow::Error;
 
-    fn apply(&self, individual: &I, _: &mut rand::rngs::ThreadRng) -> Result<Self::Output> {
+    fn apply(
+        &self,
+        individual: &I,
+        _: &mut rand::rngs::ThreadRng,
+    ) -> Result<Self::Output, Self::Error> {
         Ok(individual.genome().clone())
     }
 }

--- a/packages/ec-core/src/operator/genome_scorer.rs
+++ b/packages/ec-core/src/operator/genome_scorer.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-
 use super::{composable::Wrappable, Composable, Operator};
 use crate::{
     individual::{ec::EcIndividual, scorer::Scorer},
@@ -34,10 +32,16 @@ where
     P: Population,
     GM: Operator<&'pop P>,
     S: Scorer<GM::Output, Score = R>,
+    anyhow::Error: From<GM::Error>,
 {
     type Output = EcIndividual<GM::Output, S::Score>;
+    type Error = anyhow::Error;
 
-    fn apply(&self, population: &'pop P, rng: &mut rand::rngs::ThreadRng) -> Result<Self::Output> {
+    fn apply(
+        &self,
+        population: &'pop P,
+        rng: &mut rand::rngs::ThreadRng,
+    ) -> Result<Self::Output, Self::Error> {
         let genome = self.genome_maker.apply(population, rng)?;
         let score = self.scorer.score(&genome);
         // TODO: We probably don't want to bake in `EcIndividual` here, but instead
@@ -45,4 +49,5 @@ where
         Ok(EcIndividual::new(genome, score))
     }
 }
+
 impl<GM, S> Composable for GenomeScorer<GM, S> {}

--- a/packages/ec-core/src/operator/identity.rs
+++ b/packages/ec-core/src/operator/identity.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use rand::rngs::ThreadRng;
 
 use super::{Composable, Operator};
@@ -18,8 +17,9 @@ where
     T: Clone,
 {
     type Output = T;
+    type Error = anyhow::Error;
 
-    fn apply(&self, (): (), _: &mut ThreadRng) -> Result<Self::Output> {
+    fn apply(&self, (): (), _: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
         Ok(self.value.clone())
     }
 }

--- a/packages/ec-core/src/operator/mod.rs
+++ b/packages/ec-core/src/operator/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use rand::rngs::ThreadRng;
 
 pub mod composable;
@@ -13,10 +12,11 @@ pub use composable::Composable;
 
 pub trait Operator<Input>: Composable {
     type Output;
+    type Error;
 
     /// # Errors
     /// This will return an error if there's some problem applying the operator.
     /// Given how general this concept is, there's no good way of saying here
     /// what that might be.
-    fn apply(&self, input: Input, rng: &mut ThreadRng) -> Result<Self::Output>;
+    fn apply(&self, input: Input, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error>;
 }

--- a/packages/ec-core/src/operator/mutator/mod.rs
+++ b/packages/ec-core/src/operator/mutator/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use rand::rngs::ThreadRng;
 
 use super::{Composable, Operator};
@@ -7,7 +6,7 @@ pub trait Mutator<G> {
     /// # Errors
     /// This can return an error if there is an error mutating the given
     /// genome.
-    fn mutate(&self, genome: G, rng: &mut ThreadRng) -> Result<G>;
+    fn mutate(&self, genome: G, rng: &mut ThreadRng) -> anyhow::Result<G>;
 }
 
 pub struct Mutate<M> {
@@ -25,8 +24,9 @@ where
     M: Mutator<G>,
 {
     type Output = G;
+    type Error = anyhow::Error;
 
-    fn apply(&self, genome: G, rng: &mut ThreadRng) -> Result<Self::Output> {
+    fn apply(&self, genome: G, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
         self.mutator.mutate(genome, rng)
     }
 }

--- a/packages/ec-core/src/operator/recombinator/mod.rs
+++ b/packages/ec-core/src/operator/recombinator/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use rand::rngs::ThreadRng;
 
 use super::{Composable, Operator};
@@ -19,7 +18,7 @@ pub trait Recombinator<GS> {
     /// # Errors
     /// This will return an error if there's some problem with the
     /// recombination.
-    fn recombine(&self, genomes: GS, rng: &mut ThreadRng) -> Result<Self::Output>;
+    fn recombine(&self, genomes: GS, rng: &mut ThreadRng) -> anyhow::Result<Self::Output>;
 }
 
 pub struct Recombine<R> {
@@ -37,8 +36,9 @@ where
     R: Recombinator<G>,
 {
     type Output = R::Output;
+    type Error = anyhow::Error;
 
-    fn apply(&self, genomes: G, rng: &mut ThreadRng) -> Result<Self::Output> {
+    fn apply(&self, genomes: G, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
         self.recombinator.recombine(genomes, rng)
     }
 }

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -39,8 +39,9 @@ where
     S: Selector<P>,
 {
     type Output = &'pop P::Individual;
+    type Error = anyhow::Error;
 
-    fn apply(&self, population: &'pop P, rng: &mut ThreadRng) -> Result<Self::Output> {
+    fn apply(&self, population: &'pop P, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
         self.selector.select(population, rng)
     }
 }


### PR DESCRIPTION
This adds an associated `Error` type for the `Operator` trait and changes the return type for `apply` to be a `std::result::Result` instead of an `anyhow::Result`.

This forced changes in anything that implemented `Operator`, as well as several things that acted on `Operator`s.

In several cases we had to add bounds saying that `anyhow::Error: From<X::Error>` to ensure that we could convert associated errors to `anyhow::Error`s. This (and other uses of `anyhow` in `ec_core`) should ultimately be removed as we transition to `miette` errors.
