### PR TITLE
Add explicit errors for selectors

### DIFF
--- a/packages/ec-core/Cargo.toml
+++ b/packages/ec-core/Cargo.toml
@@ -27,12 +27,13 @@ rand = { workspace = true, features = ["alloc"] }
 rayon = "1.7.0"
 macro_railroad_annotation = { workspace = true }
 rustversion = { workspace = true }
+thiserror = { workspace = true }
+miette = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["alloc", "small_rng"] }
 criterion = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
-thiserror = { workspace = true }
 proptest = { workspace = true }
 test-strategy = { workspace = true }
 

--- a/packages/ec-core/src/operator/selector/error.rs
+++ b/packages/ec-core/src/operator/selector/error.rs
@@ -1,0 +1,10 @@
+use miette::Diagnostic;
+
+#[derive(Debug, thiserror::Error, Diagnostic)]
+pub enum SelectionError {
+    #[error("Can't select from an empty population")]
+    #[diagnostic(
+        help = "Add a minimum of one individual to your your population before trying to select"
+    )]
+    EmptyPopulation,
+}

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -7,6 +7,7 @@ pub mod best;
 pub mod error;
 pub mod lexicase;
 pub mod random;
+pub mod recursive_weighted;
 pub mod tournament;
 pub mod weighted;
 pub mod worst;

--- a/packages/ec-core/src/operator/selector/recursive_weighted.rs
+++ b/packages/ec-core/src/operator/selector/recursive_weighted.rs
@@ -1,0 +1,147 @@
+use std::marker::PhantomData;
+
+use rand::{seq::IndexedRandom, Rng};
+
+use super::Selector;
+use crate::{operator::selector::weighted::WeightedError, population::Population};
+
+trait WithWeight<P>: Selector<P>
+where
+    P: Population,
+{
+    fn weight(&self) -> usize;
+}
+
+struct Weighted<T> {
+    weight: usize,
+    selector: T,
+}
+
+impl<P, T> WithWeight<P> for Weighted<T>
+where
+    P: Population,
+    T: Selector<P>,
+{
+    fn weight(&self) -> usize {
+        self.weight
+    }
+}
+
+impl<P, T> Selector<P> for Weighted<T>
+where
+    P: Population,
+    T: Selector<P>,
+{
+    type Error = T::Error;
+
+    fn select<'pop>(
+        &self,
+        population: &'pop P,
+        rng: &mut rand::prelude::ThreadRng,
+    ) -> Result<&'pop <P as Population>::Individual, Self::Error> {
+        self.selector.select(population, rng)
+    }
+}
+
+struct WeightedSelectors<P, A, B>
+where
+    P: Population,
+    A: WithWeight<P>,
+    B: WithWeight<P>,
+{
+    a: A,
+    b: B,
+    _p: PhantomData<P>,
+}
+
+enum WeightedSelectorsError<P, A, B>
+where
+    P: Population,
+    A: Selector<P>,
+    B: Selector<P>,
+{
+    A(A::Error),
+    B(B::Error),
+    NonZeroSum,
+    // #[error("Adding the weights {0} and {1} overflows")]
+    WeightSumOverflows(usize, usize),
+}
+
+impl<P, A, B> Selector<P> for WeightedSelectors<P, A, B>
+where
+    P: Population,
+    A: WithWeight<P>,
+    B: WithWeight<P>,
+{
+    type Error = WeightedSelectorsError<P, A, B>;
+
+    fn select<'pop>(
+        &self,
+        population: &'pop P,
+        rng: &mut rand::prelude::ThreadRng,
+    ) -> Result<&'pop <P as Population>::Individual, Self::Error> {
+        let a_weight = self.a.weight();
+        let b_weight = self.b.weight();
+        let weight_sum = a_weight
+            .checked_add(b_weight)
+            .ok_or_else(|| WeightedSelectorsError::WeightSumOverflows(a_weight, b_weight))?;
+        if weight_sum == 0 {
+            return Err(WeightedSelectorsError::NonZeroSum);
+        }
+        let choose_a = rng.gen_range(0..weight_sum) < a_weight;
+        if choose_a {
+            self.a
+                .select(population, rng)
+                .map_err(|e| WeightedSelectorsError::A(e))
+        } else {
+            self.b
+                .select(population, rng)
+                .map_err(|e| WeightedSelectorsError::B(e))
+        }
+    }
+}
+
+// impl<A: Selector, B: Selector> Selector for WeightedSelector<A, B> {
+//     type Error = WSelectorError<A, B>;
+// }
+
+// impl<A: WithWeight, B: WithWeight> WithWeight for WeightedSelector<A, B> {
+//     const WEIGHT: usize = { A::WEIGHT + B::WEIGHT };
+// }
+
+// impl<A: WithWeight, B: WithWeight> WeightedSelector<A, B> {
+//     fn new<const WEIGHT_A: usize, const WEIGHT_B: usize, Sel_A: Selector,
+// Sel_B: Selector>(         selector1: Sel_A,
+//         selector2: Sel_B,
+//     ) -> WeightedSelector<Weight<WEIGHT_A, Sel_A>, Weight<WEIGHT_B, Sel_B>> {
+//         WeightedSelector {
+//             a: Weight {
+//                 selector: selector1,
+//             },
+//             b: Weight {
+//                 selector: selector2,
+//             },
+//         }
+//     }
+
+//     fn with_selector<const WEIGHT: usize, const Sel: Selector>(
+//         selector: A,
+//     ) -> WeightedSelector<Weight<WEIGHT, Sel>, Self> {
+//         WeightedSelector {
+//             a: Weight { selector },
+//             b: self,
+//         }
+//     }
+
+//     // this should be in the trait but for simplicities sake this is
+// pseudocode     fn select() {
+//         let weight_a = A::WEIGHT;
+//         let weight_b = B::WEIGHT;
+
+//         if choose(weight_a, weight_b) {
+//             self.a.select()
+//         } else {
+//             self.b.select()
+//         }
+//     }
+// }

--- a/packages/ec-core/src/operator/selector/weighted.rs
+++ b/packages/ec-core/src/operator/selector/weighted.rs
@@ -1,11 +1,33 @@
-use anyhow::{Context, Result};
-use rand::{rngs::ThreadRng, seq::IndexedRandom};
+use std::error::Error;
 
-use super::Selector;
+use miette::Diagnostic;
+use rand::{
+    rngs::ThreadRng,
+    seq::{IndexedRandom, WeightError},
+};
+
+use super::{error::SelectionError, Selector};
 use crate::population::Population;
 
 pub struct Weighted<P: Population> {
-    selectors: Vec<(Box<dyn Selector<P> + Send + Sync>, usize)>,
+    selectors: Vec<(
+        Box<dyn Selector<P, Error = Box<dyn Error>> + Send + Sync>,
+        usize,
+    )>,
+}
+
+#[derive(Debug, thiserror::Error, Diagnostic)]
+pub enum WeightedError {
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Selector(#[from] SelectionError),
+
+    #[error(transparent)]
+    #[diagnostic(help = "Ensure that the weights are all non-negative and add to more than zero")]
+    Weight(#[from] WeightError),
+
+    #[error(transparent)]
+    Other(Box<dyn Error>),
 }
 
 impl<P: Population> Weighted<P> {
@@ -15,7 +37,10 @@ impl<P: Population> Weighted<P> {
     #[must_use]
     pub fn new<S>(selector: S, weight: usize) -> Self
     where
-        S: Selector<P> + Send + Sync + 'static,
+        S: Selector<P, Error = std::boxed::Box<(dyn std::error::Error + 'static)>>
+            + Send
+            + Sync
+            + 'static,
     {
         Self {
             selectors: vec![(Box::new(selector), weight)],
@@ -25,7 +50,10 @@ impl<P: Population> Weighted<P> {
     #[must_use]
     pub fn with_selector<S>(mut self, selector: S, weight: usize) -> Self
     where
-        S: Selector<P> + Send + Sync + 'static,
+        S: Selector<P, Error = std::boxed::Box<(dyn std::error::Error + 'static)>>
+            + Send
+            + Sync
+            + 'static,
     {
         self.selectors.push((Box::new(selector), weight));
         self
@@ -36,16 +64,36 @@ impl<P> Selector<P> for Weighted<P>
 where
     P: Population,
 {
+    type Error = WeightedError;
+
     fn select<'pop>(
         &self,
         population: &'pop P,
         rng: &mut ThreadRng,
-    ) -> Result<&'pop P::Individual> {
-        let (selector, _) = self
-            .selectors
-            .choose_weighted(rng, |(_, w)| *w)
-            .context("The set of selectors was empty")?;
-        selector.select(population, rng)
+    ) -> Result<&'pop P::Individual, Self::Error> {
+        let (selector, _) = self.selectors.choose_weighted(rng, |(_, w)| *w)?;
+        selector
+            .select(population, rng)
+            .map_err(WeightedError::Other)
+    }
+}
+
+impl<P, S> Selector<P> for Box<S>
+where
+    P: Population,
+    S: Selector<P>,
+    S::Error: Error + 'static,
+{
+    type Error = Box<dyn Error>;
+
+    fn select<'pop>(
+        &self,
+        population: &'pop P,
+        rng: &mut ThreadRng,
+    ) -> Result<&'pop <P as Population>::Individual, Self::Error> {
+        (**self)
+            .select(population, rng)
+            .map_err(|e| Box::new(e).into())
     }
 }
 
@@ -70,7 +118,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         // We'll make a selector that has a 50/50 chance of choosing the highest
         // or lowest value.
-        let weighted = Weighted::new(Best, 1).with_selector(Worst, 1);
+        let weighted = Weighted::new(Box::new(Best), 1).with_selector(Box::new(Worst), 1);
         let selection = weighted.select(&pop, &mut rng).unwrap();
         let extremes: [&i32; 2] = pop.iter().minmax().into_option().unwrap().into();
         assert!(extremes.contains(&selection));

--- a/packages/ec-core/src/operator/selector/worst.rs
+++ b/packages/ec-core/src/operator/selector/worst.rs
@@ -1,7 +1,6 @@
-use anyhow::{Context, Result};
 use rand::rngs::ThreadRng;
 
-use super::Selector;
+use super::{error::SelectionError, Selector};
 use crate::population::Population;
 
 pub struct Worst;
@@ -12,11 +11,17 @@ where
     for<'pop> &'pop P: IntoIterator<Item = &'pop P::Individual>,
     P::Individual: Ord,
 {
-    fn select<'pop>(&self, population: &'pop P, _: &mut ThreadRng) -> Result<&'pop P::Individual> {
+    type Error = SelectionError;
+
+    fn select<'pop>(
+        &self,
+        population: &'pop P,
+        _: &mut ThreadRng,
+    ) -> Result<&'pop P::Individual, Self::Error> {
         population
             .into_iter()
             .min()
-            .context("The population was empty")
+            .ok_or(SelectionError::EmptyPopulation)
     }
 }
 
@@ -33,6 +38,17 @@ mod tests {
     use test_strategy::proptest;
 
     use super::{Selector, Worst};
+    use crate::operator::selector::error::SelectionError;
+
+    #[test]
+    fn empty_population() {
+        let pop: Vec<i32> = Vec::new();
+        let mut rng = rand::thread_rng();
+        assert!(matches!(
+            Worst.select(&pop, &mut rng),
+            Err(SelectionError::EmptyPopulation)
+        ));
+    }
 
     #[test]
     fn can_select_twice() {


### PR DESCRIPTION
Replace of "generic" `anyhow` errors with error types specific to the different selectors.

There is a general `SelectionError::EmptyPopulation` for the common error when trying to select from an empty population.

Different selection mechanisms have specific errors as necessary. `Tournament` has `TournamentError::LargerThanPopulation`, for example, for the case where the tournament size is larger than the population size.