### PR TITLE
Actually use nightly in vscode for clippy lints.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
     ],
     "rust-analyzer.check.overrideCommand": [
         "cargo",
+        "+nightly",
         "clippy",
         "--all-targets",
         "--workspace",


### PR DESCRIPTION
Quick fix for a blunder in #226 