### PR TITLE
Improved editor configs

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,5 +1,5 @@
 [language-server.rust-analyzer.config.rustfmt]
-overrideCommand = ["rustfmt-unstable", "--", "rustfmt"]
+overrideCommand = ["rustfmt-unstable", "--", "rustfmt", "--edition", "2021"]
 
 [language-server.rust-analyzer.config.check]
 overrideCommand = ["cargo","+nightly","clippy","--all-targets","--workspace","--message-format=json-diagnostic-rendered-ansi"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,15 @@
     "rust-analyzer.rustfmt.overrideCommand": [
         "rustfmt-unstable",
         "--",
-        "rustfmt"
-    ]
+        "rustfmt",
+        "--edition",
+        "2021"
+    ],
+    "rust-analyzer.check.overrideCommand": [
+        "cargo",
+        "clippy",
+        "--all-targets",
+        "--workspace",
+        "--message-format=json-diagnostic-rendered-ansi"
+    ],
 }


### PR DESCRIPTION
I recently found in another project that rustfmt can behave weirdly without --edition 2021. This also mirrors the changes that were made to the helix config in the meantime in vscode