### PR TITLE
Add proptest tests for selectors

### DIFF
--- a/packages/ec-core/src/operator/selector/best.rs
+++ b/packages/ec-core/src/operator/selector/best.rs
@@ -30,6 +30,8 @@ where
     )
 )]
 mod tests {
+    use test_strategy::proptest;
+
     use super::*;
 
     #[test]
@@ -38,5 +40,13 @@ mod tests {
         let mut rng = rand::thread_rng();
         assert_eq!(&9, Best.select(&pop, &mut rng).unwrap());
         assert_eq!(&9, Best.select(&pop, &mut rng).unwrap());
+    }
+
+    #[proptest]
+    fn test_best_select(#[any] values: [i32; 10]) {
+        let pop: Vec<i32> = values.into();
+        let mut rng = rand::thread_rng();
+        let largest = pop.iter().max().unwrap();
+        assert_eq!(largest, Best.select(&pop, &mut rng).unwrap());
     }
 }

--- a/packages/ec-core/src/operator/selector/best.rs
+++ b/packages/ec-core/src/operator/selector/best.rs
@@ -32,7 +32,7 @@ where
 mod tests {
     use test_strategy::proptest;
 
-    use super::*;
+    use super::{Best, Selector};
 
     #[test]
     fn can_select_twice() {

--- a/packages/ec-core/src/operator/selector/best.rs
+++ b/packages/ec-core/src/operator/selector/best.rs
@@ -36,6 +36,9 @@ mod tests {
 
     #[test]
     fn can_select_twice() {
+        // Currently `.select()` can't take an array, so we need to make this a `Vec`.
+        // Once we've generalized `.select()` appropriately we can change this to be
+        // an array. See #259
         let pop = vec![5, 8, 9, 6, 3, 2, 0];
         let mut rng = rand::thread_rng();
         assert_eq!(&9, Best.select(&pop, &mut rng).unwrap());
@@ -43,8 +46,7 @@ mod tests {
     }
 
     #[proptest]
-    fn test_best_select(#[any] values: [i32; 10]) {
-        let pop: Vec<i32> = values.into();
+    fn test_best_select(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
         let mut rng = rand::thread_rng();
         let largest = pop.iter().max().unwrap();
         assert_eq!(largest, Best.select(&pop, &mut rng).unwrap());

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -9,6 +9,7 @@ pub mod lexicase;
 pub mod random;
 pub mod tournament;
 pub mod weighted;
+pub mod worst;
 
 pub trait Selector<P>
 where

--- a/packages/ec-core/src/operator/selector/random.rs
+++ b/packages/ec-core/src/operator/selector/random.rs
@@ -21,3 +21,26 @@ where
             .context("The population was empty")
     }
 }
+
+#[cfg(test)]
+#[rustversion::attr(before(1.81), allow(clippy::unwrap_used))]
+#[rustversion::attr(
+    since(1.81),
+    expect(
+        clippy::unwrap_used,
+        reason = "Panicking is the best way to deal with errors in unit tests"
+    )
+)]
+mod tests {
+    use test_strategy::proptest;
+
+    use super::{Random, Selector};
+
+    #[proptest]
+    fn test_random(#[any] values: [i32; 10]) {
+        let pop: Vec<i32> = values.into();
+        let mut rng = rand::thread_rng();
+        let selection = Random.select(&pop, &mut rng).unwrap();
+        assert!(values.contains(selection));
+    }
+}

--- a/packages/ec-core/src/operator/selector/random.rs
+++ b/packages/ec-core/src/operator/selector/random.rs
@@ -37,10 +37,9 @@ mod tests {
     use super::{Random, Selector};
 
     #[proptest]
-    fn test_random(#[any] values: [i32; 10]) {
-        let pop: Vec<i32> = values.into();
+    fn test_random(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
         let mut rng = rand::thread_rng();
         let selection = Random.select(&pop, &mut rng).unwrap();
-        assert!(values.contains(selection));
+        assert!(pop.contains(selection));
     }
 }

--- a/packages/ec-core/src/operator/selector/weighted.rs
+++ b/packages/ec-core/src/operator/selector/weighted.rs
@@ -59,6 +59,7 @@ where
     )
 )]
 mod tests {
+    use itertools::Itertools;
     use test_strategy::proptest;
 
     use super::Weighted;
@@ -72,8 +73,7 @@ mod tests {
         // or lowest value.
         let weighted = Weighted::new(Best, 1).with_selector(Worst, 1);
         let selection = weighted.select(&pop, &mut rng).unwrap();
-        let smallest = values.iter().min().unwrap();
-        let largest = values.iter().max().unwrap();
-        assert!([smallest, largest].contains(&selection));
+        let extremes: [&i32; 2] = pop.iter().minmax().into_option().unwrap().into();
+        assert!(extremes.contains(&selection));
     }
 }

--- a/packages/ec-core/src/operator/selector/weighted.rs
+++ b/packages/ec-core/src/operator/selector/weighted.rs
@@ -48,3 +48,32 @@ where
         selector.select(population, rng)
     }
 }
+
+#[cfg(test)]
+#[rustversion::attr(before(1.81), allow(clippy::unwrap_used))]
+#[rustversion::attr(
+    since(1.81),
+    expect(
+        clippy::unwrap_used,
+        reason = "Panicking is the best way to deal with errors in unit tests"
+    )
+)]
+mod tests {
+    use test_strategy::proptest;
+
+    use super::Weighted;
+    use crate::operator::selector::{best::Best, worst::Worst, Selector};
+
+    #[proptest]
+    fn test_random(#[any] values: [i32; 10]) {
+        let pop: Vec<i32> = values.into();
+        let mut rng = rand::thread_rng();
+        // We'll make a selector that has a 50/50 chance of choosing the highest
+        // or lowest value.
+        let weighted = Weighted::new(Best, 1).with_selector(Worst, 1);
+        let selection = weighted.select(&pop, &mut rng).unwrap();
+        let smallest = values.iter().min().unwrap();
+        let largest = values.iter().max().unwrap();
+        assert!([smallest, largest].contains(&selection));
+    }
+}

--- a/packages/ec-core/src/operator/selector/weighted.rs
+++ b/packages/ec-core/src/operator/selector/weighted.rs
@@ -66,8 +66,7 @@ mod tests {
     use crate::operator::selector::{best::Best, worst::Worst, Selector};
 
     #[proptest]
-    fn test_random(#[any] values: [i32; 10]) {
-        let pop: Vec<i32> = values.into();
+    fn test_random(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
         let mut rng = rand::thread_rng();
         // We'll make a selector that has a 50/50 chance of choosing the highest
         // or lowest value.

--- a/packages/ec-core/src/operator/selector/worst.rs
+++ b/packages/ec-core/src/operator/selector/worst.rs
@@ -36,6 +36,9 @@ mod tests {
 
     #[test]
     fn can_select_twice() {
+        // Currently `.select()` can't take an array, so we need to make this a `Vec`.
+        // Once we've generalized `.select()` appropriately we can change this to be
+        // an array. See #259
         let pop = vec![5, 8, 9, 6, 3, 2, 10];
         let mut rng = rand::thread_rng();
         assert_eq!(&2, Worst.select(&pop, &mut rng).unwrap());
@@ -43,8 +46,7 @@ mod tests {
     }
 
     #[proptest]
-    fn test_worst_select(#[any] values: [i32; 10]) {
-        let pop: Vec<i32> = values.into();
+    fn test_worst_select(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
         let mut rng = rand::thread_rng();
         let smallest = pop.iter().min().unwrap();
         assert_eq!(smallest, Worst.select(&pop, &mut rng).unwrap());

--- a/packages/ec-core/src/operator/selector/worst.rs
+++ b/packages/ec-core/src/operator/selector/worst.rs
@@ -1,0 +1,52 @@
+use anyhow::{Context, Result};
+use rand::rngs::ThreadRng;
+
+use super::Selector;
+use crate::population::Population;
+
+pub struct Worst;
+
+impl<P> Selector<P> for Worst
+where
+    P: Population,
+    for<'pop> &'pop P: IntoIterator<Item = &'pop P::Individual>,
+    P::Individual: Ord,
+{
+    fn select<'pop>(&self, population: &'pop P, _: &mut ThreadRng) -> Result<&'pop P::Individual> {
+        population
+            .into_iter()
+            .min()
+            .context("The population was empty")
+    }
+}
+
+#[cfg(test)]
+#[rustversion::attr(before(1.81), allow(clippy::unwrap_used))]
+#[rustversion::attr(
+    since(1.81),
+    expect(
+        clippy::unwrap_used,
+        reason = "Panicking is the best way to deal with errors in unit tests"
+    )
+)]
+mod tests {
+    use test_strategy::proptest;
+
+    use super::{Selector, Worst};
+
+    #[test]
+    fn can_select_twice() {
+        let pop = vec![5, 8, 9, 6, 3, 2, 10];
+        let mut rng = rand::thread_rng();
+        assert_eq!(&2, Worst.select(&pop, &mut rng).unwrap());
+        assert_eq!(&2, Worst.select(&pop, &mut rng).unwrap());
+    }
+
+    #[proptest]
+    fn test_worst_select(#[any] values: [i32; 10]) {
+        let pop: Vec<i32> = values.into();
+        let mut rng = rand::thread_rng();
+        let smallest = pop.iter().min().unwrap();
+        assert_eq!(smallest, Worst.select(&pop, &mut rng).unwrap());
+    }
+}


### PR DESCRIPTION
This adds `proptest` for all the selectors mentioned in #240:

- #242
- #243 
- #244 

I also added a new `Worst` selector because that made it easier to write a reasonable test for the `Weighted` selector. That might also be useful in some EC contexts where, for example, we might want to select the worst individual for removal from the population.

We had talked about doing these in separate PRs, but in the end it was so straightforward that I figured I'd just do them all as a batch.

Closes: #240 
Closes: #242 
Closes: #243 
Closes: #244 