### PR TITLE
Rename `num-generations` to `max-generations`, and `Args` to `CliArgs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,36 +100,18 @@ default = [
 
 [workspace.metadata.example_runner.templates]
 balanced.arguments = [
-  "--num-generations",
+  "--max-generations",
   "10",
   "--population-size",
   "200"
 ]
 big_population.arguments = [
-  "--num-generations",
+  "--max-generations",
   "1",
   "--population-size",
   "2000"
 ]
 many_generations.arguments = [
-  "--num-generations",
-  "200",
-  "--population-size",
-  "10"
-]
-balanced_v2.arguments = [
-  "--max-generations",
-  "10",
-  "--population-size",
-  "200"
-]
-big_population_v2.arguments = [
-  "--max-generations",
-  "1",
-  "--population-size",
-  "2000"
-]
-many_generations_v2.arguments = [
   "--max-generations",
   "200",
   "--population-size",

--- a/packages/ec-linear/examples/count_ones/args.rs
+++ b/packages/ec-linear/examples/count_ones/args.rs
@@ -9,7 +9,7 @@ pub enum RunModel {
 /// Simple genetic algorithm in Rust
 #[derive(Parser, Debug, Copy, Clone)]
 #[clap(author, version, about, long_about = None)]
-pub struct Args {
+pub struct CliArgs {
     /// Should we use parallelism when doing the run?
     #[clap(short, long, value_enum, default_value_t = RunModel::Parallel)]
     pub run_model: RunModel,
@@ -23,6 +23,6 @@ pub struct Args {
     pub bit_length: usize,
 
     /// Number of generations to run
-    #[clap(short, long, value_parser, default_value_t = 100)]
-    pub num_generations: usize,
+    #[clap(short = 'g', long, value_parser, default_value_t = 100)]
+    pub max_generations: usize,
 }

--- a/packages/ec-linear/examples/count_ones/main.rs
+++ b/packages/ec-linear/examples/count_ones/main.rs
@@ -43,7 +43,7 @@ use rand::{
     thread_rng,
 };
 
-use crate::args::{Args, RunModel};
+use crate::args::{CliArgs, RunModel};
 
 #[must_use]
 pub fn count_ones(bits: &[bool]) -> TestResults<Score<i64>> {
@@ -51,12 +51,12 @@ pub fn count_ones(bits: &[bool]) -> TestResults<Score<i64>> {
 }
 
 fn main() -> Result<()> {
-    let Args {
+    let CliArgs {
         run_model,
         population_size,
         bit_length,
-        num_generations,
-    } = Args::parse();
+        max_generations,
+    } = CliArgs::parse();
 
     let mut rng = thread_rng();
 
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
     // TODO: It might be useful to insert some kind of logging system so we can
     //   make this less imperative in nature.
 
-    for generation_number in 0..num_generations {
+    for generation_number in 0..max_generations {
         match run_model {
             RunModel::Serial => generation.serial_next()?,
             RunModel::Parallel => generation.par_next()?,
@@ -108,7 +108,7 @@ fn main() -> Result<()> {
 
         let best = Best.select(generation.population(), &mut rng)?;
         // TODO: Change 2 to be the smallest number of digits needed for
-        //  num_generations-1.
+        //  max_generations-1.
         println!("Generation {generation_number:2} best is {best}");
     }
 

--- a/packages/ec-linear/examples/hiff/args.rs
+++ b/packages/ec-linear/examples/hiff/args.rs
@@ -9,7 +9,7 @@ pub enum RunModel {
 /// Simple genetic algorithm in Rust
 #[derive(Parser, Debug, Copy, Clone)]
 #[clap(author, version, about, long_about = None)]
-pub struct Args {
+pub struct CliArgs {
     /// Should we use parallelism when doing the run?
     #[clap(short, long, value_enum, default_value_t = RunModel::Parallel)]
     pub run_model: RunModel,
@@ -23,6 +23,6 @@ pub struct Args {
     pub bit_length: usize,
 
     /// Number of generations to run
-    #[clap(short, long, value_parser, default_value_t = 100)]
-    pub num_generations: usize,
+    #[clap(short = 'g', long, value_parser, default_value_t = 100)]
+    pub max_generations: usize,
 }

--- a/packages/ec-linear/examples/hiff/main.rs
+++ b/packages/ec-linear/examples/hiff/main.rs
@@ -36,7 +36,7 @@ use ec_linear::{
 };
 use rand::{distr::Standard, prelude::Distribution, thread_rng};
 
-use crate::args::{Args, RunModel};
+use crate::args::{CliArgs, RunModel};
 
 #[must_use]
 fn hiff(bits: &[bool]) -> (bool, TestResults<Score<usize>>) {
@@ -64,12 +64,12 @@ fn hiff(bits: &[bool]) -> (bool, TestResults<Score<usize>>) {
 }
 
 fn main() -> Result<()> {
-    let Args {
+    let CliArgs {
         run_model,
         population_size,
         bit_length,
-        num_generations,
-    } = Args::parse();
+        max_generations,
+    } = CliArgs::parse();
 
     let mut rng = thread_rng();
 
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
     // TODO: It might be useful to insert some kind of logging system so we can
     //   make this less imperative in nature.
 
-    for generation_number in 0..num_generations {
+    for generation_number in 0..max_generations {
         match run_model {
             RunModel::Serial => generation.serial_next()?,
             RunModel::Parallel => generation.par_next()?,
@@ -120,7 +120,7 @@ fn main() -> Result<()> {
         let best = Best.select(generation.population(), &mut rng)?;
 
         // TODO: Change 2 to be the smallest number of digits needed for
-        //  num_generations-1.
+        //  max_generations-1.
         println!("Generation {generation_number:2} best is {best}");
     }
 

--- a/packages/push/Cargo.toml
+++ b/packages/push/Cargo.toml
@@ -47,18 +47,6 @@ macros = ["dep:push_macros"]
 [lints]
 workspace = true
 
-[package.metadata.example_runner.examples]
-median = [
-  { template = "balanced_v2" },
-  { template = "big_population_v2" },
-  { template = "many_generations_v2" }
-]
-smallest = [
-  { template = "balanced_v2" },
-  { template = "big_population_v2" },
-  { template = "many_generations_v2" }
-]
-
 [[bench]]
 name = "regression-evaluation"
 harness = false

--- a/packages/push/examples/complex_regression/args.rs
+++ b/packages/push/examples/complex_regression/args.rs
@@ -9,7 +9,7 @@ pub enum RunModel {
 /// Simple genetic algorithm in Rust
 #[derive(Parser, Debug, Copy, Clone)]
 #[clap(author, version, about, long_about = None)]
-pub struct Args {
+pub struct CliArgs {
     /// Should we use parallelism when doing the run?
     #[clap(short, long, value_enum, default_value_t = RunModel::Parallel)]
     pub run_model: RunModel,
@@ -27,6 +27,6 @@ pub struct Args {
     pub max_genome_length: usize,
 
     /// Number of generations to run
-    #[clap(short, long, value_parser, default_value_t = 100)]
-    pub num_generations: usize,
+    #[clap(short = 'g', long, value_parser, default_value_t = 100)]
+    pub max_generations: usize,
 }

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -38,7 +38,7 @@ use push::{
 };
 use rand::{prelude::Distribution, thread_rng};
 
-use crate::args::{Args, RunModel};
+use crate::args::{CliArgs, RunModel};
 
 /*
  * This is an implementation of the "complex regression" problem from the
@@ -112,13 +112,13 @@ fn score_genome(
 
 fn main() -> Result<()> {
     // FIXME: Respect the max_genome_length input
-    let Args {
+    let CliArgs {
         run_model,
         population_size,
         max_initial_instructions,
-        num_generations,
+        max_generations,
         ..
-    } = Args::parse();
+    } = CliArgs::parse();
 
     let mut rng = thread_rng();
 
@@ -181,7 +181,7 @@ fn main() -> Result<()> {
     // TODO: It might be useful to insert some kind of logging system so we can
     // make this less imperative in nature.
 
-    for generation_number in 0..num_generations {
+    for generation_number in 0..max_generations {
         match run_model {
             RunModel::Serial => generation.serial_next()?,
             RunModel::Parallel => generation.par_next()?,
@@ -189,7 +189,7 @@ fn main() -> Result<()> {
 
         let best = Best.select(generation.population(), &mut rng)?;
         // TODO: Change 2 to be the smallest number of digits needed for
-        // num_generations-1.
+        // max_generations-1.
         println!("Generation {generation_number:2} best is {best}");
 
         if best.test_results.total_result.error == OrderedFloat(0.0) {

--- a/packages/push/examples/simple_regression/args.rs
+++ b/packages/push/examples/simple_regression/args.rs
@@ -9,7 +9,7 @@ pub enum RunModel {
 /// Simple genetic algorithm in Rust
 #[derive(Parser, Debug, Copy, Clone)]
 #[clap(author, version, about, long_about = None)]
-pub struct Args {
+pub struct CliArgs {
     /// Should we use parallelism when doing the run?
     #[clap(short, long, value_enum, default_value_t = RunModel::Parallel)]
     pub run_model: RunModel,
@@ -27,6 +27,6 @@ pub struct Args {
     pub max_genome_length: usize,
 
     /// Number of generations to run
-    #[clap(short, long, value_parser, default_value_t = 100)]
-    pub num_generations: usize,
+    #[clap(short = 'g', long, value_parser, default_value_t = 100)]
+    pub max_generations: usize,
 }

--- a/packages/push/examples/simple_regression/main.rs
+++ b/packages/push/examples/simple_regression/main.rs
@@ -41,7 +41,7 @@ use push::{
 };
 use rand::{distr::Distribution, thread_rng};
 
-use crate::args::{Args, RunModel};
+use crate::args::{CliArgs, RunModel};
 
 /*
 * This is an implementation of the "simple regression" problem from the
@@ -115,13 +115,13 @@ fn score_genome(
 
 fn main() -> Result<()> {
     // FIXME: Respect the max_genome_length input
-    let Args {
+    let CliArgs {
         run_model,
         population_size,
         max_initial_instructions,
-        num_generations,
+        max_generations,
         ..
-    } = Args::parse();
+    } = CliArgs::parse();
 
     let mut rng = thread_rng();
 
@@ -179,7 +179,7 @@ fn main() -> Result<()> {
     // TODO: It might be useful to insert some kind of logging system so we can
     // make this less imperative in nature.
 
-    for generation_number in 0..num_generations {
+    for generation_number in 0..max_generations {
         match run_model {
             RunModel::Serial => generation.serial_next()?,
             RunModel::Parallel => generation.par_next()?,
@@ -187,7 +187,7 @@ fn main() -> Result<()> {
 
         let best = Best.select(generation.population(), &mut rng)?;
         // TODO: Change 2 to be the smallest number of digits needed for
-        // num_generations-1.
+        // max_generations-1.
         println!("Generation {generation_number:2} best is {best}\n");
 
         if best.test_results.total_result.error == OrderedFloat(0.0) {


### PR DESCRIPTION
This renames `num_generations` to `max_generations` in all the `clap` configurations, and adds `-g` as the short form for everyone.

This also renames `Args` to `CliArgs` in all the examples and updates the CI configuration so we just have a single configuration set.

Closes #189 
Closes #190 