### PR TITLE
Ignore duplicate version of `heck` crate

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,5 +4,6 @@ allowed-duplicate-crates = [
   "rand_core",
   "base64",
   "itertools",
-  "syn"
+  "syn",
+  "heck"
 ]


### PR DESCRIPTION
This tells Clippy to not worry about the fact that we have multiple version of the `heck` crate. Hopefully we can remove this after we get updated versions of some other crates.