### PR TITLE
Add specific `strum(to_string = …)` for Push `Push` instructions

### DIFF
--- a/packages/push/Cargo.toml
+++ b/packages/push/Cargo.toml
@@ -23,8 +23,8 @@ miette = { workspace = true }
 ec-core = { workspace = true }
 ec-linear = { workspace = true }
 
-strum = "0.26.2"
-strum_macros = "0.26.2"
+strum = "0.26.3"
+strum_macros = "0.26.4"
 embed-doc-image = "0.1.4"
 push_macros = { workspace = true, optional = true }
 collectable = "0.0.2"

--- a/packages/push/src/instruction/bool.rs
+++ b/packages/push/src/instruction/bool.rs
@@ -11,6 +11,7 @@ use crate::{
 #[derive(Debug, strum_macros::Display, Clone, PartialEq, Eq, EnumIter)]
 #[non_exhaustive]
 pub enum BoolInstruction {
+    #[strum(to_string = "Push({0})")]
     Push(bool),
     Not,
     Or,
@@ -170,5 +171,20 @@ mod property_tests {
 
         prop_assert_eq!(result_state.bool.size(), 1);
         prop_assert_eq!(*result_state.bool.top().unwrap(), !x || y);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::BoolInstruction;
+
+    #[test]
+    fn auto_display() {
+        assert_eq!(format!("{}", BoolInstruction::Not), "Not");
+    }
+
+    #[test]
+    fn manual_push_display() {
+        assert_eq!(format!("{}", BoolInstruction::Push(true)), "Push(true)");
     }
 }

--- a/packages/push/src/instruction/float.rs
+++ b/packages/push/src/instruction/float.rs
@@ -13,6 +13,7 @@ use crate::{
 #[derive(Debug, strum_macros::Display, Copy, Clone, EnumIter, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum FloatInstruction {
+    #[strum(to_string = "Push({0})")]
     Push(OrderedFloat<f64>),
     Add,
     Subtract,
@@ -121,5 +122,20 @@ impl FloatInstruction {
             .map(|(x, y)| op(x, y))
             .push_onto(state)
             .with_stack_discard::<OrderedFloat<f64>>(1)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::FloatInstruction;
+
+    #[test]
+    fn auto_display() {
+        assert_eq!(format!("{}", FloatInstruction::NotEqual), "NotEqual");
+    }
+
+    #[test]
+    fn manual_push_display() {
+        assert_eq!(format!("{}", FloatInstruction::Push(1.0.into())), "Push(1)");
     }
 }

--- a/packages/push/src/instruction/int/mod.rs
+++ b/packages/push/src/instruction/int/mod.rs
@@ -15,8 +15,8 @@ use crate::{
 #[non_exhaustive]
 #[must_use]
 pub enum IntInstruction {
+    #[strum(to_string = "Push({0})")]
     Push(i64),
-
     Negate(Negate),
     Abs(Abs),
     Min,
@@ -339,5 +339,20 @@ where
                     .with_stack_discard::<bool>(1)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::IntInstruction;
+
+    #[test]
+    fn auto_display() {
+        assert_eq!(format!("{}", IntInstruction::IsZero), "IsZero");
+    }
+
+    #[test]
+    fn manual_push_display() {
+        assert_eq!(format!("{}", IntInstruction::Push(1)), "Push(1)");
     }
 }


### PR DESCRIPTION
We need to display the values being pushed when we use a `Push(T)` instruction for `BoolInstruction`, `IntInstruction`, or `FloatInstruction`. This uses the `#[strum(to_string = "Push({0})")]` annotation to get each of these to display with a form like `Float-Push(1)`.

~~Adding these failed with the versions of `strum` and `strum-macros` that we were using at that point. I ran `cargo update` to update all the dependencies, including those for `strum` and `strum-macros`. That fixed the display, but unfortunately lead to a Clippy warning "multiple versions for dependency `heck`: 0.4.1, 0.5.0", which causes all the checks to fail on this PR.~~
Edit: Since this was laying around for so long I (@JustusFluegel ) just reset-ted to the main branch and cherry-picked the relevant commit. The heck issue also doesn't show up anymore.

Closes #222 