### PR TITLE
Clean up Clippy warnings in doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - run: cargo test --all-targets --verbose
       - run: cargo test --doc --verbose
       - run: cargo clippy --all-targets
+      - run: chmod +x scripts/cargo-rustdoc-clippy && export PATH="$(pwd)/scripts/:$PATH" && cargo rustdoc-clippy -- -Dwarnings
       - run: cargo install rustfmt-unstable
       # Currently (v1.x) rustfmt accepts unstable features as
       # arguments only, this wrapper reads the file and passes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       - run: cargo test --all-targets --verbose
       - run: cargo test --doc --verbose
       - run: cargo clippy --all-targets
-      - run: chmod +x scripts/cargo-rustdoc-clippy && export PATH="$(pwd)/scripts/:$PATH" && cargo rustdoc-clippy -- -Dwarnings
       - run: cargo install rustfmt-unstable
       # Currently (v1.x) rustfmt accepts unstable features as
       # arguments only, this wrapper reads the file and passes
@@ -41,3 +40,13 @@ jobs:
       - run: rustfmt-unstable --config-file rustfmt.toml -- cargo fmt --check -- --config error_on_line_overflow=true
       - run: cargo install example-runner-cli
       - run: example-runner-cli --error-on-unconfigured --error-on-unknown --parallel
+  doctest-clippy:
+    name: clippy doctests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          components: clippy
+          toolchain: nightly
+      - run: chmod +x scripts/cargo-rustdoc-clippy && export PATH="$(pwd)/scripts/:$PATH" && cargo rustdoc-clippy -- -Dwarnings

--- a/packages/ec-core/src/lib.rs
+++ b/packages/ec-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(test(attr(warn(unused))))]
+
 pub mod child_maker;
 pub mod distributions;
 pub mod generation;

--- a/packages/ec-core/src/operator/selector/tournament.rs
+++ b/packages/ec-core/src/operator/selector/tournament.rs
@@ -30,7 +30,7 @@ impl Tournament {
     /// Create a tournament selector with tournament size 3:
     /// ```
     /// # use ec_core::operator::selector::tournament::Tournament;
-    /// let selector = Tournament::of_size::<3>();
+    /// let _selector = Tournament::of_size::<3>();
     /// ```
     #[must_use]
     pub const fn of_size<const N: usize>() -> Self {

--- a/packages/ec-linear/src/lib.rs
+++ b/packages/ec-linear/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(test(attr(warn(unused))))]
+
 pub mod genome;
 pub mod mutator;
 pub mod recombinator;

--- a/packages/push-macros/src/lib.rs
+++ b/packages/push-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(test(attr(warn(unused))))]
+
 use push_state::printing::generate_builder::generate_builder;
 use quote::quote;
 use syn::{spanned::Spanned, DeriveInput};

--- a/packages/push-macros/src/push_state/printing/generate_builder.rs
+++ b/packages/push-macros/src/push_state/printing/generate_builder.rs
@@ -238,7 +238,7 @@ pub fn generate_builder(
                     let outtro = "# Ok::<(), StackError>(())";
 
                     let doctest_code = quote! {
-                        let mut state = #struct_ident::builder()
+                        let state = #struct_ident::builder()
                             .with_max_stack_size(#max_stack_size)
                             .with_no_program()
                             .#fn_ident([#sample_values])?
@@ -419,7 +419,7 @@ pub fn generate_builder(
             let outtro = "# Ok::<(), StackError>(())";
 
             let doctest_code = quote! {
-                let mut state = #struct_ident::builder()
+                let state = #struct_ident::builder()
                     .with_max_stack_size(100)
                     .with_no_program()
                     .build();

--- a/packages/push/src/evaluation/cases/iter.rs
+++ b/packages/push/src/evaluation/cases/iter.rs
@@ -12,7 +12,7 @@ impl<Input, Output> IntoIterator for Cases<Input, Output> {
     /// # Examples
     ///
     /// ```
-    /// # use push::evaluation::{Case, Cases, WithTargetFn};
+    /// # use push::evaluation::{Case, WithTargetFn};
     /// #
     /// let inputs = ["Hello", "People"];
     /// let cases = inputs.with_target_fn(|s| s.len());
@@ -93,7 +93,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// # use push::evaluation::{Case, Cases};
+    /// # use push::evaluation::Cases;
     /// #
     /// let items = [("Hello", 5), ("People", 6)];
     /// let cases = Cases::from_iter(items);

--- a/packages/push/src/evaluation/cases/mod.rs
+++ b/packages/push/src/evaluation/cases/mod.rs
@@ -17,7 +17,7 @@ pub use with_target_fn::WithTargetFn;
 /// # Examples
 ///
 /// ```
-/// # use push::evaluation::{Case, Cases, WithTargetFn};
+/// # use push::evaluation::WithTargetFn;
 /// #
 /// let inputs = ["this", "and", "those"];
 /// // Pair strings (inputs) with their lengths (outputs).
@@ -151,7 +151,7 @@ impl<Input, Output> Cases<Input, Output> {
     /// # Examples
     ///
     /// ```
-    /// # use push::evaluation::{Case, Cases, WithTargetFn};
+    /// # use push::evaluation::{Case, WithTargetFn};
     /// #
     /// let inputs = ["Hello", "People"];
     /// let cases = inputs.with_target_fn(|s| s.len());
@@ -173,7 +173,7 @@ impl<Input, Output> Cases<Input, Output> {
     /// # use push::evaluation::{Case, Cases};
     /// #
     /// let first_case = Case::new("Hello", 5);
-    /// let mut second_case = Case::new("People", 6);
+    /// let second_case = Case::new("People", 6);
     /// let mut cases = Cases::new().with_case(first_case).with_case(second_case);
     ///
     /// cases.iter_mut().for_each(|c| c.output *= 2);

--- a/scripts/cargo-rustdoc-clippy
+++ b/scripts/cargo-rustdoc-clippy
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [[ $# -gt 0 && "$1" = "rustdoc-clippy" ]]
+then
+  shift
+
+  if [[ $# -gt 0 && "$1" = "--help" ]]
+  then
+    echo "USAGE: cargo rustdoc-clippy [cargo-options] [-- [rustdoc-options] [-- [clippy-options]]]"
+    exit
+  fi
+
+  cargo_args=()
+  while [[ $# -gt 0 && "$1" != "--" ]]
+  do
+    cargo_args+="$1"
+    shift
+  done
+
+  if [[ $# -gt 0 ]]
+  then
+    shift
+  fi
+
+  rustdoc_args=()
+  while [[ $# -gt 0 && "$1" != "--" ]]
+  do
+    rustdoc_args+="$1"
+    shift
+  done
+
+  if [[ $# -gt 0 ]]
+  then
+    shift
+  fi
+
+  clippy_args=()
+  while [[ $# -gt 0 ]]
+  do
+    clippy_args+="$1"
+    shift
+  done
+
+  CLIPPYFLAGS="$(IFS="\x1E"; echo "${clippy_args[*]}")" RUSTDOCFLAGS="--no-run --nocapture --test-builder "$0" -Z unstable-options ${rustdoc_args[@]}" exec cargo test --doc "${cargo_args[@]}"
+else
+  if [[ "$CLIPPYFLAGS" != "" ]]
+  then
+    exec clippy-driver "${(@s:\x1E:)CLIPPYFLAGS}" "${@}"
+  else
+    exec clippy-driver "${@}"
+  fi
+fi


### PR DESCRIPTION
This runs Clippy on all the doctests, and includes checking for `unused` elements.

This generated several warnings, which we also cleaned up.

Closes #255 