### PR TITLE
Rustfmt changes 1.81

### DIFF
--- a/packages/ec-core/benches/test_results.rs
+++ b/packages/ec-core/benches/test_results.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use ec_core::{distributions::collection::ConvertToCollectionGenerator, test_results::TestResults};
 use rand::{
     distr::{Distribution, Standard},

--- a/packages/ec-core/src/distributions/choices.rs
+++ b/packages/ec-core/src/distributions/choices.rs
@@ -8,13 +8,13 @@ pub trait ChoicesDistribution {
     fn num_choices(&self) -> NonZeroUsize;
 }
 
-impl<'a, T> ChoicesDistribution for Slice<'a, T> {
+impl<T> ChoicesDistribution for Slice<'_, T> {
     fn num_choices(&self) -> NonZeroUsize {
         self.num_choices()
     }
 }
 
-impl<'a, T> ChoicesDistribution for &'a T
+impl<T> ChoicesDistribution for &T
 where
     T: ChoicesDistribution + ?Sized,
 {
@@ -23,7 +23,7 @@ where
     }
 }
 
-impl<'a, T> ChoicesDistribution for &'a mut T
+impl<T> ChoicesDistribution for &mut T
 where
     T: ChoicesDistribution + ?Sized,
 {

--- a/packages/ec-core/src/distributions/wrappers/owned.rs
+++ b/packages/ec-core/src/distributions/wrappers/owned.rs
@@ -78,10 +78,10 @@ impl<T, U> ChoicesDistribution for OneOfCloning<T, U> {
     }
 }
 
-impl<'a, T, U> Distribution<U> for OneOfCloning<T, U>
+impl<T, U> Distribution<U> for OneOfCloning<T, U>
 where
     T: Borrow<[U]>,
-    U: 'a + Clone,
+    U: Clone,
 {
     #[rustversion::attr(before(1.81), allow(clippy::unwrap_used))]
     #[rustversion::attr(

--- a/packages/ec-core/src/distributions/wrappers/slice_cloning.rs
+++ b/packages/ec-core/src/distributions/wrappers/slice_cloning.rs
@@ -34,13 +34,13 @@ impl<'a, T> SliceCloning<'a, T> {
     }
 }
 
-impl<'a, T> ChoicesDistribution for SliceCloning<'a, T> {
+impl<T> ChoicesDistribution for SliceCloning<'_, T> {
     fn num_choices(&self) -> NonZeroUsize {
         self.0.num_choices()
     }
 }
 
-impl<'a, T> Distribution<T> for SliceCloning<'a, T>
+impl<T> Distribution<T> for SliceCloning<'_, T>
 where
     T: Clone,
 {

--- a/packages/ec-core/src/individual/ec.rs
+++ b/packages/ec-core/src/individual/ec.rs
@@ -10,8 +10,8 @@ use std::{
 use rand::prelude::Distribution;
 
 use super::{
-    scorer::{FnScorer, Scorer},
     Individual,
+    scorer::{FnScorer, Scorer},
 };
 
 /// `EcIndividual` is a struct that represents an individual in an evolutionary

--- a/packages/ec-core/src/operator/composable/repeat_with.rs
+++ b/packages/ec-core/src/operator/composable/repeat_with.rs
@@ -67,7 +67,7 @@ impl<F, const N: usize> Composable for RepeatWith<F, N> {}
 mod tests {
     use std::{convert::Infallible, ops::Range};
 
-    use rand::{thread_rng, Rng};
+    use rand::{Rng, thread_rng};
 
     use super::*;
 

--- a/packages/ec-core/src/operator/genome_scorer.rs
+++ b/packages/ec-core/src/operator/genome_scorer.rs
@@ -1,4 +1,4 @@
-use super::{composable::Wrappable, Composable, Operator};
+use super::{Composable, Operator, composable::Wrappable};
 use crate::{
     individual::{ec::EcIndividual, scorer::Scorer},
     population::Population,

--- a/packages/ec-core/src/operator/selector/best.rs
+++ b/packages/ec-core/src/operator/selector/best.rs
@@ -1,6 +1,6 @@
 use rand::rngs::ThreadRng;
 
-use super::{error::EmptyPopulation, Selector};
+use super::{Selector, error::EmptyPopulation};
 use crate::population::Population;
 
 #[derive(Debug)]

--- a/packages/ec-core/src/operator/selector/dyn_weighted.rs
+++ b/packages/ec-core/src/operator/selector/dyn_weighted.rs
@@ -6,7 +6,7 @@ use rand::{
     seq::{IndexedRandom, WeightError},
 };
 
-use super::{error::EmptyPopulation, Selector};
+use super::{Selector, error::EmptyPopulation};
 use crate::population::Population;
 
 trait DynSelector<P>
@@ -116,7 +116,7 @@ mod tests {
     use test_strategy::proptest;
 
     use super::DynWeighted;
-    use crate::operator::selector::{best::Best, worst::Worst, Selector};
+    use crate::operator::selector::{Selector, best::Best, worst::Worst};
 
     #[proptest]
     fn best_or_worst(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {

--- a/packages/ec-core/src/operator/selector/lexicase.rs
+++ b/packages/ec-core/src/operator/selector/lexicase.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, mem::swap, ops::Not};
 
 use rand::{prelude::SliceRandom, rngs::ThreadRng};
 
-use super::{error::EmptyPopulation, Selector};
+use super::{Selector, error::EmptyPopulation};
 use crate::{individual::Individual, population::Population, test_results::TestResults};
 
 #[derive(Debug)]
@@ -114,7 +114,7 @@ mod tests {
 
     use proptest::{
         collection,
-        prelude::{any, Strategy},
+        prelude::{Strategy, any},
         prop_assert, prop_assert_eq,
     };
     use test_strategy::proptest;

--- a/packages/ec-core/src/operator/selector/random.rs
+++ b/packages/ec-core/src/operator/selector/random.rs
@@ -1,6 +1,6 @@
 use rand::{prelude::IndexedRandom, rngs::ThreadRng};
 
-use super::{error::EmptyPopulation, Selector};
+use super::{Selector, error::EmptyPopulation};
 use crate::population::Population;
 
 #[derive(Debug)]

--- a/packages/ec-core/src/operator/selector/tournament.rs
+++ b/packages/ec-core/src/operator/selector/tournament.rs
@@ -117,7 +117,7 @@ mod tests {
     use super::Tournament;
     use crate::{
         individual::ec::EcIndividual,
-        operator::selector::{tournament::TournamentSizeError, Selector},
+        operator::selector::{Selector, tournament::TournamentSizeError},
     };
 
     #[test]

--- a/packages/ec-core/src/operator/selector/worst.rs
+++ b/packages/ec-core/src/operator/selector/worst.rs
@@ -1,6 +1,6 @@
 use rand::rngs::ThreadRng;
 
-use super::{error::EmptyPopulation, Selector};
+use super::{Selector, error::EmptyPopulation};
 use crate::population::Population;
 
 #[derive(Debug)]

--- a/packages/ec-core/src/population.rs
+++ b/packages/ec-core/src/population.rs
@@ -20,7 +20,7 @@ impl<I> Population for Vec<I> {
 mod tests {
     use core::ops::Range;
 
-    use rand::{prelude::Distribution, thread_rng, Rng};
+    use rand::{Rng, prelude::Distribution, thread_rng};
 
     use crate::{distributions::collection::ConvertToCollectionGenerator, population::Population};
 

--- a/packages/ec-core/src/weighted/weighted_pair.rs
+++ b/packages/ec-core/src/weighted/weighted_pair.rs
@@ -84,14 +84,14 @@ mod tests {
 
     use crate::{
         operator::selector::{
-            best::Best, random::Random, tournament::Tournament, worst::Worst, Selector,
+            Selector, best::Best, random::Random, tournament::Tournament, worst::Worst,
         },
         weighted::{
+            Weighted,
             error::{SelectionError, WeightSumOverflow, ZeroWeight},
             weighted_pair::WeightedPair,
             with_weight::WithWeight,
             with_weighted_item::WithWeightedItem,
-            Weighted,
         },
     };
 

--- a/packages/ec-core/src/weighted/with_weighted_item.rs
+++ b/packages/ec-core/src/weighted/with_weighted_item.rs
@@ -1,5 +1,5 @@
 use super::{
-    error::WeightSumOverflow, weighted_pair::WeightedPair, with_weight::WithWeight, Weighted,
+    Weighted, error::WeightSumOverflow, weighted_pair::WeightedPair, with_weight::WithWeight,
 };
 
 pub trait WithWeightedItem

--- a/packages/ec-linear/examples/count_ones/main.rs
+++ b/packages/ec-linear/examples/count_ones/main.rs
@@ -15,22 +15,22 @@ pub mod args;
 
 use std::ops::Not;
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::collection::ConvertToCollectionGenerator,
     generation::Generation,
     individual::{ec::WithScorer, scorer::FnScorer},
     operator::{
+        Composable,
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,
         mutator::Mutate,
         recombinator::Recombine,
         selector::{
-            best::Best, dyn_weighted::DynWeighted, lexicase::Lexicase, tournament::Tournament,
-            Select, Selector,
+            Select, Selector, best::Best, dyn_weighted::DynWeighted, lexicase::Lexicase,
+            tournament::Tournament,
         },
-        Composable,
     },
     test_results::{Score, TestResults},
 };

--- a/packages/ec-linear/examples/hiff/main.rs
+++ b/packages/ec-linear/examples/hiff/main.rs
@@ -11,22 +11,22 @@ pub mod args;
 
 use std::{iter::once, ops::Not};
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::collection::ConvertToCollectionGenerator,
     generation::Generation,
     individual::{ec::WithScorer, scorer::FnScorer},
     operator::{
+        Composable,
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,
         mutator::Mutate,
         recombinator::Recombine,
         selector::{
-            best::Best, dyn_weighted::DynWeighted, lexicase::Lexicase, tournament::Tournament,
-            Select, Selector,
+            Select, Selector, best::Best, dyn_weighted::DynWeighted, lexicase::Lexicase,
+            tournament::Tournament,
         },
-        Composable,
     },
     test_results::{Score, TestResults},
 };

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -5,7 +5,7 @@ use ec_core::{
     distributions::collection::{self, ConvertToCollectionGenerator},
     genome::Genome,
 };
-use rand::{distr::Standard, prelude::Distribution, rngs::ThreadRng, Rng};
+use rand::{Rng, distr::Standard, prelude::Distribution, rngs::ThreadRng};
 
 use super::Linear;
 use crate::recombinator::crossover::Crossover;

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -1,5 +1,5 @@
 use ec_core::{genome::Genome, operator::mutator::Mutator};
-use rand::{prelude::Distribution, rngs::ThreadRng, Rng};
+use rand::{Rng, prelude::Distribution, rngs::ThreadRng};
 
 use crate::genome::Linear;
 

--- a/packages/ec-linear/src/mutator/with_rate.rs
+++ b/packages/ec-linear/src/mutator/with_rate.rs
@@ -2,7 +2,7 @@ use std::ops::Not;
 
 use anyhow::Result;
 use ec_core::operator::mutator::Mutator;
-use rand::{rngs::ThreadRng, Rng};
+use rand::{Rng, rngs::ThreadRng};
 
 use crate::genome::Linear;
 

--- a/packages/ec-linear/src/recombinator/two_point_xo.rs
+++ b/packages/ec-linear/src/recombinator/two_point_xo.rs
@@ -1,6 +1,6 @@
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use ec_core::operator::recombinator::Recombinator;
-use rand::{rngs::ThreadRng, Rng};
+use rand::{Rng, rngs::ThreadRng};
 
 use super::crossover::Crossover;
 

--- a/packages/ec-linear/src/recombinator/uniform_xo.rs
+++ b/packages/ec-linear/src/recombinator/uniform_xo.rs
@@ -1,6 +1,6 @@
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use ec_core::operator::recombinator::Recombinator;
-use rand::{rngs::ThreadRng, Rng};
+use rand::{Rng, rngs::ThreadRng};
 
 use super::crossover::Crossover;
 

--- a/packages/push-macros/src/doctest_tokenstream.rs
+++ b/packages/push-macros/src/doctest_tokenstream.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, ToTokens};
+use quote::{ToTokens, quote};
 use syn::{LitStr, Token};
 
 #[derive(Debug, Clone)]

--- a/packages/push-macros/src/lib.rs
+++ b/packages/push-macros/src/lib.rs
@@ -2,7 +2,7 @@
 
 use push_state::printing::generate_builder::generate_builder;
 use quote::quote;
-use syn::{spanned::Spanned, DeriveInput};
+use syn::{DeriveInput, spanned::Spanned};
 
 use crate::push_state::{parsing::parse_fields, printing::derive_has_stack::derive_has_stack};
 

--- a/packages/push-macros/src/push_state/parsing/macro_args.rs
+++ b/packages/push-macros/src/push_state/parsing/macro_args.rs
@@ -1,5 +1,5 @@
 use quote::ToTokens;
-use syn::{parse::Parse, punctuated::Punctuated, Token};
+use syn::{Token, parse::Parse, punctuated::Punctuated};
 
 use super::FlagsValue;
 

--- a/packages/push-macros/src/push_state/parsing/mod.rs
+++ b/packages/push-macros/src/push_state/parsing/mod.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 
 use proc_macro2::Span;
 use syn::{
+    Field, Ident, Token, Type,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
-    Field, Ident, Token, Type,
 };
 
 use self::{macro_args::PushStateFlags, stack_attribute_args::StackMarkerFlags};

--- a/packages/push-macros/src/push_state/parsing/stack_attribute_args.rs
+++ b/packages/push-macros/src/push_state/parsing/stack_attribute_args.rs
@@ -1,11 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{
-    bracketed,
+    Expr, Ident, Path, Token, bracketed,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     spanned::Spanned,
-    Expr, Ident, Path, Token,
 };
 
 use super::spanned_value::SpannedValue;

--- a/packages/push-macros/src/push_state/printing/generate_builder.rs
+++ b/packages/push-macros/src/push_state/printing/generate_builder.rs
@@ -1,12 +1,12 @@
 use ident_case_conversions::CaseConversions;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{ext::IdentExt, Generics, Ident, Visibility};
+use syn::{Generics, Ident, Visibility, ext::IdentExt};
 
 use crate::{
-    doctest_tokenstream::{doctest, Import},
+    doctest_tokenstream::{Import, doctest},
     push_state::parsing::{
-        stack_attribute_args::StackMarkerFlags, ExecStackInput, InputInstructionsInput, StacksInput,
+        ExecStackInput, InputInstructionsInput, StacksInput, stack_attribute_args::StackMarkerFlags,
     },
 };
 

--- a/packages/push/benches/regression-evaluation.rs
+++ b/packages/push/benches/regression-evaluation.rs
@@ -11,12 +11,12 @@
     //           for test code."
 )]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use ordered_float::OrderedFloat;
 use push::{
     genome::plushy::{Plushy, PushGene},
     instruction::{FloatInstruction, PushInstruction},
-    push_vm::{program::PushProgram, push_state::PushState, HasStack, State},
+    push_vm::{HasStack, State, program::PushProgram, push_state::PushState},
     vec_into,
 };
 

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -11,18 +11,18 @@ pub mod args;
 
 use std::ops::Not;
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::collection::ConvertToCollectionGenerator,
     generation::Generation,
     individual::{ec::WithScorer, scorer::FnScorer},
     operator::{
+        Composable,
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,
         mutator::Mutate,
-        selector::{best::Best, lexicase::Lexicase, Select, Selector},
-        Composable,
+        selector::{Select, Selector, best::Best, lexicase::Lexicase},
     },
     test_results::{self, TestResults},
     uniform_distribution_of,
@@ -33,8 +33,8 @@ use ordered_float::OrderedFloat;
 use push::{
     evaluation::{Case, Cases, WithTargetFn},
     genome::plushy::{ConvertToGeneGenerator, Plushy},
-    instruction::{variable_name::VariableName, FloatInstruction, PushInstruction},
-    push_vm::{program::PushProgram, push_state::PushState, HasStack, State},
+    instruction::{FloatInstruction, PushInstruction, variable_name::VariableName},
+    push_vm::{HasStack, State, program::PushProgram, push_state::PushState},
 };
 use rand::{prelude::Distribution, thread_rng};
 

--- a/packages/push/examples/median/main.rs
+++ b/packages/push/examples/median/main.rs
@@ -2,18 +2,18 @@ pub mod args;
 
 use std::ops::Not;
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::{collection::ConvertToCollectionGenerator, conversion::IntoDistribution},
     generation::Generation,
     individual::{ec::WithScorer, scorer::FnScorer},
     operator::{
+        Composable,
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,
         mutator::Mutate,
-        selector::{best::Best, lexicase::Lexicase, Select, Selector},
-        Composable,
+        selector::{Select, Selector, best::Best, lexicase::Lexicase},
     },
     test_results::{self, TestResults},
 };
@@ -22,14 +22,15 @@ use push::{
     evaluation::{Case, Cases, WithTargetFn},
     genome::plushy::{GeneGenerator, Plushy},
     instruction::{
-        variable_name::VariableName, BoolInstruction, ExecInstruction, IntInstruction,
-        PushInstruction,
+        BoolInstruction, ExecInstruction, IntInstruction, PushInstruction,
+        variable_name::VariableName,
     },
-    push_vm::{program::PushProgram, push_state::PushState, stack::StackError, HasStack, State},
+    push_vm::{HasStack, State, program::PushProgram, push_state::PushState, stack::StackError},
 };
 use rand::{
+    Rng,
     distr::{Distribution, Uniform},
-    thread_rng, Rng,
+    thread_rng,
 };
 use strum::IntoEnumIterator;
 

--- a/packages/push/examples/simple_regression/main.rs
+++ b/packages/push/examples/simple_regression/main.rs
@@ -11,21 +11,21 @@ pub mod args;
 
 use std::ops::Not;
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::collection::ConvertToCollectionGenerator,
     generation::Generation,
     individual::{ec::WithScorer, scorer::FnScorer},
     operator::{
+        Composable,
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,
         mutator::Mutate,
         selector::{
-            best::Best, dyn_weighted::DynWeighted, lexicase::Lexicase, tournament::Tournament,
-            Select, Selector,
+            Select, Selector, best::Best, dyn_weighted::DynWeighted, lexicase::Lexicase,
+            tournament::Tournament,
         },
-        Composable,
     },
     test_results::{self, TestResults},
     uniform_distribution_of,
@@ -36,8 +36,8 @@ use ordered_float::OrderedFloat;
 use push::{
     evaluation::{Case, Cases, WithTargetFn},
     genome::plushy::{ConvertToGeneGenerator, Plushy},
-    instruction::{variable_name::VariableName, FloatInstruction, PushInstruction},
-    push_vm::{program::PushProgram, push_state::PushState, HasStack, State},
+    instruction::{FloatInstruction, PushInstruction, variable_name::VariableName},
+    push_vm::{HasStack, State, program::PushProgram, push_state::PushState},
 };
 use rand::{distr::Distribution, thread_rng};
 

--- a/packages/push/examples/smallest/main.rs
+++ b/packages/push/examples/smallest/main.rs
@@ -2,18 +2,18 @@ pub mod args;
 
 use std::ops::Not;
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::{collection::ConvertToCollectionGenerator, conversion::IntoDistribution},
     generation::Generation,
     individual::{ec::WithScorer, scorer::FnScorer},
     operator::{
+        Composable,
         genome_extractor::GenomeExtractor,
         genome_scorer::GenomeScorer,
         mutator::Mutate,
-        selector::{best::Best, lexicase::Lexicase, Select, Selector},
-        Composable,
+        selector::{Select, Selector, best::Best, lexicase::Lexicase},
     },
     test_results::{self, TestResults},
 };
@@ -22,10 +22,10 @@ use push::{
     evaluation::{Case, Cases, WithTargetFn},
     genome::plushy::{GeneGenerator, Plushy},
     instruction::{
-        variable_name::VariableName, BoolInstruction, ExecInstruction, IntInstruction,
-        PushInstruction,
+        BoolInstruction, ExecInstruction, IntInstruction, PushInstruction,
+        variable_name::VariableName,
     },
-    push_vm::{program::PushProgram, push_state::PushState, stack::StackError, HasStack, State},
+    push_vm::{HasStack, State, program::PushProgram, push_state::PushState, stack::StackError},
 };
 use rand::{
     distr::{Distribution, Uniform},

--- a/packages/push/src/genome/plushy.rs
+++ b/packages/push/src/genome/plushy.rs
@@ -6,7 +6,7 @@ use ec_core::{
     genome::Genome,
 };
 use ec_linear::genome::Linear;
-use rand::{prelude::Distribution, Rng};
+use rand::{Rng, prelude::Distribution};
 
 use crate::instruction::{NumOpens, PushInstruction};
 
@@ -263,7 +263,7 @@ mod test {
 
     use super::*;
     use crate::{
-        instruction::{variable_name::VariableName, BoolInstruction, IntInstruction},
+        instruction::{BoolInstruction, IntInstruction, variable_name::VariableName},
         list_into::vec_into,
     };
 

--- a/packages/push/src/instruction/exec/dup_block.rs
+++ b/packages/push/src/instruction/exec/dup_block.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::InstructionResult,
-    instruction::{instruction_error::PushInstructionError, Instruction, NumOpens},
-    push_vm::{program::PushProgram, stack::PushOnto, HasStack},
+    instruction::{Instruction, NumOpens, instruction_error::PushInstructionError},
+    push_vm::{HasStack, program::PushProgram, stack::PushOnto},
 };
 
 /// An instruction that duplicates (clones) the top

--- a/packages/push/src/instruction/exec/ifelse.rs
+++ b/packages/push/src/instruction/exec/ifelse.rs
@@ -1,11 +1,11 @@
 use super::when::When;
 use crate::{
     error::{Error, InstructionResult},
-    instruction::{instruction_error::PushInstructionError, Instruction, NumOpens},
+    instruction::{Instruction, NumOpens, instruction_error::PushInstructionError},
     push_vm::{
+        HasStack,
         program::PushProgram,
         stack::{StackDiscard, StackError, StackPush},
-        HasStack,
     },
 };
 
@@ -163,7 +163,7 @@ mod tests {
     use crate::{
         error::into_state::IntoState,
         instruction::{
-            instruction_error::PushInstructionError, ExecInstruction, Instruction, IntInstruction,
+            ExecInstruction, Instruction, IntInstruction, instruction_error::PushInstructionError,
         },
         list_into::arr_into,
         push_vm::{program::PushProgram, push_state::PushState, stack::StackError},

--- a/packages/push/src/instruction/exec/mod.rs
+++ b/packages/push/src/instruction/exec/mod.rs
@@ -7,10 +7,10 @@ mod when;
 use strum_macros::EnumIter;
 
 use self::{dup_block::DupBlock, ifelse::IfElse, noop::Noop, unless::Unless, when::When};
-use super::{instruction_error::PushInstructionError, Instruction, NumOpens, PushInstruction};
+use super::{Instruction, NumOpens, PushInstruction, instruction_error::PushInstructionError};
 use crate::{
     error::InstructionResult,
-    push_vm::{program::PushProgram, HasStack},
+    push_vm::{HasStack, program::PushProgram},
 };
 
 #[derive(Debug, strum_macros::Display, Copy, Clone, Eq, PartialEq, EnumIter)]

--- a/packages/push/src/instruction/exec/noop.rs
+++ b/packages/push/src/instruction/exec/noop.rs
@@ -1,4 +1,4 @@
-use crate::instruction::{instruction_error::PushInstructionError, Instruction, NumOpens};
+use crate::instruction::{Instruction, NumOpens, instruction_error::PushInstructionError};
 
 /// A "no-op" instruction that does nothing, i.e., always
 /// runs successfully and makes no changes to the stacks.

--- a/packages/push/src/instruction/exec/unless.rs
+++ b/packages/push/src/instruction/exec/unless.rs
@@ -1,10 +1,10 @@
 use crate::{
     error::{Error, InstructionResult},
-    instruction::{instruction_error::PushInstructionError, Instruction, NumOpens},
+    instruction::{Instruction, NumOpens, instruction_error::PushInstructionError},
     push_vm::{
+        HasStack,
         program::PushProgram,
         stack::{StackDiscard, StackError},
-        HasStack,
     },
 };
 

--- a/packages/push/src/instruction/exec/when.rs
+++ b/packages/push/src/instruction/exec/when.rs
@@ -1,10 +1,10 @@
 use crate::{
     error::{Error, InstructionResult},
-    instruction::{instruction_error::PushInstructionError, Instruction, NumOpens},
+    instruction::{Instruction, NumOpens, instruction_error::PushInstructionError},
     push_vm::{
+        HasStack,
         program::PushProgram,
         stack::{StackDiscard, StackError},
-        HasStack,
     },
 };
 

--- a/packages/push/src/instruction/float.rs
+++ b/packages/push/src/instruction/float.rs
@@ -5,8 +5,8 @@ use super::{Instruction, PushInstruction, PushInstructionError};
 use crate::{
     error::{Error, InstructionResult, MapInstructionError},
     push_vm::{
-        stack::{PushOnto, Stack, StackDiscard, StackError},
         HasStack,
+        stack::{PushOnto, Stack, StackDiscard, StackError},
     },
 };
 
@@ -79,12 +79,9 @@ where
 
             Self::Dup => {
                 if state.stack::<OrderedFloat<f64>>().is_full() {
-                    return Err(Error::fatal(
-                        state,
-                        StackError::Overflow {
-                            stack_type: "float",
-                        },
-                    ));
+                    return Err(Error::fatal(state, StackError::Overflow {
+                        stack_type: "float",
+                    }));
                 }
                 let float_stack: &mut Stack<OrderedFloat<f64>> =
                     state.stack_mut::<OrderedFloat<f64>>();
@@ -122,10 +119,9 @@ impl FloatInstruction {
         S: Clone + HasStack<OrderedFloat<f64>> + HasStack<bool>,
     {
         if state.stack::<bool>().is_full() {
-            return Err(Error::fatal(
-                state,
-                StackError::Overflow { stack_type: "bool" },
-            ));
+            return Err(Error::fatal(state, StackError::Overflow {
+                stack_type: "bool",
+            }));
         }
         let float_stack: &mut Stack<OrderedFloat<f64>> = state.stack_mut::<OrderedFloat<f64>>();
         float_stack

--- a/packages/push/src/instruction/int/abs.rs
+++ b/packages/push/src/instruction/int/abs.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::InstructionResult,
-    instruction::{instruction_error::PushInstructionError, Instruction},
-    push_vm::{stack::PushOnto, HasStack},
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{HasStack, stack::PushOnto},
 };
 
 /// An instruction that takes the absolute value of the top
@@ -106,7 +106,7 @@ mod tests {
     use super::Abs;
     use crate::{
         instruction::Instruction,
-        push_vm::{push_state::PushState, HasStack},
+        push_vm::{HasStack, push_state::PushState},
     };
 
     // We need to make sure `Abs` properly handles the

--- a/packages/push/src/instruction/int/mod.rs
+++ b/packages/push/src/instruction/int/mod.rs
@@ -242,10 +242,9 @@ where
                 // the instruction, we need to check for the case that the boolean stack is
                 // already full, and return an `Overflow` error if it is.
                 if state.stack::<bool>().is_full() {
-                    return Err(Error::fatal(
-                        state,
-                        StackError::Overflow { stack_type: "bool" },
-                    ));
+                    return Err(Error::fatal(state, StackError::Overflow {
+                        stack_type: "bool",
+                    }));
                 }
                 let int_stack: &mut Stack<i64> = state.stack_mut::<i64>();
                 match self {

--- a/packages/push/src/instruction/int/negate.rs
+++ b/packages/push/src/instruction/int/negate.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::InstructionResult,
     instruction::{Instruction, PushInstructionError},
-    push_vm::{stack::PushOnto, HasStack},
+    push_vm::{HasStack, stack::PushOnto},
 };
 
 /// An instruction that negates the top
@@ -106,7 +106,7 @@ mod tests {
     use super::Negate;
     use crate::{
         instruction::Instruction,
-        push_vm::{push_state::PushState, HasStack},
+        push_vm::{HasStack, push_state::PushState},
     };
 
     // We need to make sure `Negate` properly handles the

--- a/packages/push/src/push_vm/mod.rs
+++ b/packages/push/src/push_vm/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{stateful::FatalError, InstructionResult},
+    error::{InstructionResult, stateful::FatalError},
     instruction::Instruction,
 };
 

--- a/packages/push/src/push_vm/program.rs
+++ b/packages/push/src/push_vm/program.rs
@@ -1,9 +1,9 @@
-use super::{push_state::PushState, stack::StackError, HasStack};
+use super::{HasStack, push_state::PushState, stack::StackError};
 use crate::{
     error::{Error, InstructionResult},
     genome::plushy::{Plushy, PushGene},
     instruction::{
-        instruction_error::PushInstructionError, Instruction, NumOpens, PushInstruction,
+        Instruction, NumOpens, PushInstruction, instruction_error::PushInstructionError,
     },
 };
 
@@ -113,7 +113,7 @@ mod test {
             BoolInstruction, ExecInstruction, FloatInstruction, Instruction, IntInstruction,
         },
         list_into::{arr_into, vec_into},
-        push_vm::{push_state::PushState, HasStack},
+        push_vm::{HasStack, push_state::PushState},
     };
 
     #[test]
@@ -131,18 +131,15 @@ mod test {
         // [Instruction(Int-Add), Instruction(Exec-IfElse),
         // Block([Instruction(Int-Multiply)]), Block([Instruction(Exec-Dup),
         // Block([Instruction(Int-Subtract)])])]
-        assert_eq!(
-            program,
-            vec_into![
-                IntInstruction::Add,
-                ExecInstruction::if_else(),
-                PushProgram::Block(vec_into![IntInstruction::Multiply]),
-                PushProgram::Block(vec_into![
-                    ExecInstruction::dup_block(),
-                    PushProgram::Block(vec_into![IntInstruction::Subtract])
-                ])
-            ]
-        );
+        assert_eq!(program, vec_into![
+            IntInstruction::Add,
+            ExecInstruction::if_else(),
+            PushProgram::Block(vec_into![IntInstruction::Multiply]),
+            PushProgram::Block(vec_into![
+                ExecInstruction::dup_block(),
+                PushProgram::Block(vec_into![IntInstruction::Subtract])
+            ])
+        ]);
     }
 
     #[test]

--- a/packages/push/src/push_vm/push_state.rs
+++ b/packages/push/src/push_vm/push_state.rs
@@ -3,12 +3,12 @@ use std::collections::HashMap;
 pub use ordered_float::OrderedFloat;
 
 use crate::{
-    error::{stateful::FatalError, try_recover::TryRecover, InstructionResult},
+    error::{InstructionResult, stateful::FatalError, try_recover::TryRecover},
     instruction::{
-        instruction_error::PushInstructionError, variable_name::VariableName, Instruction,
-        PushInstruction,
+        Instruction, PushInstruction, instruction_error::PushInstructionError,
+        variable_name::VariableName,
     },
-    push_vm::{program::PushProgram, stack::Stack, State},
+    push_vm::{State, program::PushProgram, stack::Stack},
 };
 
 // TODO: It might make sense to separate out the specification of
@@ -126,8 +126,8 @@ mod simple_check {
     use crate::{
         genome::plushy::{Plushy, PushGene},
         instruction::{
-            variable_name::VariableName, BoolInstruction, FloatInstruction, IntInstruction,
-            PushInstruction,
+            BoolInstruction, FloatInstruction, IntInstruction, PushInstruction,
+            variable_name::VariableName,
         },
         list_into::vec_into,
         push_vm::{program::PushProgram, push_state::PushState},

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -411,10 +411,10 @@ impl<T> Stack<T> {
     {
         let iter = iter.into_iter();
         // Check that adding these items won't overflow the stack.
-        if !iter
+        if iter
             .len()
             .checked_add(self.size())
-            .is_some_and(|x| x <= self.max_stack_size)
+            .is_none_or(|x| x > self.max_stack_size)
         {
             return Err(StackError::Overflow {
                 stack_type: std::any::type_name::<T>(),

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -22,13 +22,10 @@ pub trait HasStack<T> {
         Self: Sized,
     {
         if self.stack::<U>().is_full() {
-            Err(Error::fatal(
-                self,
-                StackError::Overflow {
-                    // TODO: Should make sure to overflow a stack so we know what this looks like.
-                    stack_type: std::any::type_name::<T>(),
-                },
-            ))
+            Err(Error::fatal(self, StackError::Overflow {
+                // TODO: Should make sure to overflow a stack so we know what this looks like.
+                stack_type: std::any::type_name::<T>(),
+            }))
         } else {
             Ok(self)
         }
@@ -564,12 +561,9 @@ mod test {
     fn top_from_empty_fails() {
         let stack: Stack<bool> = Stack::default();
         let result = stack.top().unwrap_err();
-        assert_eq!(
-            result,
-            StackError::Underflow {
-                num_requested: 1,
-                num_present: 0
-            }
-        );
+        assert_eq!(result, StackError::Underflow {
+            num_requested: 1,
+            num_present: 0
+        });
     }
 }

--- a/packages/push/tests/float.rs
+++ b/packages/push/tests/float.rs
@@ -16,7 +16,7 @@ use ordered_float::OrderedFloat;
 use proptest::prop_assert_eq;
 use push::{
     instruction::{FloatInstruction, Instruction, PushInstruction},
-    push_vm::{push_state::PushState, stack::StackError, HasStack},
+    push_vm::{HasStack, push_state::PushState, stack::StackError},
 };
 use test_strategy::proptest;
 

--- a/packages/push/tests/int.rs
+++ b/packages/push/tests/int.rs
@@ -10,9 +10,9 @@
 use proptest::prop_assert_eq;
 use push::{
     instruction::{
-        instruction_error::PushInstructionError, Instruction, IntInstruction, IntInstructionError,
+        Instruction, IntInstruction, IntInstructionError, instruction_error::PushInstructionError,
     },
-    push_vm::{push_state::PushState, HasStack},
+    push_vm::{HasStack, push_state::PushState},
 };
 use strum::IntoEnumIterator;
 use test_strategy::proptest;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,7 @@
+style_edition="2024"
 unstable_features=true
 wrap_comments=true
 format_code_in_doc_comments=true
 format_strings=true
 imports_granularity="Crate"
 group_imports="StdExternalCrate"
-version="Two"


### PR DESCRIPTION
This applies the changes done in rustfmt for rust 1.81, which is currently incompatible with stable (till the 17th of November), and should be merged after that.

Also, this is based on #276 