### PR TITLE
Migrate away from anyhow Errors and to custom error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,6 @@ checksum = "72852736692ec862655eca398c9bb1b476161b563c9f80f45f4808b9629750d6"
 name = "ec-core"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "criterion",
  "itertools 0.13.0",
  "macro_railroad_annotation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
@@ -34,9 +34,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,63 +49,63 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -125,9 +125,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "better_any"
@@ -166,9 +166,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
@@ -177,16 +177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
-name = "cc"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
 
 [[package]]
 name = "cfg-if"
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -245,21 +245,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "collectable"
@@ -269,9 +269,9 @@ checksum = "08abddbaad209601e53c7dd4308d8c04c06f17bb7df006434e586a22b83be45a"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "criterion"
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -342,9 +342,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "easy-cast"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10936778145f3bea71fd9bf61332cce28c28e96a380714f7ab34838b80733fd6"
+checksum = "72852736692ec862655eca398c9bb1b476161b563c9f80f45f4808b9629750d6"
 
 [[package]]
 name = "ec-core"
@@ -356,8 +356,9 @@ dependencies = [
  "macro_railroad_annotation",
  "miette",
  "num-traits",
+ "polonius-the-crab",
  "proptest",
- "rand 0.9.0-alpha.2",
+ "rand 0.9.0-beta.1",
  "rayon",
  "test-strategy",
  "thiserror",
@@ -370,15 +371,17 @@ dependencies = [
  "anyhow",
  "clap",
  "ec-core",
+ "miette",
  "num-traits",
- "rand 0.9.0-alpha.2",
+ "rand 0.9.0-beta.1",
+ "thiserror",
 ]
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "embed-doc-image"
@@ -394,19 +397,19 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fnv"
@@ -422,14 +425,29 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a78f88e84d239c7f2619ae8b091603c26208e1cb322571f5a29d6806f56ee5e"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "rustix",
+ "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
+ "windows-targets",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "half"
@@ -455,15 +473,18 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
-name = "htmlescape"
-version = "0.3.1"
+name = "higher-kinded-types"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+checksum = "561985554c8b8d4808605c90a5f1979cc6c31a5d20b78465cd59501233c6678e"
+dependencies = [
+ "never-say-never",
+]
 
 [[package]]
 name = "ident_case_conversions"
@@ -473,14 +494,14 @@ checksum = "6adcc45088fbcbe7963bdca7bda19ab4214ffd794c6ef88813a3cb983ba7d881"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -495,9 +516,9 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -528,73 +549,74 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "macro_railroad"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f265a449ea0f49d18453db0daa0f81d6859ffa5f92f6788ee4d9653532fc67c"
+checksum = "1745158e5e753b78fdcbccc054dba9aeb6a8a0db7347d5c83689b2be8d6cbb21"
 dependencies = [
  "proc-macro2",
  "railroad",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "macro_railroad_annotation"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7057808dda4762c0f93a7bbc654deac7be3975490e1815ba93fd5d0f5320066"
+checksum = "c2c7f1192765ac5527d99eca4b6c3b0964662282b848a8693c240e2b585dd9b7"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "macro_railroad",
  "manyhow",
  "proc-macro2",
  "quote",
  "rand 0.8.5",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -606,7 +628,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -622,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miette"
@@ -654,17 +676,23 @@ checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
+
+[[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
 name = "num-traits"
@@ -678,24 +706,24 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "ordered-float"
@@ -709,15 +737,15 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "plotters"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -728,33 +756,46 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
+name = "polonius-the-crab"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "e97ca2c89572ae41bbec1c99498251f87dd5a94e500c5ec19c382dd593dd5ce9"
+dependencies = [
+ "higher-kinded-types",
+ "never-say-never",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy 0.7.35",
+]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -767,7 +808,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -827,7 +868,7 @@ dependencies = [
  "ordered-float",
  "proptest",
  "push_macros",
- "rand 0.9.0-alpha.2",
+ "rand 0.9.0-beta.1",
  "strum",
  "strum_macros",
  "test-case",
@@ -847,7 +888,7 @@ dependencies = [
  "proc-macro-assertions",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -858,20 +899,19 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "railroad"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fedaa01e5a17f30fbae3b16b5c28a0a396a15b74fcd9d24c11dc3d1634c823"
+checksum = "0ecedffc46c1b2cb04f4b80e094eae6b3f3f470a9635f1f396dd5206428f6b58"
 dependencies = [
- "htmlescape",
  "unicode-width",
 ]
 
@@ -888,13 +928,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0-alpha.2"
+version = "0.9.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e256ff62cee3e03def855c4d4260106d2bb1696fdc01af03e9935b993720a5"
+checksum = "c8478de76992f2825a1052cc2ae9d1401cdb62687761d4100ddd69a73dc3dc48"
 dependencies = [
- "rand_chacha 0.9.0-alpha.2",
- "rand_core 0.9.0-alpha.2",
- "zerocopy",
+ "rand_chacha 0.9.0-beta.1",
+ "rand_core 0.9.0-beta.1",
+ "zerocopy 0.8.13",
 ]
 
 [[package]]
@@ -909,12 +949,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.9.0-alpha.2"
+version = "0.9.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d299e9db34f6623b2a9e86c015d6e173d5f46d64d4b9b8cc46ae8a982a50b04c"
+checksum = "f16da77124f4ee9fabd55ce6540866e9101431863b4876de58b68797f331adf2"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0-alpha.2",
+ "rand_core 0.9.0-beta.1",
 ]
 
 [[package]]
@@ -923,17 +963,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.0-alpha.2"
+version = "0.9.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e93f5a5e3c528cda9acb0928c31b2ba868c551cc46e67b778075e34aab9906"
+checksum = "a98fa0b8309344136abe6244130311e76997e546f76fae8054422a7539b43df7"
 dependencies = [
- "getrandom",
- "zerocopy",
+ "getrandom 0.3.0-rc.0",
+ "zerocopy 0.8.13",
 ]
 
 [[package]]
@@ -967,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -979,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -990,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
@@ -1002,15 +1042,15 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1055,36 +1095,37 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1110,7 +1151,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1121,42 +1162,42 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "supports-color"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
  "is_ci",
 ]
 
 [[package]]
 name = "supports-hyperlinks"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
+checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
 
 [[package]]
 name = "supports-unicode"
@@ -1177,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1188,14 +1229,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1226,7 +1268,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1237,7 +1279,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "test-case-core",
 ]
 
@@ -1250,7 +1292,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1280,7 +1322,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1301,9 +1343,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1313,15 +1355,15 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"
@@ -1349,35 +1391,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1385,28 +1436,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1414,11 +1465,11 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1504,12 +1555,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d"
+dependencies = [
+ "zerocopy-derive 0.8.13",
 ]
 
 [[package]]
@@ -1520,5 +1590,16 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7988d73a4303ca289df03316bc490e934accf371af6bc745393cf3c2c5c4f25d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,7 +361,6 @@ dependencies = [
 name = "ec-linear"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "ec-core",
  "miette",
@@ -854,7 +847,6 @@ dependencies = [
 name = "push"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "collectable",
  "criterion",
@@ -863,6 +855,7 @@ dependencies = [
  "ec-linear",
  "embed-doc-image",
  "macro_railroad_annotation",
+ "miette",
  "num-traits",
  "ordered-float",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ license = "MIT OR Apache-2.0"
 debug = true
 
 [workspace.dependencies]
-anyhow = "1.0.80"
 clap = "4.5.1"
 rand = "0.9.0-alpha.2"
 num-traits = "0.2.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ proptest = "1.5.0"
 criterion = "0.5.1"
 miette = "7.4.0"
 test-case = "3.3.1"
+polonius-the-crab = "0.4.2"
 
 ec-core = { path = "packages/ec-core" }
 ec-linear = { path = "packages/ec-linear" }

--- a/clippy.toml
+++ b/clippy.toml
@@ -8,12 +8,9 @@ allowed-duplicate-crates = [
   "heck",
   # https://github.com/eminence/terminal-size/pull/62
   "windows-sys",
-  "windows-targets",
-  "windows_aarch64_gnullvm",
-  "windows_aarch64_msvc",
-  "windows_i686_gnu",
-  "windows_i686_msvc",
-  "windows_x86_64_gnu",
-  "windows_x86_64_gnullvm",
-  "windows_x86_64_msvc"
+  # Updated dependencies of rand@0.9.x-beta.x, which the current ecosystem is currently behind of
+  "zerocopy",
+  "zerocopy-derive",
+  "wasi",
+  "getrandom"
 ]

--- a/packages/ec-core/Cargo.toml
+++ b/packages/ec-core/Cargo.toml
@@ -28,6 +28,7 @@ rayon = "1.7.0"
 macro_railroad_annotation = { workspace = true }
 thiserror = { workspace = true }
 miette = { workspace = true }
+polonius-the-crab = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["alloc", "small_rng"] }

--- a/packages/ec-core/Cargo.toml
+++ b/packages/ec-core/Cargo.toml
@@ -20,7 +20,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { workspace = true }
 itertools = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true, features = ["alloc"] }

--- a/packages/ec-core/benches/test_results.rs
+++ b/packages/ec-core/benches/test_results.rs
@@ -1,8 +1,8 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use ec_core::{distributions::collection::ConvertToCollectionGenerator, test_results::TestResults};
 use rand::{
-    distr::{Distribution, Standard},
-    thread_rng,
+    distr::{Distribution, StandardUniform},
+    rng,
 };
 
 // Benchmark the time required to construct instances of `TestResults` from a
@@ -27,8 +27,8 @@ pub fn find_smallest(c: &mut Criterion) {
     // in `TestResults` (`i64`) so that the sum of the values in a vector
     // won't overflow the largest possible value in the `TestResults` type.
     let test_results: Vec<TestResults<i64>> = Distribution::<Vec<i32>>::sample_iter(
-        Standard.into_collection_generator(NUM_VALUES),
-        &mut thread_rng(),
+        StandardUniform.into_collection_generator(NUM_VALUES),
+        &mut rng(),
     )
     .map(Into::into)
     .take(NUM_RESULTS)

--- a/packages/ec-core/src/distributions/collection.rs
+++ b/packages/ec-core/src/distributions/collection.rs
@@ -79,11 +79,6 @@ where
 /// The number of element and the mechanism for generating
 /// random elements are specified in the `CollectionGenerator`
 /// struct.
-///
-/// # Errors
-///
-/// This returns an `anyhow::Error` generating any of
-/// the elements returns an error.
 impl<T, C> Distribution<Vec<T>> for Generator<C>
 where
     C: Distribution<T>,

--- a/packages/ec-core/src/distributions/wrappers/owned.rs
+++ b/packages/ec-core/src/distributions/wrappers/owned.rs
@@ -50,7 +50,7 @@ where
     /// let distr = OneOfCloning::new(options)?;
     /// assert_eq!(options.len(), distr.num_choices().get());
     ///
-    /// let val = distr.sample(&mut rand::thread_rng());
+    /// let val = distr.sample(&mut rand::rng());
     /// assert!(options.contains(&val));
     ///
     /// # Ok::<(), EmptySlice>(())

--- a/packages/ec-core/src/distributions/wrappers/slice_cloning.rs
+++ b/packages/ec-core/src/distributions/wrappers/slice_cloning.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 
+use miette::Diagnostic;
 use rand::{distr::Slice, prelude::Distribution};
 
 use crate::distributions::choices::ChoicesDistribution;
@@ -9,19 +10,10 @@ use crate::distributions::choices::ChoicesDistribution;
 #[derive(Debug, Clone, Copy)]
 pub struct SliceCloning<'a, T>(Slice<'a, T>);
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error, Diagnostic)]
+#[error("Tried to create a `distributions::Slice` with an empty slice")]
+#[diagnostic(help = "Ensure your slice has at least length one.")]
 pub struct EmptySlice;
-
-impl core::fmt::Display for EmptySlice {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "Tried to create a `distributions::Slice` with an empty slice"
-        )
-    }
-}
-
-impl std::error::Error for EmptySlice {}
 
 impl<'a, T> SliceCloning<'a, T> {
     /// Create a new `Slice` instance which samples uniformly from the slice.

--- a/packages/ec-core/src/generation.rs
+++ b/packages/ec-core/src/generation.rs
@@ -1,5 +1,5 @@
-use itertools::Itertools;
-use rayon::prelude::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
+use polonius_the_crab::{polonius, polonius_try};
+use rayon::prelude::{FromParallelIterator, ParallelIterator};
 
 use crate::{operator::Operator, population::Population};
 
@@ -28,24 +28,40 @@ where
     P: Population + FromParallelIterator<P::Individual> + Send + Sync,
     P::Individual: Send,
     for<'a> C: Operator<&'a P, Output = P::Individual, Error: Send> + Send + Sync,
-    for<'a> anyhow::Error: From<<C as Operator<&'a P>>::Error>,
 {
     /// Make the next generation using a Rayon parallel iterator.
     /// # Errors
     ///
     /// This can return errors if any aspect of creating the next generation
     /// fail. That can include constructing or scoring the genomes.
-    pub fn par_next(&mut self) -> anyhow::Result<()> {
-        let pop_size = self.population.size();
-        let population = (0..pop_size)
-            .into_par_iter()
-            .map_init(rand::thread_rng, |rng, _| {
-                self.child_maker.apply(&self.population, rng)
-            })
-            .collect::<Result<_, _>>()?;
+    pub fn par_next(&mut self) -> Result<(), <C as Operator<&P>>::Error> {
+        // Should be able to be removed along with workaround
+        let mut alias = self;
+
+        // this is the code that should work, but currently doesn't because of NLL
+        // limitations (should compile in future versions of rust just fine)
+        // let population = rayon::iter::repeatn(&self.population,
+        // self.population.size())     .map_init(rand::rng, |rng, p|
+        // self.child_maker.apply(p, rng))     .collect::<Result<_, _>>()?;
+
+        // Workaround for current compiler limitations
+
+        let new_population = polonius!(
+            |alias| -> Result<(), <C as Operator<&'polonius P>>::Error> {
+                polonius_try!(
+                    rayon::iter::repeatn(&alias.population, alias.population.size())
+                        .map_init(rand::rng, |rng, p| alias.child_maker.apply(p, rng))
+                        .collect::<Result<_, _>>()
+                )
+            }
+        );
+
+        // end of workaround
+
         // TODO: We can reduce allocations by pre-allocating the memory for "old" and
         // "new"   population in `::new()` and then re-using those vectors here.
-        self.population = population;
+        alias.population = new_population;
+
         Ok(())
     }
 }
@@ -54,23 +70,37 @@ impl<P, C> Generation<P, C>
 where
     P: Population + FromIterator<P::Individual>,
     C: for<'a> Operator<&'a P, Output = P::Individual>,
-    for<'a> anyhow::Error: From<<C as Operator<&'a P>>::Error>,
 {
     /// Make the next generation serially.
     /// # Errors
     ///
     /// This can return errors if any aspect of creating the next generation
     /// fail. That can include constructing or scoring the genomes.
-    pub fn serial_next(&mut self) -> anyhow::Result<()> {
-        let pop_size = self.population.size();
-        let mut rng = rand::thread_rng();
-        // Switch to `repeat_with` and `take`
-        let new_population = (0..pop_size)
-            .map(|_| self.child_maker.apply(&self.population, &mut rng))
-            .try_collect()?;
+    pub fn serial_next(&mut self) -> Result<(), <C as Operator<&P>>::Error> {
+        let mut alias = self;
+        let mut rng = rand::rng();
+
+        // this is the code that should work, but currently doesn't because of NLL
+        // limitations (should compile in future versions of rust just fine)
+        // let new_population = std::iter::repeat_n(&self.population,
+        // self.population.size())     .map(|p| self.child_maker.apply(p, &mut
+        // rng))     .collect::<Result<_, _>>()?;
+
+        // Workaround for current compiler limitations
+
+        let new_population = polonius!(
+            |alias| -> Result<(), <C as Operator<&'polonius P>>::Error> {
+                polonius_try!(
+                    std::iter::repeat_n(&alias.population, alias.population.size())
+                        .map(|p| alias.child_maker.apply(p, &mut rng))
+                        .collect::<Result<_, _>>()
+                )
+            }
+        );
+
         // TODO: We can reduce allocations by pre-allocating the memory for "old" and
         // "new"   population in `::new()` and then re-using those vectors here.
-        self.population = new_population;
+        alias.population = new_population;
         Ok(())
     }
 }

--- a/packages/ec-core/src/operator/composable/and.rs
+++ b/packages/ec-core/src/operator/composable/and.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use rand::rngs::ThreadRng;
 
 use super::{super::Operator, Composable};
@@ -17,27 +16,63 @@ impl<F, G> And<F, G> {
     }
 }
 
+#[derive(Debug)]
+pub enum AndError<T, U> {
+    First(T),
+    Second(U),
+}
+
+impl<T, U> std::fmt::Display for AndError<T, U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::First(_) => f.write_str(
+                "Error while applying the first passed operator (`T`) in the `And<T,>` Operator",
+            ),
+            Self::Second(_) => f.write_str(
+                "Error while applying the second passed operator (`U`) in the `And<,U>` Operator",
+            ),
+        }
+    }
+}
+
+impl<T, U> std::error::Error for AndError<T, U>
+where
+    T: std::error::Error + 'static,
+    U: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::First(t) => Some(t),
+            Self::Second(t) => Some(t),
+        }
+    }
+}
+
+impl<T, U> miette::Diagnostic for AndError<T, U>
+where
+    T: miette::Diagnostic + 'static,
+    U: miette::Diagnostic + 'static,
+{
+    fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
+        match self {
+            Self::First(t) => Some(t),
+            Self::Second(t) => Some(t),
+        }
+    }
+}
+
 impl<A, F, G> Operator<A> for And<F, G>
 where
     A: Clone,
     F: Operator<A>,
     G: Operator<A>,
-    anyhow::Error: From<F::Error> + From<G::Error>,
 {
     type Output = (F::Output, G::Output);
-    type Error = anyhow::Error;
+    type Error = AndError<F::Error, G::Error>;
 
     fn apply(&self, x: A, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
-        let f_value = self
-            .f
-            .apply(x.clone(), rng)
-            .map_err(anyhow::Error::from)
-            .context("f in `And` failed")?;
-        let g_value = self
-            .g
-            .apply(x, rng)
-            .map_err(anyhow::Error::from)
-            .context("g in `And` failed")?;
+        let f_value = self.f.apply(x.clone(), rng).map_err(AndError::First)?;
+        let g_value = self.g.apply(x, rng).map_err(AndError::Second)?;
         Ok((f_value, g_value))
     }
 }

--- a/packages/ec-core/src/operator/composable/map.rs
+++ b/packages/ec-core/src/operator/composable/map.rs
@@ -56,7 +56,7 @@ where
         rng: &mut rand::rngs::ThreadRng,
     ) -> Result<Self::Output, Self::Error> {
         let first_result = self.f.apply(x, rng).map_err(|e| MapError(e, 0))?;
-        let second_result = self.f.apply(y, rng).map_err(|e| MapError(e, 0))?;
+        let second_result = self.f.apply(y, rng).map_err(|e| MapError(e, 1))?;
         Ok([first_result, second_result])
     }
 }
@@ -74,7 +74,7 @@ where
         rng: &mut rand::rngs::ThreadRng,
     ) -> Result<Self::Output, Self::Error> {
         let first_result = self.f.apply(x, rng).map_err(|e| MapError(e, 0))?;
-        let second_result = self.f.apply(y, rng).map_err(|e| MapError(e, 0))?;
+        let second_result = self.f.apply(y, rng).map_err(|e| MapError(e, 1))?;
         Ok((first_result, second_result))
     }
 }

--- a/packages/ec-core/src/operator/composable/map.rs
+++ b/packages/ec-core/src/operator/composable/map.rs
@@ -1,5 +1,3 @@
-use anyhow::Context;
-
 use super::Composable;
 use crate::operator::Operator;
 
@@ -13,30 +11,52 @@ impl<F> Map<F> {
     }
 }
 
+#[derive(Debug)]
+pub struct MapError<T>(T, usize);
+
+impl<T> std::fmt::Display for MapError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Error while applying passed operator on the {}-th element of the mapped iterable",
+            self.1
+        )
+    }
+}
+
+impl<T> std::error::Error for MapError<T>
+where
+    T: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl<T> miette::Diagnostic for MapError<T>
+where
+    T: miette::Diagnostic + 'static,
+{
+    fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
+        Some(&self.0)
+    }
+}
+
 // I think I can parameterize over the 2 here to make this more general?
 impl<F, Input> Operator<[Input; 2]> for Map<F>
 where
     F: Operator<Input>,
-    anyhow::Error: From<F::Error>,
 {
     type Output = [F::Output; 2];
-    type Error = anyhow::Error;
+    type Error = MapError<F::Error>;
 
     fn apply(
         &self,
         [x, y]: [Input; 2],
         rng: &mut rand::rngs::ThreadRng,
     ) -> Result<Self::Output, Self::Error> {
-        let first_result = self
-            .f
-            .apply(x, rng)
-            .map_err(anyhow::Error::from)
-            .context("Calling f with {x} in `Map` failed")?;
-        let second_result = self
-            .f
-            .apply(y, rng)
-            .map_err(anyhow::Error::from)
-            .context("Calling f with {y} in `Map` failed")?;
+        let first_result = self.f.apply(x, rng).map_err(|e| MapError(e, 0))?;
+        let second_result = self.f.apply(y, rng).map_err(|e| MapError(e, 0))?;
         Ok([first_result, second_result])
     }
 }
@@ -44,26 +64,17 @@ where
 impl<F, Input> Operator<(Input, Input)> for Map<F>
 where
     F: Operator<Input>,
-    anyhow::Error: From<F::Error>,
 {
     type Output = (F::Output, F::Output);
-    type Error = anyhow::Error;
+    type Error = MapError<F::Error>;
 
     fn apply(
         &self,
         (x, y): (Input, Input),
         rng: &mut rand::rngs::ThreadRng,
     ) -> Result<Self::Output, Self::Error> {
-        let first_result = self
-            .f
-            .apply(x, rng)
-            .map_err(anyhow::Error::from)
-            .context("Calling f with {x} in `Map` failed")?;
-        let second_result = self
-            .f
-            .apply(y, rng)
-            .map_err(anyhow::Error::from)
-            .context("Calling f with {y} in `Map` failed")?;
+        let first_result = self.f.apply(x, rng).map_err(|e| MapError(e, 0))?;
+        let second_result = self.f.apply(y, rng).map_err(|e| MapError(e, 0))?;
         Ok((first_result, second_result))
     }
 }
@@ -71,10 +82,9 @@ where
 impl<F, Input> Operator<Vec<Input>> for Map<F>
 where
     F: Operator<Input>,
-    anyhow::Error: From<F::Error>,
 {
     type Output = Vec<F::Output>;
-    type Error = anyhow::Error;
+    type Error = MapError<F::Error>;
 
     fn apply(
         &self,
@@ -83,12 +93,8 @@ where
     ) -> Result<Self::Output, Self::Error> {
         input
             .into_iter()
-            .map(|x| {
-                self.f
-                    .apply(x, rng)
-                    .map_err(anyhow::Error::from)
-                    .context("Applying f to {x} in `Map` failed")
-            })
+            .enumerate()
+            .map(|(i, x)| self.f.apply(x, rng).map_err(|e| MapError(e, i)))
             .collect()
     }
 }

--- a/packages/ec-core/src/operator/composable/repeat_with.rs
+++ b/packages/ec-core/src/operator/composable/repeat_with.rs
@@ -59,7 +59,7 @@ impl<F, const N: usize> Composable for RepeatWith<F, N> {}
 mod tests {
     use std::{convert::Infallible, ops::Range};
 
-    use rand::{Rng, thread_rng};
+    use rand::{Rng, rng};
 
     use super::*;
 
@@ -82,7 +82,7 @@ mod tests {
     fn deterministic() {
         const LENGTH: usize = 5;
         let desired_value = 7;
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let repeater: RepeatWith<AddOne, LENGTH> = RepeatWith::new(AddOne);
         let result = repeater.apply(desired_value, &mut rng).unwrap();
         assert_eq!(LENGTH, result.len());
@@ -99,7 +99,7 @@ mod tests {
             range: Range<i32>,
             rng: &mut rand::rngs::ThreadRng,
         ) -> Result<Self::Output, Self::Error> {
-            Ok(rng.gen_range(range))
+            Ok(rng.random_range(range))
         }
     }
     impl Composable for UniformRange {}
@@ -108,7 +108,7 @@ mod tests {
     fn stochastic() {
         const LENGTH: usize = 5;
         let range = 0..7;
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let repeater: RepeatWith<UniformRange, LENGTH> = RepeatWith::new(UniformRange);
         let result = repeater.apply(range.clone(), &mut rng).unwrap();
         assert_eq!(LENGTH, result.len());

--- a/packages/ec-core/src/operator/composable/repeat_with.rs
+++ b/packages/ec-core/src/operator/composable/repeat_with.rs
@@ -20,10 +20,9 @@ impl<F, Input, const N: usize> Operator<Input> for RepeatWith<F, N>
 where
     Input: Clone,
     F: Operator<Input>,
-    anyhow::Error: From<F::Error>,
 {
     type Output = [F::Output; N];
-    type Error = anyhow::Error;
+    type Error = F::Error;
 
     fn apply(
         &self,
@@ -51,10 +50,6 @@ impl<F, const N: usize> Composable for RepeatWith<F, N> {}
     clippy::arithmetic_side_effects,
     reason = "The tradeoff safety <> ease of writing arguably lies on the ease of writing side \
               for test code."
-)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
 )]
 mod tests {
     use std::{convert::Infallible, ops::Range};
@@ -84,7 +79,7 @@ mod tests {
         let desired_value = 7;
         let mut rng = rng();
         let repeater: RepeatWith<AddOne, LENGTH> = RepeatWith::new(AddOne);
-        let result = repeater.apply(desired_value, &mut rng).unwrap();
+        let Ok(result) = repeater.apply(desired_value, &mut rng);
         assert_eq!(LENGTH, result.len());
         result.into_iter().all(|x| x == desired_value);
     }

--- a/packages/ec-core/src/operator/composable/repeat_with.rs
+++ b/packages/ec-core/src/operator/composable/repeat_with.rs
@@ -79,6 +79,13 @@ mod tests {
         let desired_value = 7;
         let mut rng = rng();
         let repeater: RepeatWith<AddOne, LENGTH> = RepeatWith::new(AddOne);
+        // This is fine since the compiler can use static analysis to
+        // verify that the Err variant of the result enum is uninhabited (can't be
+        // constructed, is of type '!') and as such the Pattern `Ok()` becomes
+        // irrefutable here.
+        //
+        // If it wasn't, then we would either need a match block or a else clause
+        // instead and the compiler would complain.
         let Ok(result) = repeater.apply(desired_value, &mut rng);
         assert_eq!(LENGTH, result.len());
         result.into_iter().all(|x| x == desired_value);

--- a/packages/ec-core/src/operator/composable/then.rs
+++ b/packages/ec-core/src/operator/composable/then.rs
@@ -47,7 +47,7 @@ impl<F, G> Composable for Then<F, G> {}
 pub mod tests {
     use std::convert::Infallible;
 
-    use rand::thread_rng;
+    use rand::rng;
 
     use super::*;
 
@@ -76,7 +76,7 @@ pub mod tests {
     #[test]
     fn increment_then_double() {
         let combo = Increment.then(Double);
-        let result = combo.apply(7, &mut thread_rng()).unwrap();
+        let result = combo.apply(7, &mut rng()).unwrap();
         assert_eq!(16, result);
     }
 }

--- a/packages/ec-core/src/operator/composable/then.rs
+++ b/packages/ec-core/src/operator/composable/then.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use rand::rngs::ThreadRng;
 
 use super::{super::Operator, Composable};
@@ -14,22 +13,62 @@ impl<F, G> Then<F, G> {
     }
 }
 
+#[derive(Debug)]
+pub enum ThenError<T, U> {
+    First(T),
+    Second(U),
+}
+
+impl<T, U> std::fmt::Display for ThenError<T, U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::First(_) => f.write_str(
+                "Error while applying the first passed operator (`T`) in the `Then<T,>` Operator",
+            ),
+            Self::Second(_) => f.write_str(
+                "Error while applying the second passed operator (`U`) in the `Then<,U>` Operator",
+            ),
+        }
+    }
+}
+
+impl<T, U> std::error::Error for ThenError<T, U>
+where
+    T: std::error::Error + 'static,
+    U: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::First(t) => Some(t),
+            Self::Second(t) => Some(t),
+        }
+    }
+}
+
+impl<T, U> miette::Diagnostic for ThenError<T, U>
+where
+    T: miette::Diagnostic + 'static,
+    U: miette::Diagnostic + 'static,
+{
+    fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
+        match self {
+            Self::First(t) => Some(t),
+            Self::Second(t) => Some(t),
+        }
+    }
+}
+
 impl<A, F, G> Operator<A> for Then<F, G>
 where
     F: Operator<A>,
     G: Operator<F::Output>,
-    anyhow::Error: From<F::Error> + From<G::Error>,
 {
     type Output = G::Output;
-    type Error = anyhow::Error;
+    type Error = ThenError<F::Error, G::Error>;
 
     fn apply(&self, x: A, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
-        let f_result = self
-            .f
-            .apply(x, rng)
-            .map_err(anyhow::Error::from)
-            .context("f in `Then` failed")?;
-        self.g.apply(f_result, rng).map_err(anyhow::Error::from)
+        let f_result = self.f.apply(x, rng).map_err(ThenError::First)?;
+        self.g.apply(f_result, rng).map_err(ThenError::Second)
     }
 }
 impl<F, G> Composable for Then<F, G> {}

--- a/packages/ec-core/src/operator/constant.rs
+++ b/packages/ec-core/src/operator/constant.rs
@@ -15,9 +15,9 @@ use super::{Composable, Operator};
 ///
 /// ```
 /// # use ec_core::operator::{Operator, constant::Constant};
-/// # use rand::thread_rng;
+/// # use rand::rng;
 /// #
-/// let mut rng = thread_rng();
+/// let mut rng = rng();
 /// // This will always return 5 regardless of the input.
 /// let constant_five = Constant::new(5);
 ///
@@ -57,13 +57,13 @@ impl<T> Composable for Constant<T> {}
 
 #[cfg(test)]
 mod tests {
-    use rand::thread_rng;
+    use rand::rng;
 
     use crate::operator::{Operator, constant::Constant};
 
     #[test]
     fn is_constant() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         // This should always return 5 regardless of the input.
         let constant_five = Constant::new(5);
 

--- a/packages/ec-core/src/operator/genome_extractor.rs
+++ b/packages/ec-core/src/operator/genome_extractor.rs
@@ -61,7 +61,7 @@ use crate::individual::Individual;
 ///     .count();
 ///
 /// assert_eq!(num_different, 1);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct GenomeExtractor;
 

--- a/packages/ec-core/src/operator/genome_extractor.rs
+++ b/packages/ec-core/src/operator/genome_extractor.rs
@@ -16,7 +16,7 @@ use crate::individual::Individual;
 /// extract the genome from an individual and mutate it.
 ///
 /// ```
-/// # use rand::{rngs::ThreadRng, thread_rng, Rng};
+/// # use rand::{rngs::ThreadRng, rng, Rng};
 /// # use ec_core::{
 /// #     individual::ec::EcIndividual,
 /// #     operator::{
@@ -25,17 +25,21 @@ use crate::individual::Individual;
 /// #         Composable, Operator,
 /// #     },
 /// # };
+/// # use std::convert::Infallible;
+/// #
 /// type Genome<T> = [T; 4];
 /// // Flip a single bit in an array of booleans.
 /// struct FlipOne;
 ///
 /// impl Mutator<Genome<bool>> for FlipOne {
+///     type Error = Infallible;
+///
 ///     fn mutate(
 ///         &self,
 ///         mut genome: Genome<bool>,
 ///         rng: &mut ThreadRng,
-///     ) -> anyhow::Result<Genome<bool>> {
-///         let index = rng.gen_range(0..genome.len());
+///     ) -> Result<Genome<bool>, Self::Error> {
+///         let index = rng.random_range(0..genome.len());
 ///         genome[index] = !genome[index];
 ///         Ok(genome)
 ///     }
@@ -47,7 +51,7 @@ use crate::individual::Individual;
 /// let mutate = Mutate::new(FlipOne);
 /// let chain = GenomeExtractor.then(mutate);
 ///
-/// let result = chain.apply(&individual, &mut thread_rng())?;
+/// let result = chain.apply(&individual, &mut rng())?;
 ///
 /// // Count the number of genome values that have been changed, which should be 1.
 /// let num_different = result
@@ -83,7 +87,9 @@ impl Composable for GenomeExtractor {}
 #[expect(clippy::unwrap_used, reason = "panicking is appropriate in tests")]
 #[cfg(test)]
 mod tests {
-    use rand::{Rng, rngs::ThreadRng, thread_rng};
+    use std::convert::Infallible;
+
+    use rand::{Rng, rng, rngs::ThreadRng};
 
     use super::GenomeExtractor;
     use crate::{
@@ -98,12 +104,13 @@ mod tests {
     struct FlipOne;
 
     impl Mutator<Genome<bool>> for FlipOne {
+        type Error = Infallible;
         fn mutate(
             &self,
             mut genome: Genome<bool>,
             rng: &mut ThreadRng,
-        ) -> anyhow::Result<Genome<bool>> {
-            let index = rng.gen_range(0..genome.len());
+        ) -> Result<Genome<bool>, Self::Error> {
+            let index = rng.random_range(0..genome.len());
             genome[index] = !genome[index];
             Ok(genome)
         }
@@ -117,7 +124,7 @@ mod tests {
         let mutate = Mutate::new(FlipOne);
         let chain = GenomeExtractor.then(mutate);
 
-        let result = chain.apply(&individual, &mut thread_rng()).unwrap();
+        let result = chain.apply(&individual, &mut rng()).unwrap();
 
         let num_same = result
             .iter()

--- a/packages/ec-core/src/operator/identity.rs
+++ b/packages/ec-core/src/operator/identity.rs
@@ -14,9 +14,9 @@ use super::{Composable, Operator};
 ///
 /// ```
 /// # use ec_core::operator::{Operator, identity::Identity};
-/// # use rand::thread_rng;
+/// # use rand::rng;
 /// #
-/// let mut rng = thread_rng();
+/// let mut rng = rng();
 /// // This will always return the value that is passed in.
 /// let identity = Identity;
 ///
@@ -43,13 +43,13 @@ impl Composable for Identity {}
 
 #[cfg(test)]
 mod tests {
-    use rand::thread_rng;
+    use rand::rng;
 
     use crate::operator::{Operator, identity::Identity};
 
     #[test]
     fn returns_input() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         // This should always return its input.
         let identity = Identity;
 

--- a/packages/ec-core/src/operator/mutator/mod.rs
+++ b/packages/ec-core/src/operator/mutator/mod.rs
@@ -180,7 +180,7 @@ pub trait Mutator<G> {
 /// let operator = Mutate::new(FlipOne);
 /// let chain = operator.then(CountTrue);
 /// assert_eq!(chain.apply(genome, &mut rng())?, 1);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// We can also pass a _reference_ to a [`Mutator`] (i.e., `&Mutator`) to
@@ -230,7 +230,7 @@ pub trait Mutator<G> {
 /// let mutate = Mutate::new(&FlipOne);
 /// let chain = mutate.then(CountTrue);
 /// assert_eq!(chain.apply(genome, &mut rng())?, 1);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct Mutate<M> {
     /// The wrapped [`Mutator`] that this [`Mutate`] will apply

--- a/packages/ec-core/src/operator/mutator/mod.rs
+++ b/packages/ec-core/src/operator/mutator/mod.rs
@@ -21,27 +21,30 @@ use super::{Composable, Operator};
 /// that exactly one bit has changed.
 ///
 /// ```
-/// # use rand::{rngs::ThreadRng, thread_rng, Rng};
+/// # use rand::{rngs::ThreadRng, rng, Rng};
 /// # use ec_core::operator::mutator::Mutator;
+/// # use std::convert::Infallible;
 /// #
 /// type Genome<T> = [T; 4];
 ///
 /// struct FlipOne;
 ///
 /// impl Mutator<Genome<bool>> for FlipOne {
+///     type Error = Infallible;
+///
 ///     fn mutate(
 ///         &self,
 ///         mut genome: Genome<bool>,
 ///         rng: &mut ThreadRng,
-///     ) -> anyhow::Result<Genome<bool>> {
-///         let index = rng.gen_range(0..genome.len());
+///     ) -> Result<Genome<bool>, Self::Error> {
+///         let index = rng.random_range(0..genome.len());
 ///         genome[index] = !genome[index];
 ///         Ok(genome)
 ///     }
 /// }
 ///
 /// let genome = [true, false, false, true];
-/// let child_genome = FlipOne.mutate(genome.clone(), &mut thread_rng()).unwrap();
+/// let child_genome = FlipOne.mutate(genome.clone(), &mut rng()).unwrap();
 /// let num_diffs = genome
 ///     .iter()
 ///     .zip(child_genome.iter()) // Pair up corresponding elements from the two genomes
@@ -50,6 +53,8 @@ use super::{Composable, Operator};
 /// assert_eq!(num_diffs, 1);
 /// ```
 pub trait Mutator<G> {
+    type Error;
+
     /// Mutate the given `genome` returning a new genome of the same type (`G`)
     ///
     /// # Errors
@@ -57,7 +62,7 @@ pub trait Mutator<G> {
     /// This will return an error if there is an error mutating the given
     /// genome. This will usually be because the given `genome` is invalid in
     /// some way, thus making the mutation impossible.
-    fn mutate(&self, genome: G, rng: &mut ThreadRng) -> anyhow::Result<G>;
+    fn mutate(&self, genome: G, rng: &mut ThreadRng) -> Result<G, Self::Error>;
 }
 
 /// A wrapper that converts a [`Mutator`] into an [`Operator`].
@@ -81,12 +86,13 @@ pub trait Mutator<G> {
 /// mutator.
 ///
 /// ```
-/// # use rand::{rngs::ThreadRng, thread_rng};
+/// # use rand::{rngs::ThreadRng, rng};
 /// #
 /// # use ec_core::operator::{
 /// #     mutator::{Mutate, Mutator},
 /// #     Operator,
 /// # };
+/// # use std::convert::Infallible;
 /// #
 /// type Genome<T> = [T; 4];
 ///
@@ -94,22 +100,24 @@ pub trait Mutator<G> {
 /// struct FlipFirst;
 ///
 /// impl Mutator<Genome<bool>> for FlipFirst {
+///     type Error = Infallible;
+///
 ///     fn mutate(
 ///         &self,
 ///         mut genome: Genome<bool>,
 ///         _: &mut ThreadRng,
-///     ) -> anyhow::Result<Genome<bool>> {
+///     ) -> Result<Genome<bool>, Self::Error> {
 ///         genome[0] = !genome[0];
 ///         Ok(genome)
 ///     }
 /// }
 ///
 /// let genome = [true, false, false, true];
-/// let mutator_result = FlipFirst.mutate(genome.clone(), &mut thread_rng()).unwrap();
+/// let mutator_result = FlipFirst.mutate(genome.clone(), &mut rng()).unwrap();
 ///
 /// // Create a `Mutate` operator from the `FlipFirst` mutator
 /// let mutate = Mutate::new(FlipFirst);
-/// let operator_result = mutate.apply(genome.clone(), &mut thread_rng()).unwrap();
+/// let operator_result = mutate.apply(genome.clone(), &mut rng()).unwrap();
 ///
 /// assert_eq!(mutator_result, operator_result);
 /// ```
@@ -127,7 +135,7 @@ pub trait Mutator<G> {
 /// #     mutator::{Mutate, Mutator},
 /// #     Composable, Operator,
 /// # };
-/// # use rand::{rngs::ThreadRng, thread_rng, Rng};
+/// # use rand::{rngs::ThreadRng, rng, Rng};
 /// #
 /// type Genome<T> = [T; 4];
 ///
@@ -135,12 +143,14 @@ pub trait Mutator<G> {
 /// struct FlipOne;
 ///
 /// impl Mutator<Genome<bool>> for FlipOne {
+///     type Error = Infallible;
+///
 ///     fn mutate(
 ///         &self,
 ///         mut genome: Genome<bool>,
 ///         rng: &mut ThreadRng,
-///     ) -> anyhow::Result<Genome<bool>> {
-///         let index = rng.gen_range(0..genome.len());
+///     ) -> Result<Genome<bool>, Self::Error> {
+///         let index = rng.random_range(0..genome.len());
 ///         genome[index] = !genome[index];
 ///         Ok(genome)
 ///     }
@@ -169,7 +179,7 @@ pub trait Mutator<G> {
 /// // Wrap the mutator in a `Mutate` operator so we can chain it with `CountTrue`
 /// let operator = Mutate::new(FlipOne);
 /// let chain = operator.then(CountTrue);
-/// assert_eq!(chain.apply(genome, &mut thread_rng())?, 1);
+/// assert_eq!(chain.apply(genome, &mut rng())?, 1);
 /// # Ok::<(), anyhow::Error>(())
 /// ```
 ///
@@ -182,7 +192,8 @@ pub trait Mutator<G> {
 /// #     mutator::{Mutate, Mutator},
 /// #     Composable, Operator,
 /// # };
-/// # use rand::{rngs::ThreadRng, thread_rng, Rng};
+/// # use rand::{rngs::ThreadRng, rng, Rng};
+/// # use std::convert::Infallible;
 /// #
 /// # type Genome<T> = [T; 4];
 /// #
@@ -190,8 +201,10 @@ pub trait Mutator<G> {
 /// # struct FlipOne;
 /// #
 /// # impl Mutator<Genome<bool>> for FlipOne {
-/// #    fn mutate(&self, mut genome: Genome<bool>, rng: &mut ThreadRng) -> anyhow::Result<Genome<bool>> {
-/// #        let index = rng.gen_range(0..genome.len());
+/// #    type Error = Infallible;
+/// #
+/// #    fn mutate(&self, mut genome: Genome<bool>, rng: &mut ThreadRng) -> Result<Genome<bool>, Self::Error> {
+/// #        let index = rng.random_range(0..genome.len());
 /// #        genome[index] = !genome[index];
 /// #        Ok(genome)
 /// #    }
@@ -203,7 +216,7 @@ pub trait Mutator<G> {
 /// #
 /// # impl Operator<Genome<bool>> for CountTrue {
 /// #    type Output = usize;
-/// #    type Error = anyhow::Error;
+/// #    type Error = Infallible;
 /// #
 /// #    fn apply(&self, genome: Genome<bool>, _: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
 /// #        Ok(genome.iter().filter(|&&x| x).count())
@@ -216,7 +229,7 @@ pub trait Mutator<G> {
 /// // Wrap a reference to the mutator in a `Mutate` operator so we can chain it with `CountTrue`
 /// let mutate = Mutate::new(&FlipOne);
 /// let chain = mutate.then(CountTrue);
-/// assert_eq!(chain.apply(genome, &mut thread_rng())?, 1);
+/// assert_eq!(chain.apply(genome, &mut rng())?, 1);
 /// # Ok::<(), anyhow::Error>(())
 /// ```
 pub struct Mutate<M> {
@@ -235,7 +248,7 @@ where
     M: Mutator<G>,
 {
     type Output = G;
-    type Error = anyhow::Error;
+    type Error = M::Error;
 
     /// Apply this `Mutator` as an `Operator`
     fn apply(&self, genome: G, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
@@ -251,7 +264,20 @@ impl<M, G> Mutator<G> for &M
 where
     M: Mutator<G>,
 {
-    fn mutate(&self, genome: G, rng: &mut ThreadRng) -> anyhow::Result<G> {
+    type Error = M::Error;
+
+    fn mutate(&self, genome: G, rng: &mut ThreadRng) -> Result<G, Self::Error> {
+        (**self).mutate(genome, rng)
+    }
+}
+
+impl<M, G> Mutator<G> for &mut M
+where
+    M: Mutator<G>,
+{
+    type Error = M::Error;
+
+    fn mutate(&self, genome: G, rng: &mut ThreadRng) -> Result<G, Self::Error> {
         (**self).mutate(genome, rng)
     }
 }
@@ -262,7 +288,9 @@ where
 )]
 #[cfg(test)]
 mod tests {
-    use rand::{Rng, rngs::ThreadRng, thread_rng};
+    use std::convert::Infallible;
+
+    use rand::{Rng, rng, rngs::ThreadRng};
 
     use super::Mutator;
     use crate::operator::{Composable, Operator, mutator::Mutate};
@@ -272,12 +300,14 @@ mod tests {
     struct FlipOne;
 
     impl Mutator<Genome<bool>> for FlipOne {
+        type Error = Infallible;
+
         fn mutate(
             &self,
             mut genome: Genome<bool>,
             rng: &mut ThreadRng,
-        ) -> anyhow::Result<Genome<bool>> {
-            let index = rng.gen_range(0..genome.len());
+        ) -> Result<Genome<bool>, Self::Error> {
+            let index = rng.random_range(0..genome.len());
             genome[index] = !genome[index];
             Ok(genome)
         }
@@ -289,7 +319,7 @@ mod tests {
 
     impl Operator<Genome<bool>> for CountTrue {
         type Output = usize;
-        type Error = anyhow::Error;
+        type Error = Infallible;
 
         fn apply(
             &self,
@@ -314,7 +344,7 @@ mod tests {
     #[test]
     fn flip_one() {
         let genome = [true, false, false, true];
-        let child_genome = FlipOne.mutate(genome, &mut thread_rng()).unwrap();
+        let child_genome = FlipOne.mutate(genome, &mut rng()).unwrap();
         assert_eq!(count_differences(&genome, &child_genome), 1);
     }
 
@@ -324,7 +354,7 @@ mod tests {
         let mutator = FlipOne;
         // Wrap the mutator in a `Mutate` operator
         let operator = Mutate::new(mutator);
-        let child_genome = operator.apply(genome, &mut thread_rng()).unwrap();
+        let child_genome = operator.apply(genome, &mut rng()).unwrap();
         assert_eq!(count_differences(&genome, &child_genome), 1);
     }
 
@@ -334,7 +364,7 @@ mod tests {
         let mutator = FlipOne;
         // Wrap a reference to the mutator in a `Mutate` to make it an `Operator`.
         let operator = Mutate::new(&mutator);
-        let child_genome = operator.apply(genome, &mut thread_rng()).unwrap();
+        let child_genome = operator.apply(genome, &mut rng()).unwrap();
         assert_eq!(count_differences(&genome, &child_genome), 1);
     }
 
@@ -346,7 +376,7 @@ mod tests {
         let operator = Mutate::new(mutator);
         let count_true = CountTrue;
         let chain = operator.then(count_true);
-        assert_eq!(chain.apply(genome, &mut thread_rng()).unwrap(), 1);
+        assert_eq!(chain.apply(genome, &mut rng()).unwrap(), 1);
     }
 
     #[test]
@@ -358,6 +388,6 @@ mod tests {
         let operator = Mutate::new(&mutator);
         let count_true = CountTrue;
         let chain = operator.then(count_true);
-        assert_eq!(chain.apply(genome, &mut thread_rng()).unwrap(), 1);
+        assert_eq!(chain.apply(genome, &mut rng()).unwrap(), 1);
     }
 }

--- a/packages/ec-core/src/operator/recombinator/mod.rs
+++ b/packages/ec-core/src/operator/recombinator/mod.rs
@@ -34,8 +34,9 @@ use super::{Composable, Operator};
 /// second parent.
 ///
 /// ```
-/// # use rand::{rngs::ThreadRng, thread_rng, Rng};
+/// # use rand::{rngs::ThreadRng, rng, Rng};
 /// # use ec_core::operator::recombinator::Recombinator;
+/// # use std::convert::Infallible;
 /// #
 /// struct SwapOne;
 /// type Genome<T> = [T; 4];
@@ -43,13 +44,14 @@ use super::{Composable, Operator};
 ///
 /// impl<T: Copy> Recombinator<Parents<T>> for SwapOne {
 ///     type Output = Genome<T>;
+///     type Error = Infallible;
 ///
 ///     fn recombine(
 ///         &self,
 ///         (mut first_parent, second_parent): Parents<T>,
 ///         rng: &mut ThreadRng,
-///     ) -> anyhow::Result<Genome<T>> {
-///         let index = rng.gen_range(0..first_parent.len());
+///     ) -> Result<Genome<T>, Self::Error> {
+///         let index = rng.random_range(0..first_parent.len());
 ///         first_parent[index] = second_parent[index];
 ///         Ok(first_parent)
 ///     }
@@ -59,18 +61,21 @@ use super::{Composable, Operator};
 /// // should result in a child with three zeros and a single one.
 /// let first_parent = [0, 0, 0, 0];
 /// let second_parent = [1, 1, 1, 1];
-/// let child = SwapOne.recombine((first_parent, second_parent), &mut thread_rng())?;
+/// let child = SwapOne.recombine((first_parent, second_parent), &mut rng())?;
 /// let num_zeros = child.iter().filter(|&&x| x == 0).count();
 /// let num_ones = child.iter().filter(|&&x| x == 1).count();
 /// assert_eq!(num_zeros, 3);
 /// assert_eq!(num_ones, 1);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub trait Recombinator<GS> {
     /// The type of the output genome after recombination. This is typically
     /// the same as the type of genomes in the input group of type `GS`, but
     /// that isn't strictly required here.
     type Output;
+
+    /// The type of the error that can happen using this recombinator
+    type Error;
 
     /// Recombine the given `genomes` returning a new genome of type `Output`.
     ///
@@ -79,7 +84,7 @@ pub trait Recombinator<GS> {
     /// This will return an error if there is an error recombining the given
     /// parent genomes. This will usually be because the given `genomes` are
     /// invalid in some way, thus making recombination impossible.
-    fn recombine(&self, genomes: GS, rng: &mut ThreadRng) -> anyhow::Result<Self::Output>;
+    fn recombine(&self, genomes: GS, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error>;
 }
 
 /// A wrapper that converts a `Recombinator` into an `Operator`,
@@ -104,9 +109,10 @@ pub trait Recombinator<GS> {
 /// calling [`Recombinator::recombine`] directly on the recombinator.
 ///
 /// ```
-/// # use rand::{rngs::ThreadRng, thread_rng};
-/// #
+/// # use rand::{rngs::ThreadRng, rng};
 /// # use ec_core::operator::{Operator, recombinator::{Recombinator, Recombine}};
+/// # use std::convert::Infallible;
+/// #
 /// // A simple `Recombinator` that swaps one element from the second parent
 /// // into the corresponding position in the first parent.
 /// struct SwapFirst;
@@ -115,12 +121,13 @@ pub trait Recombinator<GS> {
 /// type Parents<T> = (Genome<T>, Genome<T>);
 /// impl<T: Copy> Recombinator<Parents<T>> for SwapFirst {
 ///     type Output = Genome<T>;
+///     type Error = Infallible;
 ///
 ///     fn recombine(
 ///         &self,
 ///         (mut first_parent, second_parent): Parents<T>,
 ///         _: &mut ThreadRng,
-///     ) -> anyhow::Result<Genome<T>> {
+///     ) -> Result<Genome<T>, Self::Error> {
 ///         first_parent[0] = second_parent[0];
 ///         Ok(first_parent)
 ///     }
@@ -130,17 +137,15 @@ pub trait Recombinator<GS> {
 /// let second_parent = [1, 1, 1, 1];
 ///
 /// let recombinator = SwapFirst;
-/// let recombinator_result = recombinator.recombine(
-///     (first_parent.clone(), second_parent.clone()),
-///     &mut thread_rng(),
-/// )?;
+/// let recombinator_result =
+///     recombinator.recombine((first_parent.clone(), second_parent.clone()), &mut rng())?;
 ///
 /// // Wrap the recombinator in a `Recombine` to make it an `Operator`.
 /// let recombine = Recombine::new(recombinator);
-/// let operator_result = recombine.apply((first_parent, second_parent), &mut thread_rng())?;
+/// let operator_result = recombine.apply((first_parent, second_parent), &mut rng())?;
 ///
 /// assert_eq!(recombinator_result, operator_result);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// Because [`Recombine`] and [`Operator`] are both [`Composable`], you can
@@ -154,7 +159,7 @@ pub trait Recombinator<GS> {
 ///
 /// ```
 /// # use std::convert::Infallible;
-/// # use rand::{rngs::ThreadRng, thread_rng, Rng};
+/// # use rand::{rngs::ThreadRng, rng, Rng};
 /// #
 /// # use ec_core::operator::{recombinator::{Recombinator, Recombine}, Composable, Operator};
 /// #
@@ -166,13 +171,14 @@ pub trait Recombinator<GS> {
 /// type Parents<T> = (Genome<T>, Genome<T>);
 /// impl<T: Copy> Recombinator<Parents<T>> for SwapOne {
 ///     type Output = Genome<T>;
+///     type Error = Infallible;
 ///
 ///     fn recombine(
 ///         &self,
 ///         (mut first_parent, second_parent): Parents<T>,
 ///         rng: &mut ThreadRng,
-///     ) -> anyhow::Result<Genome<T>> {
-///         let index = rng.gen_range(0..first_parent.len());
+///     ) -> Result<Genome<T>, Self::Error> {
+///         let index = rng.random_range(0..first_parent.len());
 ///         first_parent[index] = second_parent[index];
 ///         Ok(first_parent)
 ///     }
@@ -206,9 +212,9 @@ pub trait Recombinator<GS> {
 /// let count_true = CountTrue;
 /// let chain = recombine.then(count_true);
 ///
-/// let count = chain.apply((first_parent, second_parent), &mut thread_rng())?;
+/// let count = chain.apply((first_parent, second_parent), &mut rng())?;
 /// assert_eq!(count, 3);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// We can also pass a _reference_ to a [`Recombinator`] (i.e.,
@@ -217,7 +223,8 @@ pub trait Recombinator<GS> {
 /// ownership of the recombinator.
 ///
 /// ```
-/// # use rand::{rngs::ThreadRng, thread_rng, Rng};
+/// # use rand::{rngs::ThreadRng, rng, Rng};
+/// # use std::convert::Infallible;
 /// #
 /// # use ec_core::operator::{recombinator::{Recombinator, Recombine}, Composable, Operator};
 /// #
@@ -230,13 +237,14 @@ pub trait Recombinator<GS> {
 /// #
 /// # impl<T: Copy> Recombinator<Parents<T>> for SwapOne {
 /// #     type Output = Genome<T>;
+/// #     type Error = Infallible;
 /// #
 /// #     fn recombine(
 /// #         &self,
 /// #         (mut first_parent, second_parent): Parents<T>,
 /// #         rng: &mut ThreadRng,
-/// #     ) -> anyhow::Result<Genome<T>> {
-/// #         let index = rng.gen_range(0..first_parent.len());
+/// #     ) -> Result<Genome<T>, Self::Error> {
+/// #         let index = rng.random_range(0..first_parent.len());
 /// #         first_parent[index] = second_parent[index];
 /// #         Ok(first_parent)
 /// #     }
@@ -248,7 +256,7 @@ pub trait Recombinator<GS> {
 /// #
 /// # impl Operator<Genome<bool>> for CountTrue {
 /// #     type Output = usize;
-/// #     type Error = anyhow::Error;
+/// #     type Error = Infallible;
 /// #
 /// #     fn apply(&self, genome: Genome<bool>, _: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
 /// #         Ok(genome.iter().filter(|&&x| x).count())
@@ -265,9 +273,9 @@ pub trait Recombinator<GS> {
 /// let chain = recombine.then(CountTrue);
 ///
 /// let count = chain
-///     .apply((first_parent, second_parent), &mut thread_rng())?;
+///     .apply((first_parent, second_parent), &mut rng())?;
 /// assert_eq!(count, 3);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct Recombine<R> {
     /// The wrapped [`Recombinator`] that this [`Recombine`] will apply
@@ -285,7 +293,7 @@ where
     R: Recombinator<G>,
 {
     type Output = R::Output;
-    type Error = anyhow::Error;
+    type Error = R::Error;
 
     /// Apply the wrapped [`Recombinator`] as an [`Operator`] to the given
     /// genomes.
@@ -303,8 +311,9 @@ where
     R: Recombinator<GS>,
 {
     type Output = R::Output;
+    type Error = R::Error;
 
-    fn recombine(&self, genomes: GS, rng: &mut ThreadRng) -> anyhow::Result<Self::Output> {
+    fn recombine(&self, genomes: GS, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
         (**self).recombine(genomes, rng)
     }
 }
@@ -317,7 +326,7 @@ where
 mod tests {
     use std::convert::Infallible;
 
-    use rand::{Rng, rngs::ThreadRng, thread_rng};
+    use rand::{Rng, rng, rngs::ThreadRng};
 
     use super::{Recombinator, Recombine};
     use crate::operator::{Composable, Operator};
@@ -331,13 +340,14 @@ mod tests {
 
     impl<T: Copy> Recombinator<Parents<T>> for SwapOne {
         type Output = Genome<T>;
+        type Error = Infallible;
 
         fn recombine(
             &self,
             (mut first_parent, second_parent): Parents<T>,
             rng: &mut ThreadRng,
-        ) -> anyhow::Result<Genome<T>> {
-            let index = rng.gen_range(0..first_parent.len());
+        ) -> Result<Genome<T>, Self::Error> {
+            let index = rng.random_range(0..first_parent.len());
             first_parent[index] = second_parent[index];
             Ok(first_parent)
         }
@@ -366,7 +376,7 @@ mod tests {
         let first_parent = [0, 0, 0, 0];
         let second_parent = [1, 1, 1, 1];
         let child = SwapOne
-            .recombine((first_parent, second_parent), &mut thread_rng())
+            .recombine((first_parent, second_parent), &mut rng())
             .unwrap();
         // `child` should be all zeros except for the one place where
         // a one was swapped in from the second parent.
@@ -386,7 +396,7 @@ mod tests {
         let recombine = Recombine::new(recombinator);
 
         let child = recombine
-            .apply((first_parent, second_parent), &mut thread_rng())
+            .apply((first_parent, second_parent), &mut rng())
             .unwrap();
         let num_zeros = child.iter().filter(|&&x| x == 0).count();
         let num_ones = child.iter().filter(|&&x| x == 1).count();
@@ -405,7 +415,7 @@ mod tests {
         let recombine = Recombine::new(&recombinator);
 
         let child = recombine
-            .apply((first_parent, second_parent), &mut thread_rng())
+            .apply((first_parent, second_parent), &mut rng())
             .unwrap();
         let num_zeros = child.iter().filter(|&&x| x == 0).count();
         let num_ones = child.iter().filter(|&&x| x == 1).count();
@@ -426,7 +436,7 @@ mod tests {
         let chain = recombine.then(count_true);
 
         let count = chain
-            .apply((first_parent, second_parent), &mut thread_rng())
+            .apply((first_parent, second_parent), &mut rng())
             .unwrap();
         assert_eq!(count, 3);
     }
@@ -446,7 +456,7 @@ mod tests {
         let chain = recombine.then(count_true);
 
         let count = chain
-            .apply((first_parent, second_parent), &mut thread_rng())
+            .apply((first_parent, second_parent), &mut rng())
             .unwrap();
         assert_eq!(count, 3);
     }

--- a/packages/ec-core/src/operator/selector/best.rs
+++ b/packages/ec-core/src/operator/selector/best.rs
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     fn empty_population() {
         let pop: Vec<i32> = Vec::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         assert!(matches!(Best.select(&pop, &mut rng), Err(EmptyPopulation)));
     }
 
@@ -47,14 +47,14 @@ mod tests {
         // Once we've generalized `.select()` appropriately we can change this to be
         // an array. See #259
         let pop = vec![5, 8, 9, 6, 3, 2, 0];
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         assert_eq!(&9, Best.select(&pop, &mut rng).unwrap());
         assert_eq!(&9, Best.select(&pop, &mut rng).unwrap());
     }
 
     #[proptest]
     fn test_best_select(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let largest = pop.iter().max().unwrap();
         assert_eq!(largest, Best.select(&pop, &mut rng).unwrap());
     }

--- a/packages/ec-core/src/operator/selector/dyn_weighted.rs
+++ b/packages/ec-core/src/operator/selector/dyn_weighted.rs
@@ -116,7 +116,7 @@ mod tests {
 
     #[proptest]
     fn best_or_worst(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         // We'll make a selector that has a 50/50 chance of choosing the highest
         // or lowest value.
         let weighted = DynWeighted::new(Best, 1).with_selector(Worst, 1);

--- a/packages/ec-core/src/operator/selector/lexicase.rs
+++ b/packages/ec-core/src/operator/selector/lexicase.rs
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn empty_population() {
         let pop = population_from_single_scores([]);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let selector = Lexicase::new(0);
         assert!(matches!(
             selector.select(&pop, &mut rng),
@@ -160,7 +160,7 @@ mod tests {
         let population = population_from_single_scores([5, 8, 9, 6, 3, 2, 0]);
 
         let lexicase = Lexicase::new(1);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         assert_eq!(&2, lexicase.select(&population, &mut rng).unwrap().genome());
     }
@@ -171,7 +171,7 @@ mod tests {
         let population = population_from_single_scores([5, 8, 9, 6, 3, 2, 0, 9]);
 
         let lexicase = Lexicase::new(1);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let selected = *lexicase.select(&population, &mut rng).unwrap().genome();
         assert!(
@@ -187,7 +187,7 @@ mod tests {
             population_from_scores([[5, 3], [8, 2], [9, 8], [6, 2], [3, 8], [2, 8], [0, 6]]);
 
         let lexicase = Lexicase::new(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         assert_eq!(&2, lexicase.select(&population, &mut rng).unwrap().genome());
     }
@@ -206,7 +206,7 @@ mod tests {
         ]);
 
         let lexicase = Lexicase::new(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let selected = *lexicase.select(&population, &mut rng).unwrap().genome();
         assert!(
@@ -246,7 +246,7 @@ mod tests {
 
         let num_test_cases = population[0].test_results.len();
         let lexicase = Lexicase::new(num_test_cases);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let selected = lexicase.select(&population, &mut rng).unwrap().genome();
         prop_assert_eq!(selected, &winning_label);

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -25,42 +25,43 @@ pub use error::EmptyPopulation;
 ///
 /// ```
 /// # use ec_core::operator::selector::{best::Best, Selector};
-/// # use rand::thread_rng;
+/// # use rand::rng;
 /// #
 /// let population = vec![5, 8, 9, 2, 3, 6];
-/// let winner = Best.select(&population, &mut thread_rng())?;
+/// let winner = Best.select(&population, &mut rng())?;
 /// assert_eq!(*winner, 9);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// Here we implement a `First` selector that always returns the first
 /// element in a vector.
 ///
 /// ```
-/// # use rand::{rngs::ThreadRng, thread_rng};
-/// # use anyhow::Context;
+/// # use rand::{rngs::ThreadRng, rng};
 /// # use ec_core::operator::selector::Selector;
 /// #
 /// struct First;
 ///
+/// #[derive(Debug, Error)]
+/// #[error("Should be at least one individual in the population")]
+/// struct EmptyPopulationError;
+///
 /// impl Selector<Vec<u8>> for First {
-///     type Error = anyhow::Error;
+///     type Error = EmptyPopulationError;
 ///
 ///     fn select<'pop>(
 ///         &self,
 ///         population: &'pop Vec<u8>,
 ///         _: &mut ThreadRng,
-///     ) -> anyhow::Result<&'pop u8> {
-///         population
-///             .first()
-///             .context("Should be at least one individual in the population")
+///     ) -> Result<&'pop u8, Self::Error> {
+///         population.first().ok_or(EmptyPopulationError)
 ///     }
 /// }
 ///
 /// let population = vec![5, 8, 9];
-/// let choice = First.select(&population, &mut thread_rng())?;
+/// let choice = First.select(&population, &mut rng())?;
 /// assert_eq!(*choice, 5);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub trait Selector<P>
 where
@@ -99,7 +100,7 @@ where
 ///
 /// ```
 /// # use anyhow::Context;
-/// # use rand::{rngs::ThreadRng, thread_rng};
+/// # use rand::{rngs::ThreadRng, rng};
 /// #
 /// # use ec_core::operator::{Operator, selector::{Select, Selector}};
 /// #
@@ -125,10 +126,10 @@ where
 ///
 /// // Selectors return references to the individuals they choose, so we
 /// // get a `&u8` back from `select` and `apply`.
-/// let selector_result: &u8 = First.select(&population, &mut thread_rng())?;
+/// let selector_result: &u8 = First.select(&population, &mut rng())?;
 /// assert_eq!(*selector_result, 5);
 ///
-/// let operator_result: &u8 = select.apply(&population, &mut thread_rng())?;
+/// let operator_result: &u8 = select.apply(&population, &mut rng())?;
 /// assert_eq!(selector_result, operator_result);
 /// # Ok::<(), anyhow::Error>(())
 /// ```
@@ -142,7 +143,7 @@ where
 ///
 /// ```
 /// # use anyhow::Context;
-/// # use rand::{rngs::ThreadRng, thread_rng};
+/// # use rand::{rngs::ThreadRng, rng};
 /// # use std::convert::Infallible;
 /// #
 /// # use ec_core::operator::{Composable, Operator, selector::{Select, Selector}};
@@ -186,7 +187,7 @@ where
 ///
 /// // The `StrLen` operator will take the `&String` returned by the `First`
 /// // selector and return its length.
-/// let choice_length: usize = chain.apply(&population, &mut thread_rng())?;
+/// let choice_length: usize = chain.apply(&population, &mut rng())?;
 /// assert_eq!(choice_length, 5);
 /// # Ok::<(), anyhow::Error>(())
 /// ```
@@ -197,7 +198,7 @@ where
 ///
 /// ```
 /// # use anyhow::Context;
-/// # use rand::{rngs::ThreadRng, thread_rng};
+/// # use rand::{rngs::ThreadRng, rng};
 /// #
 /// # use ec_core::operator::{Composable, Operator, selector::{Select, Selector}};
 /// #
@@ -232,7 +233,7 @@ where
 /// let ref_select = Select::new(&First);
 /// let chain = ref_select.then(StrLen);
 /// let population: Vec<String> = vec!["Hello".to_string(), "World".to_string()];
-/// let choice_length: usize = chain.apply(&population, &mut thread_rng())?;
+/// let choice_length: usize = chain.apply(&population, &mut rng())?;
 /// assert_eq!(choice_length, 5);
 /// # Ok::<(), anyhow::Error>(())
 /// ```
@@ -290,7 +291,7 @@ where
 #[cfg(test)]
 mod tests {
     use anyhow::Context;
-    use rand::{rngs::ThreadRng, thread_rng};
+    use rand::{rng, rngs::ThreadRng};
 
     use super::{Select, Selector};
     use crate::operator::{Composable, Operator};
@@ -332,7 +333,7 @@ mod tests {
     #[test]
     fn can_implement_simple_selector() {
         let population = vec![5, 8, 9];
-        let choice = First.select(&population, &mut thread_rng()).unwrap();
+        let choice = First.select(&population, &mut rng()).unwrap();
         assert_eq!(*choice, 5);
     }
 
@@ -340,7 +341,7 @@ mod tests {
     fn can_wrap_selector() {
         let select = Select::new(First);
         let population = vec![5, 8, 9];
-        let choice = select.apply(&population, &mut thread_rng()).unwrap();
+        let choice = select.apply(&population, &mut rng()).unwrap();
         assert_eq!(*choice, 5);
     }
 
@@ -350,7 +351,7 @@ mod tests {
         // still successfully select values.
         let select = Select::new(&First);
         let population = vec![5, 8, 9];
-        let choice = select.apply(&population, &mut thread_rng()).unwrap();
+        let choice = select.apply(&population, &mut rng()).unwrap();
         assert_eq!(*choice, 5);
     }
 
@@ -360,7 +361,7 @@ mod tests {
         let double = StrLen;
         let chain = select.then(double);
         let population: Vec<String> = vec!["Hello".to_string(), "World!".to_string()];
-        let length_of_choice: usize = chain.apply(&population, &mut thread_rng()).unwrap();
+        let length_of_choice: usize = chain.apply(&population, &mut rng()).unwrap();
         assert_eq!(length_of_choice, 5);
     }
 
@@ -372,7 +373,7 @@ mod tests {
         let double = StrLen;
         let chain = select.then(double);
         let population: Vec<String> = vec!["Hello".to_string(), "World!".to_string()];
-        let length_of_choice: usize = chain.apply(&population, &mut thread_rng()).unwrap();
+        let length_of_choice: usize = chain.apply(&population, &mut rng()).unwrap();
         assert_eq!(length_of_choice, 5);
     }
 }

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -38,23 +38,19 @@ pub use error::EmptyPopulation;
 ///
 /// ```
 /// # use rand::{rngs::ThreadRng, rng};
-/// # use ec_core::operator::selector::Selector;
+/// # use ec_core::operator::selector::{error::EmptyPopulation, Selector};
 /// #
 /// struct First;
 ///
-/// #[derive(Debug, thiserror::Error)]
-/// #[error("Should be at least one individual in the population")]
-/// struct EmptyPopulationError;
-///
 /// impl Selector<Vec<u8>> for First {
-///     type Error = EmptyPopulationError;
+///     type Error = EmptyPopulation;
 ///
 ///     fn select<'pop>(
 ///         &self,
 ///         population: &'pop Vec<u8>,
 ///         _: &mut ThreadRng,
 ///     ) -> Result<&'pop u8, Self::Error> {
-///         population.first().ok_or(EmptyPopulationError)
+///         population.first().ok_or(EmptyPopulation)
 ///     }
 /// }
 ///
@@ -101,23 +97,19 @@ where
 /// ```
 /// # use rand::{rngs::ThreadRng, rng};
 /// #
-/// # use ec_core::operator::{Operator, selector::{Select, Selector}};
+/// # use ec_core::operator::{Operator, selector::{error::EmptyPopulation, Select, Selector}};
 /// #
 /// struct First; // Simple selector that always returns the first element in a vector.
 ///
-/// #[derive(Debug, thiserror::Error)]
-/// #[error("At least one individual in the population is required to make a selection from it")]
-/// struct EmptyPopulationError;
-///
 /// impl<T> Selector<Vec<T>> for First {
-///     type Error = EmptyPopulationError;
+///     type Error = EmptyPopulation;
 ///
 ///     fn select<'pop>(
 ///         &self,
 ///         population: &'pop Vec<T>,
 ///         _: &mut ThreadRng,
 ///     ) -> Result<&'pop T, Self::Error> {
-///         population.first().ok_or(EmptyPopulationError)
+///         population.first().ok_or(EmptyPopulation)
 ///     }
 /// }
 ///
@@ -146,16 +138,12 @@ where
 /// # use rand::{rngs::ThreadRng, rng};
 /// # use std::convert::Infallible;
 /// #
-/// # use ec_core::operator::{Composable, Operator, selector::{Select, Selector}};
+/// # use ec_core::operator::{Composable, Operator, selector::{error::EmptyPopulation, Select, Selector}};
 /// #
 /// # struct First; // Simple selector that always returns the first element in a vector.
 /// #
-/// # #[derive(Debug, thiserror::Error)]
-/// # #[error("Should be at least one individual in the population")]
-/// # struct EmptyPopulationError;
-/// #
 /// # impl<T> Selector<Vec<T>> for First {
-/// #    type Error = EmptyPopulationError;
+/// #    type Error = EmptyPopulation;
 /// #
 /// #    fn select<'pop>(
 /// #        &self,
@@ -164,7 +152,7 @@ where
 /// #    ) -> Result<&'pop T, Self::Error> {
 /// #        population
 /// #            .first()
-/// #            .ok_or(EmptyPopulationError)
+/// #            .ok_or(EmptyPopulation)
 /// #    }
 /// # }
 /// #
@@ -205,16 +193,12 @@ where
 /// #
 /// # use rand::{rngs::ThreadRng, rng};
 /// #
-/// # use ec_core::operator::{Composable, Operator, selector::{Select, Selector}};
+/// # use ec_core::operator::{Composable, Operator, selector::{error::EmptyPopulation, Select, Selector}};
 /// #
 /// # struct First; // Simple selector that always returns the first element in a vector.
 /// #
-/// # #[derive(Debug, thiserror::Error)]
-/// # #[error("Should be at least one individual in the population")]
-/// # struct EmptyPopulationError;
-/// #
 /// # impl<T> Selector<Vec<T>> for First {
-/// #    type Error = EmptyPopulationError;
+/// #    type Error = EmptyPopulation;
 /// #
 /// #    fn select<'pop>(
 /// #        &self,
@@ -223,7 +207,7 @@ where
 /// #    ) -> Result<&'pop T, Self::Error> {
 /// #        population
 /// #            .first()
-/// #            .ok_or(EmptyPopulationError)
+/// #            .ok_or(EmptyPopulation)
 /// #    }
 /// # }
 /// #
@@ -303,25 +287,21 @@ mod tests {
 
     use rand::{rng, rngs::ThreadRng};
 
-    use super::{Select, Selector};
+    use super::{Select, Selector, error::EmptyPopulation};
     use crate::operator::{Composable, Operator};
 
     // A simple `Selector`` that always returns the first item in a vector.
     struct First;
 
-    #[derive(Debug, thiserror::Error)]
-    #[error("At least one individual in the population is required to make a selection from it")]
-    struct EmptyPopulationError;
-
     impl<T> Selector<Vec<T>> for First {
-        type Error = EmptyPopulationError;
+        type Error = EmptyPopulation;
 
         fn select<'pop>(
             &self,
             population: &'pop Vec<T>,
             _: &mut ThreadRng,
         ) -> Result<&'pop T, Self::Error> {
-            population.first().ok_or(EmptyPopulationError)
+            population.first().ok_or(EmptyPopulation)
         }
     }
 

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -42,7 +42,7 @@ pub use error::EmptyPopulation;
 /// #
 /// struct First;
 ///
-/// #[derive(Debug, Error)]
+/// #[derive(Debug, thiserror::Error)]
 /// #[error("Should be at least one individual in the population")]
 /// struct EmptyPopulationError;
 ///
@@ -99,24 +99,25 @@ where
 /// selector.
 ///
 /// ```
-/// # use anyhow::Context;
 /// # use rand::{rngs::ThreadRng, rng};
 /// #
 /// # use ec_core::operator::{Operator, selector::{Select, Selector}};
 /// #
 /// struct First; // Simple selector that always returns the first element in a vector.
 ///
+/// #[derive(Debug, thiserror::Error)]
+/// #[error("At least one individual in the population is required to make a selection from it")]
+/// struct EmptyPopulationError;
+///
 /// impl<T> Selector<Vec<T>> for First {
-///     type Error = anyhow::Error;
+///     type Error = EmptyPopulationError;
 ///
 ///     fn select<'pop>(
 ///         &self,
 ///         population: &'pop Vec<T>,
 ///         _: &mut ThreadRng,
-///     ) -> anyhow::Result<&'pop T> {
-///         population
-///             .first()
-///             .context("Should be at least one individual in the population")
+///     ) -> Result<&'pop T, Self::Error> {
+///         population.first().ok_or(EmptyPopulationError)
 ///     }
 /// }
 ///
@@ -131,7 +132,7 @@ where
 ///
 /// let operator_result: &u8 = select.apply(&population, &mut rng())?;
 /// assert_eq!(selector_result, operator_result);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// Because both [`Select`] and [`Operator`] are [`Composable`], we can chain
@@ -142,7 +143,6 @@ where
 /// return the length of that string.
 ///
 /// ```
-/// # use anyhow::Context;
 /// # use rand::{rngs::ThreadRng, rng};
 /// # use std::convert::Infallible;
 /// #
@@ -150,17 +150,21 @@ where
 /// #
 /// # struct First; // Simple selector that always returns the first element in a vector.
 /// #
+/// # #[derive(Debug, thiserror::Error)]
+/// # #[error("Should be at least one individual in the population")]
+/// # struct EmptyPopulationError;
+/// #
 /// # impl<T> Selector<Vec<T>> for First {
-/// #    type Error = anyhow::Error;
+/// #    type Error = EmptyPopulationError;
 /// #
 /// #    fn select<'pop>(
 /// #        &self,
 /// #        population: &'pop Vec<T>,
 /// #        _: &mut ThreadRng,
-/// #    ) -> anyhow::Result<&'pop T> {
+/// #    ) -> Result<&'pop T, Self::Error> {
 /// #        population
 /// #            .first()
-/// #            .context("Should be at least one individual in the population")
+/// #            .ok_or(EmptyPopulationError)
 /// #    }
 /// # }
 /// #
@@ -189,7 +193,7 @@ where
 /// // selector and return its length.
 /// let choice_length: usize = chain.apply(&population, &mut rng())?;
 /// assert_eq!(choice_length, 5);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// We can also pass a _reference_ to a [`Selector`] (i.e., `&Selector`) to
@@ -197,24 +201,29 @@ where
 /// operators without requiring or giving up ownership of the selector.
 ///
 /// ```
-/// # use anyhow::Context;
+/// # use std::convert::Infallible;
+/// #
 /// # use rand::{rngs::ThreadRng, rng};
 /// #
 /// # use ec_core::operator::{Composable, Operator, selector::{Select, Selector}};
 /// #
 /// # struct First; // Simple selector that always returns the first element in a vector.
 /// #
+/// # #[derive(Debug, thiserror::Error)]
+/// # #[error("Should be at least one individual in the population")]
+/// # struct EmptyPopulationError;
+/// #
 /// # impl<T> Selector<Vec<T>> for First {
-/// #    type Error = anyhow::Error;
+/// #    type Error = EmptyPopulationError;
 /// #
 /// #    fn select<'pop>(
 /// #        &self,
 /// #        population: &'pop Vec<T>,
 /// #        _: &mut ThreadRng,
-/// #    ) -> anyhow::Result<&'pop T> {
+/// #    ) -> Result<&'pop T, Self::Error> {
 /// #        population
 /// #            .first()
-/// #            .context("Should be at least one individual in the population")
+/// #            .ok_or(EmptyPopulationError)
 /// #    }
 /// # }
 /// #
@@ -222,9 +231,9 @@ where
 /// #
 /// # impl Operator<&String> for StrLen {
 /// #    type Output = usize;
-/// #    type Error = anyhow::Error;
+/// #    type Error = Infallible;
 /// #
-/// #    fn apply(&self, input: &String, _: &mut ThreadRng) -> anyhow::Result<usize> {
+/// #    fn apply(&self, input: &String, _: &mut ThreadRng) -> Result<usize, Self::Error> {
 /// #        Ok(input.len())
 /// #    }
 /// # }
@@ -235,7 +244,7 @@ where
 /// let population: Vec<String> = vec!["Hello".to_string(), "World".to_string()];
 /// let choice_length: usize = chain.apply(&population, &mut rng())?;
 /// assert_eq!(choice_length, 5);
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Clone)]
 pub struct Select<S> {
@@ -290,7 +299,8 @@ where
 )]
 #[cfg(test)]
 mod tests {
-    use anyhow::Context;
+    use std::convert::Infallible;
+
     use rand::{rng, rngs::ThreadRng};
 
     use super::{Select, Selector};
@@ -299,17 +309,19 @@ mod tests {
     // A simple `Selector`` that always returns the first item in a vector.
     struct First;
 
+    #[derive(Debug, thiserror::Error)]
+    #[error("At least one individual in the population is required to make a selection from it")]
+    struct EmptyPopulationError;
+
     impl<T> Selector<Vec<T>> for First {
-        type Error = anyhow::Error;
+        type Error = EmptyPopulationError;
 
         fn select<'pop>(
             &self,
             population: &'pop Vec<T>,
             _: &mut ThreadRng,
-        ) -> anyhow::Result<&'pop T> {
-            population
-                .first()
-                .context("Should be at least one individual in the population")
+        ) -> Result<&'pop T, Self::Error> {
+            population.first().ok_or(EmptyPopulationError)
         }
     }
 
@@ -322,9 +334,9 @@ mod tests {
         T: AsRef<str>,
     {
         type Output = usize;
-        type Error = anyhow::Error;
+        type Error = Infallible;
 
-        fn apply(&self, input: T, _: &mut ThreadRng) -> anyhow::Result<usize> {
+        fn apply(&self, input: T, _: &mut ThreadRng) -> Result<usize, Self::Error> {
             Ok(input.as_ref().len())
         }
     }

--- a/packages/ec-core/src/operator/selector/random.rs
+++ b/packages/ec-core/src/operator/selector/random.rs
@@ -35,7 +35,7 @@ mod tests {
     #[test]
     fn empty_population() {
         let pop: Vec<i32> = Vec::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         assert!(matches!(
             Random.select(&pop, &mut rng),
             Err(EmptyPopulation)
@@ -44,7 +44,7 @@ mod tests {
 
     #[proptest]
     fn test_random(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let selection = Random.select(&pop, &mut rng).unwrap();
         assert!(pop.contains(selection));
     }

--- a/packages/ec-core/src/operator/selector/tournament.rs
+++ b/packages/ec-core/src/operator/selector/tournament.rs
@@ -107,7 +107,7 @@ where
 mod tests {
     use std::{num::NonZeroUsize, ops::Not};
 
-    use rand::thread_rng;
+    use rand::rng;
     use test_strategy::proptest;
 
     use super::Tournament;
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn empty_population() {
         let pop: Vec<i32> = Vec::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let selector = Tournament::new(NonZeroUsize::MIN);
         let expected_error = TournamentSizeError::new(NonZeroUsize::MIN, 0);
         assert_eq!(selector.select(&pop, &mut rng), Err(expected_error));
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn tournament_size_larger_than_population() {
         let pop: Vec<i32> = vec![0];
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let selector = Tournament::of_size::<2>();
         assert!(matches!(
             selector.select(&pop, &mut rng),
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn tournament_size_1() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let scores = &[5, 8, 9];
         let population = scores
             .iter()
@@ -161,7 +161,7 @@ mod tests {
 
     #[proptest]
     fn tournament_size_2_pop_size_2(#[any] x: i32, #[any] y: i32) {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let scores = &[x, y];
         let population = scores
             .iter()
@@ -179,7 +179,7 @@ mod tests {
         #[filter(|v| *v != #x)] y: i32,
         #[filter(|v| [#x, #y].contains(v).not())] z: i32,
     ) {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         // We know from the filters that all the scores are unique, so the selected
         // score should always be better than the smallest score.
         let scores = &[x, y, z];

--- a/packages/ec-core/src/operator/selector/worst.rs
+++ b/packages/ec-core/src/operator/selector/worst.rs
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     fn empty_population() {
         let pop: Vec<i32> = Vec::new();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         assert!(matches!(Worst.select(&pop, &mut rng), Err(EmptyPopulation)));
     }
 
@@ -47,14 +47,14 @@ mod tests {
         // Once we've generalized `.select()` appropriately we can change this to be
         // an array. See #259
         let pop = vec![5, 8, 9, 6, 3, 2, 10];
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         assert_eq!(&2, Worst.select(&pop, &mut rng).unwrap());
         assert_eq!(&2, Worst.select(&pop, &mut rng).unwrap());
     }
 
     #[proptest]
     fn test_worst_select(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let smallest = pop.iter().min().unwrap();
         assert_eq!(smallest, Worst.select(&pop, &mut rng).unwrap());
     }

--- a/packages/ec-core/src/population.rs
+++ b/packages/ec-core/src/population.rs
@@ -20,7 +20,7 @@ impl<I> Population for Vec<I> {
 mod tests {
     use core::ops::Range;
 
-    use rand::{Rng, prelude::Distribution, thread_rng};
+    use rand::{Rng, prelude::Distribution, rng};
 
     use crate::{distributions::collection::ConvertToCollectionGenerator, population::Population};
 
@@ -31,14 +31,14 @@ mod tests {
     impl Distribution<RandValue> for Range<i32> {
         fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> RandValue {
             RandValue {
-                val: rng.gen_range(self.clone()),
+                val: rng.random_range(self.clone()),
             }
         }
     }
 
     #[test]
     fn generator_works() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let population_size = 10;
         let range = -10..25;
         let vec_pop = range

--- a/packages/ec-core/src/weighted/weighted_pair.rs
+++ b/packages/ec-core/src/weighted/weighted_pair.rs
@@ -114,7 +114,7 @@ mod tests {
 
     #[proptest]
     fn best_or_worst(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         // We'll make a selector that has a 50/50 chance of choosing the highest
         // or lowest value.
         let weighted = Weighted::new(Best, 1)
@@ -127,7 +127,7 @@ mod tests {
 
     #[proptest]
     fn several_selectors(#[map(|v: [i32;10]| v.into())] pop: Vec<i32>) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         // We'll make a selector that has a 50/50 chance of choosing the highest
         // or lowest value.
         let weighted = Weighted::new(Best, 1)
@@ -142,7 +142,7 @@ mod tests {
     #[test]
     fn zero_weight_sum_error() {
         let pop = vec![5, 8, 9, 6, 3, 2, 0];
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let weighted = Weighted::new(Best, 0)
             .with_item_and_weight(Worst, 0)
             .with_item_and_weight(Random, 0)

--- a/packages/ec-linear/Cargo.toml
+++ b/packages/ec-linear/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true, features = ["alloc"] }
 
@@ -24,6 +23,7 @@ thiserror = { workspace = true }
 miette = { workspace = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/packages/ec-linear/Cargo.toml
+++ b/packages/ec-linear/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = { workspace = true }
 miette = { workspace = true }
 
 [dev-dependencies]
-anyhow = { workspace = true }
+miette = { workspace = true, features = ["fancy"] }
 clap = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/packages/ec-linear/Cargo.toml
+++ b/packages/ec-linear/Cargo.toml
@@ -20,6 +20,9 @@ rand = { workspace = true, features = ["alloc"] }
 
 ec-core = { workspace = true }
 
+thiserror = { workspace = true }
+miette = { workspace = true }
+
 [dev-dependencies]
 clap = { workspace = true, features = ["derive"] }
 

--- a/packages/ec-linear/examples/count_ones/main.rs
+++ b/packages/ec-linear/examples/count_ones/main.rs
@@ -33,8 +33,8 @@ use ec_linear::{
     recombinator::two_point_xo::TwoPointXo,
 };
 use rand::{
-    distr::{Distribution, Standard},
-    thread_rng,
+    distr::{Distribution, StandardUniform},
+    rng,
 };
 
 use crate::args::{CliArgs, RunModel};
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
         max_generations,
     } = CliArgs::parse();
 
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     let scorer = FnScorer(|bitstring: &Bitstring| count_ones(&bitstring.bits));
 
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
         .with_selector(Lexicase::new(num_test_cases), 5)
         .with_selector(Tournament::binary(), population_size - 1);
 
-    let population = Standard
+    let population = StandardUniform
         .to_collection_generator(bit_length)
         .with_scorer(scorer)
         .into_collection_generator(population_size)

--- a/packages/ec-linear/examples/count_ones/main.rs
+++ b/packages/ec-linear/examples/count_ones/main.rs
@@ -7,9 +7,6 @@
 
 pub mod args;
 
-use std::ops::Not;
-
-use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::collection::ConvertToCollectionGenerator,
@@ -32,6 +29,7 @@ use ec_linear::{
     genome::bitstring::Bitstring, mutator::with_one_over_length::WithOneOverLength,
     recombinator::two_point_xo::TwoPointXo,
 };
+use miette::ensure;
 use rand::{
     distr::{Distribution, StandardUniform},
     rng,
@@ -44,7 +42,7 @@ pub fn count_ones(bits: &[bool]) -> TestResults<Score<i64>> {
     bits.iter().copied().map(i64::from).collect()
 }
 
-fn main() -> Result<()> {
+fn main() -> miette::Result<()> {
     let CliArgs {
         run_model,
         population_size,
@@ -68,7 +66,10 @@ fn main() -> Result<()> {
         .into_collection_generator(population_size)
         .sample(&mut rng);
 
-    ensure!(population.is_empty().not());
+    ensure!(
+        !population.is_empty(),
+        "An initial populaiton is always required"
+    );
 
     println!("{population:?}");
 

--- a/packages/ec-linear/examples/hiff/main.rs
+++ b/packages/ec-linear/examples/hiff/main.rs
@@ -6,9 +6,8 @@
 
 pub mod args;
 
-use std::{iter::once, ops::Not};
+use std::iter::once;
 
-use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::collection::ConvertToCollectionGenerator,
@@ -31,6 +30,7 @@ use ec_linear::{
     genome::bitstring::Bitstring, mutator::with_one_over_length::WithOneOverLength,
     recombinator::two_point_xo::TwoPointXo,
 };
+use miette::ensure;
 use rand::{distr::StandardUniform, prelude::Distribution, rng};
 
 use crate::args::{CliArgs, RunModel};
@@ -60,7 +60,7 @@ fn hiff(bits: &[bool]) -> (bool, TestResults<Score<usize>>) {
     }
 }
 
-fn main() -> Result<()> {
+fn main() -> miette::Result<()> {
     let CliArgs {
         run_model,
         population_size,
@@ -84,7 +84,10 @@ fn main() -> Result<()> {
         .into_collection_generator(population_size)
         .sample(&mut rng);
 
-    ensure!(population.is_empty().not());
+    ensure!(
+        !population.is_empty(),
+        "An initial populaiton is always required"
+    );
 
     // Let's assume the process will be generational, i.e., we replace the entire
     // population with newly created/selected individuals every generation.

--- a/packages/ec-linear/examples/hiff/main.rs
+++ b/packages/ec-linear/examples/hiff/main.rs
@@ -31,7 +31,7 @@ use ec_linear::{
     genome::bitstring::Bitstring, mutator::with_one_over_length::WithOneOverLength,
     recombinator::two_point_xo::TwoPointXo,
 };
-use rand::{distr::Standard, prelude::Distribution, thread_rng};
+use rand::{distr::StandardUniform, prelude::Distribution, rng};
 
 use crate::args::{CliArgs, RunModel};
 
@@ -68,7 +68,7 @@ fn main() -> Result<()> {
         max_generations,
     } = CliArgs::parse();
 
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     let scorer = FnScorer(|bitstring: &Bitstring| hiff(&bitstring.bits).1);
 
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
         .with_selector(Lexicase::new(num_test_cases), 5)
         .with_selector(Tournament::binary(), population_size - 1);
 
-    let population = Standard
+    let population = StandardUniform
         .into_collection_generator(bit_length)
         .with_scorer(scorer)
         .into_collection_generator(population_size)

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -132,14 +132,26 @@ impl Linear for Bitstring {
 }
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
-#[error("Failed to access gene at position {0}")]
-#[diagnostic(help = "Check that the gene is long enough")]
-pub struct GeneAccess(usize);
+#[error("Index {index} out of bounds for a bitstring of size {bitstring_size}")]
+#[diagnostic(
+    help = "Ensure that your indices are legal, i.e., at least zero and less than the size of the \
+            bitstring"
+)]
+pub struct GeneAccess {
+    index: usize,
+    bitstring_size: usize,
+}
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
-#[error("Failed to access gene at range {}..{}", self.0.start, self.0.end)]
-#[diagnostic(help = "Check that the gene is long enough")]
-pub struct GeneAccessRange(std::ops::Range<usize>);
+#[error("Range {}..{} out of bounds for a bitstring of size {bitstring_size}", range.start, range.end)]
+#[diagnostic(
+    help("Ensure that your range bounds are legal, i.e., the start {} must be at least zero and \
+            the end {} must be at most the size of the bitstring {bitstring_size}", range.start, range.end)
+)]
+pub struct GeneAccessRange {
+    range: std::ops::Range<usize>,
+    bitstring_size: usize,
+}
 
 impl Crossover for Bitstring {
     type GeneCrossoverError = GeneAccess;
@@ -153,7 +165,10 @@ impl Crossover for Bitstring {
             std::mem::swap(lhs, rhs);
             Ok(())
         } else {
-            Err(GeneAccess(index))
+            Err(GeneAccess {
+                index,
+                bitstring_size: self.size(),
+            })
         }
     }
 
@@ -170,7 +185,10 @@ impl Crossover for Bitstring {
             lhs.swap_with_slice(rhs);
             Ok(())
         } else {
-            Err(GeneAccessRange(range))
+            Err(GeneAccessRange {
+                range,
+                bitstring_size: self.size(),
+            })
         }
     }
 }

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use ec_core::{genome::Genome, operator::mutator::Mutator};
 use rand::{Rng, prelude::Distribution, rngs::ThreadRng};
 
@@ -68,11 +70,13 @@ where
     G: Linear + IntoIterator<Item = G::Gene> + FromIterator<G::Gene>,
     GeneGenerator: Distribution<G::Gene>,
 {
-    fn mutate(&self, genome: G, rng: &mut ThreadRng) -> anyhow::Result<G> {
+    type Error = Infallible;
+
+    fn mutate(&self, genome: G, rng: &mut ThreadRng) -> Result<G, Self::Error> {
         if genome.size() == 0 {
             if let Some(addition_rate) = self.empty_addition_rate {
                 return Ok(rng
-                    .gen_bool(addition_rate)
+                    .random_bool(addition_rate)
                     .then(|| self.new_gene::<G>(rng))
                     .into_iter()
                     .collect());
@@ -84,10 +88,10 @@ where
             .flat_map(|gene| {
                 // The body of this closure is due to MizardX@Twitch;
                 // much nicer than my original approach.
-                let add_gene = rng.gen_bool(self.addition_rate);
-                let delete_gene = rng.gen_bool(self.deletion_rate);
+                let add_gene = rng.random_bool(self.addition_rate);
+                let delete_gene = rng.random_bool(self.deletion_rate);
                 // only called when `add_gene` is true
-                let delete_new_gene = add_gene && rng.gen_bool(self.deletion_rate);
+                let delete_new_gene = add_gene && rng.random_bool(self.deletion_rate);
 
                 let old_gene = (!delete_gene).then_some(gene);
 
@@ -115,7 +119,7 @@ where
 )]
 mod test {
     use ec_core::uniform_distribution_of;
-    use rand::thread_rng;
+    use rand::rng;
 
     use super::*;
     use crate::genome::vector::Vector;
@@ -138,7 +142,7 @@ mod test {
     #[test]
     #[ignore = "This is stochastic, and it will fail sometimes"]
     fn umad_test() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let char_options = uniform_distribution_of!['x'];
         let umad = Umad::new(0.3, 0.3, char_options);

--- a/packages/ec-linear/src/mutator/with_one_over_length.rs
+++ b/packages/ec-linear/src/mutator/with_one_over_length.rs
@@ -30,6 +30,8 @@ where
         let mutator = WithRate::new(mutation_rate);
         mutator
             .mutate(genome, rng)
+            // This can't happen, as the only error is the conversion error
+            // since `WithRate::mutator` can't fail.
             .map_err(|_: Infallible| unreachable!())
     }
 }
@@ -50,6 +52,8 @@ where
         let mutator = WithRate::new(mutation_rate);
         mutator
             .mutate(genome, rng)
+            // This can't happen, as the only error is the conversion error
+            // since `WithRate::mutator` can't fail.
             .map_err(|_: Infallible| unreachable!())
     }
 }

--- a/packages/ec-linear/src/mutator/with_one_over_length.rs
+++ b/packages/ec-linear/src/mutator/with_one_over_length.rs
@@ -1,7 +1,7 @@
-use std::ops::Not;
+use std::{convert::Infallible, ops::Not};
 
-use anyhow::{Context, Result};
 use ec_core::operator::mutator::Mutator;
+use miette::Diagnostic;
 use num_traits::ToPrimitive;
 use rand::rngs::ThreadRng;
 
@@ -10,20 +10,27 @@ use crate::genome::Linear;
 
 pub struct WithOneOverLength;
 
+#[derive(Debug, thiserror::Error, Diagnostic)]
+#[error("Failed to convert genome size {0} to an f32 value to be used as the mutation rate")]
+#[diagnostic(help = "Make sure the genome size is representable by an f32 when using this mutator")]
+pub struct GenomeSizeConversionError(usize);
+
 impl<T> Mutator<Vec<T>> for WithOneOverLength
 where
     T: Not<Output = T>,
 {
-    fn mutate(&self, genome: Vec<T>, rng: &mut ThreadRng) -> Result<Vec<T>> {
-        let genome_length = genome.len().to_f32().with_context(|| {
-            format!(
-                "The genome length {} couldn't be converted to an f32 value",
-                genome.len()
-            )
-        })?;
+    type Error = GenomeSizeConversionError;
+
+    fn mutate(&self, genome: Vec<T>, rng: &mut ThreadRng) -> Result<Vec<T>, Self::Error> {
+        let genome_length = genome
+            .len()
+            .to_f32()
+            .ok_or(GenomeSizeConversionError(genome.len()))?;
         let mutation_rate = 1.0 / genome_length;
         let mutator = WithRate::new(mutation_rate);
-        mutator.mutate(genome, rng)
+        mutator
+            .mutate(genome, rng)
+            .map_err(|_: Infallible| unreachable!())
     }
 }
 
@@ -32,16 +39,18 @@ where
     T: Linear + FromIterator<T::Gene> + IntoIterator<Item = T::Gene>,
     T::Gene: Not<Output = T::Gene>,
 {
-    fn mutate(&self, genome: T, rng: &mut ThreadRng) -> Result<T> {
-        let genome_length = genome.size().to_f32().with_context(|| {
-            format!(
-                "The genome length {} couldn't be converted to an f32 value",
-                genome.size()
-            )
-        })?;
+    type Error = GenomeSizeConversionError;
+
+    fn mutate(&self, genome: T, rng: &mut ThreadRng) -> Result<T, Self::Error> {
+        let genome_length = genome
+            .size()
+            .to_f32()
+            .ok_or_else(|| GenomeSizeConversionError(genome.size()))?;
         let mutation_rate = 1.0 / genome_length;
         let mutator = WithRate::new(mutation_rate);
-        mutator.mutate(genome, rng)
+        mutator
+            .mutate(genome, rng)
+            .map_err(|_: Infallible| unreachable!())
     }
 }
 
@@ -60,7 +69,7 @@ mod tests {
     #[test]
     #[ignore = "This test is stochastic, so I'm going to ignore it most of the time."]
     fn mutate_one_over_does_not_change_much() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let num_bits = 100;
         let parent_bits = Bitstring::random(num_bits, &mut rng);
 

--- a/packages/ec-linear/src/mutator/with_rate.rs
+++ b/packages/ec-linear/src/mutator/with_rate.rs
@@ -1,6 +1,5 @@
-use std::ops::Not;
+use std::{convert::Infallible, ops::Not};
 
-use anyhow::Result;
 use ec_core::operator::mutator::Mutator;
 use rand::{Rng, rngs::ThreadRng};
 
@@ -16,7 +15,9 @@ impl<T> Mutator<Vec<T>> for WithRate
 where
     T: Not<Output = T>,
 {
-    fn mutate(&self, genome: Vec<T>, rng: &mut ThreadRng) -> Result<Vec<T>> {
+    type Error = Infallible;
+
+    fn mutate(&self, genome: Vec<T>, rng: &mut ThreadRng) -> Result<Vec<T>, Self::Error> {
         Ok(genome
             .into_iter()
             .map(|bit| {
@@ -35,7 +36,8 @@ where
     T: Linear + FromIterator<T::Gene> + IntoIterator<Item = T::Gene>,
     T::Gene: Not<Output = T::Gene>,
 {
-    fn mutate(&self, genome: T, rng: &mut ThreadRng) -> Result<T> {
+    type Error = Infallible;
+    fn mutate(&self, genome: T, rng: &mut ThreadRng) -> Result<T, Self::Error> {
         Ok(genome
             .into_iter()
             .map(|bit| {
@@ -54,10 +56,6 @@ impl WithRate {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use std::iter::zip;
 
@@ -72,7 +70,7 @@ mod tests {
             mutation_rate: 0.05,
         };
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let num_bits = 100;
 
         let parent_bits = Bitstring::random(num_bits, &mut rng);
@@ -99,7 +97,7 @@ mod tests {
             mutation_rate: 0.05,
         };
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let num_bits = 100;
         let parent_bits = Bitstring::random(num_bits, &mut rng);
         let child_bits = mutator.mutate(parent_bits.clone(), &mut rng).unwrap();

--- a/packages/ec-linear/src/recombinator/crossover.rs
+++ b/packages/ec-linear/src/recombinator/crossover.rs
@@ -5,13 +5,23 @@ use crate::genome::Linear;
 // TODO: Does `Crossover` need to be visible outside
 //   this module? If not, should `pub` be replaced/removed?
 pub trait Crossover: Linear {
+    /// Error that can happen when calling [`Crossover::crossover_gene`].
+    type GeneCrossoverError;
+
+    /// Error that can happen when calling [`Crossover::crossover_segment`].
+    type SegmentCrossoverError;
+
     /// Swaps a gene at a randomly selected position, destructively
     /// modifying both this genome and `other`.
     ///
     /// # Errors
     /// This can fail if an attempt is made to crossover a gene at an index that
     /// is out of bounds for either this genome or `other`.
-    fn crossover_gene(&mut self, other: &mut Self, index: usize) -> anyhow::Result<()>;
+    fn crossover_gene(
+        &mut self,
+        other: &mut Self,
+        index: usize,
+    ) -> Result<(), Self::GeneCrossoverError>;
 
     /// Swaps a segment of this and the `other` genome that starts and
     /// ends at a randomly selected position. This is destructive, modifying
@@ -20,10 +30,9 @@ pub trait Crossover: Linear {
     /// # Errors
     /// This can fail if an attempt is made to crossover a segments whose start
     /// and end are out of bounds for either this genome or `other`.
-    fn crossover_segment(&mut self, other: &mut Self, range: Range<usize>) -> anyhow::Result<()> {
-        for index in range {
-            self.crossover_gene(other, index)?;
-        }
-        Ok(())
-    }
+    fn crossover_segment(
+        &mut self,
+        other: &mut Self,
+        range: Range<usize>,
+    ) -> Result<(), Self::SegmentCrossoverError>;
 }

--- a/packages/ec-linear/src/recombinator/errors.rs
+++ b/packages/ec-linear/src/recombinator/errors.rs
@@ -12,9 +12,17 @@ pub struct DifferentGenomeLength(pub usize, pub usize);
 
 #[derive(Debug)]
 pub enum CrossoverGeneError<E> {
+    /// Attempted to crossover genomes with differing lengths
     DifferentGenomeLength(DifferentGenomeLength),
+    /// Some other error specific to a crossover operation
     Crossover(E),
 }
+
+// We need to hand implement all these traits because `derive` for
+// `thiserror::Error` and `miette::Diagnostic` don't
+// handle generics well in this context. Hopefully that will be fixed in
+// the future and we can simplify this considerably.
+
 impl<E> Error for CrossoverGeneError<E>
 where
     E: Error + 'static,

--- a/packages/ec-linear/src/recombinator/errors.rs
+++ b/packages/ec-linear/src/recombinator/errors.rs
@@ -1,0 +1,95 @@
+use std::{
+    error::Error,
+    fmt::{Debug, Display},
+};
+
+use miette::{Diagnostic, LabeledSpan, Severity, SourceCode};
+
+#[derive(Debug, thiserror::Error, Diagnostic)]
+#[error("Attempted to perform TwoPointXo on genomes of different lengths {0} and {1}")]
+#[diagnostic(help = "Ensure your genomes are of uniform length")]
+pub struct DifferentGenomeLength(pub usize, pub usize);
+
+#[derive(Debug)]
+pub enum CrossoverGeneError<E> {
+    DifferentGenomeLength(DifferentGenomeLength),
+    Crossover(E),
+}
+impl<E> Error for CrossoverGeneError<E>
+where
+    E: Error + 'static,
+    Self: Debug + Display,
+{
+    fn source(&self) -> ::core::option::Option<&(dyn Error + 'static)> {
+        match self {
+            Self::DifferentGenomeLength(transparent) => Error::source(transparent),
+            Self::Crossover(source) => Some(source),
+        }
+    }
+}
+impl<E> Display for CrossoverGeneError<E> {
+    fn fmt(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        match self {
+            Self::DifferentGenomeLength(g) => Display::fmt(&g, formatter),
+            Self::Crossover(_) => formatter.write_str("Failed to crossover segment"),
+        }
+    }
+}
+impl<E> From<DifferentGenomeLength> for CrossoverGeneError<E> {
+    fn from(source: DifferentGenomeLength) -> Self {
+        Self::DifferentGenomeLength(source)
+    }
+}
+impl<E> Diagnostic for CrossoverGeneError<E>
+where
+    E: Error + Diagnostic + 'static,
+{
+    fn code(&self) -> Option<Box<dyn Display + '_>> {
+        match self {
+            Self::DifferentGenomeLength(unnamed, ..) => unnamed.code(),
+            Self::Crossover(unnamed, ..) => unnamed.code(),
+        }
+    }
+    fn help(&self) -> Option<Box<dyn Display + '_>> {
+        match self {
+            Self::DifferentGenomeLength(unnamed, ..) => unnamed.help(),
+            Self::Crossover(unnamed, ..) => unnamed.help(),
+        }
+    }
+    fn severity(&self) -> Option<Severity> {
+        match self {
+            Self::DifferentGenomeLength(unnamed, ..) => unnamed.severity(),
+            Self::Crossover(unnamed, ..) => unnamed.severity(),
+        }
+    }
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        match self {
+            Self::DifferentGenomeLength(unnamed, ..) => unnamed.labels(),
+            Self::Crossover(unnamed, ..) => unnamed.labels(),
+        }
+    }
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        match self {
+            Self::DifferentGenomeLength(unnamed, ..) => unnamed.source_code(),
+            Self::Crossover(unnamed, ..) => unnamed.source_code(),
+        }
+    }
+    fn related(&self) -> Option<Box<dyn Iterator<Item = &dyn Diagnostic> + '_>> {
+        match self {
+            Self::DifferentGenomeLength(unnamed, ..) => unnamed.related(),
+            Self::Crossover(unnamed, ..) => unnamed.related(),
+        }
+    }
+    fn url(&self) -> Option<Box<dyn Display + '_>> {
+        match self {
+            Self::DifferentGenomeLength(unnamed, ..) => unnamed.url(),
+            Self::Crossover(unnamed, ..) => unnamed.url(),
+        }
+    }
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        match self {
+            Self::DifferentGenomeLength(unnamed, ..) => unnamed.diagnostic_source(),
+            Self::Crossover(unnamed, ..) => unnamed.diagnostic_source(),
+        }
+    }
+}

--- a/packages/ec-linear/src/recombinator/mod.rs
+++ b/packages/ec-linear/src/recombinator/mod.rs
@@ -1,3 +1,4 @@
 pub mod crossover;
+pub mod errors;
 pub mod two_point_xo;
 pub mod uniform_xo;

--- a/packages/ec-linear/src/recombinator/uniform_xo.rs
+++ b/packages/ec-linear/src/recombinator/uniform_xo.rs
@@ -1,8 +1,10 @@
-use anyhow::{Result, ensure};
 use ec_core::operator::recombinator::Recombinator;
 use rand::{Rng, rngs::ThreadRng};
 
-use super::crossover::Crossover;
+use super::{
+    crossover::Crossover,
+    errors::{CrossoverGeneError, DifferentGenomeLength},
+};
 
 pub struct UniformXo;
 
@@ -10,19 +12,17 @@ pub struct UniformXo;
 //   we've completed the migration to a struct-based `Bitstring`.
 impl<T: Clone> Recombinator<[Vec<T>; 2]> for UniformXo {
     type Output = Vec<T>;
+    type Error = DifferentGenomeLength;
 
     fn recombine(
         &self,
         [first_genome, second_genome]: [Vec<T>; 2],
         rng: &mut ThreadRng,
-    ) -> Result<Self::Output> {
-        ensure!(
-            first_genome.len() == second_genome.len(),
-            "Attempted to perform UniformXo on genomes of different length: {} and {}",
-            first_genome.len(),
-            second_genome.len()
-        );
+    ) -> Result<Self::Output, Self::Error> {
         let len = first_genome.len();
+        if len != second_genome.len() {
+            return Err(DifferentGenomeLength(len, second_genome.len()));
+        }
         Ok((0..len)
             .map(|pos| {
                 if rng.random::<bool>() {
@@ -37,8 +37,13 @@ impl<T: Clone> Recombinator<[Vec<T>; 2]> for UniformXo {
 
 impl<T: Clone> Recombinator<(Vec<T>, Vec<T>)> for UniformXo {
     type Output = Vec<T>;
+    type Error = <Self as Recombinator<[Vec<T>; 2]>>::Error;
 
-    fn recombine(&self, genomes: (Vec<T>, Vec<T>), rng: &mut ThreadRng) -> Result<Self::Output> {
+    fn recombine(
+        &self,
+        genomes: (Vec<T>, Vec<T>),
+        rng: &mut ThreadRng,
+    ) -> Result<Self::Output, Self::Error> {
         self.recombine(<[Vec<T>; 2]>::from(genomes), rng)
     }
 }
@@ -48,22 +53,22 @@ where
     G: Crossover,
 {
     type Output = G;
+    type Error = CrossoverGeneError<G::GeneCrossoverError>;
 
     fn recombine(
         &self,
         [mut first_genome, mut second_genome]: [G; 2],
         rng: &mut ThreadRng,
-    ) -> Result<Self::Output> {
-        ensure!(
-            first_genome.size() == second_genome.size(),
-            "Attempted to perform UniformXo on genomes of different length: {} and {}",
-            first_genome.size(),
-            second_genome.size()
-        );
+    ) -> Result<Self::Output, Self::Error> {
         let len = first_genome.size();
+        if len != second_genome.size() {
+            return Err(DifferentGenomeLength(len, second_genome.size()).into());
+        }
         for i in 0..len {
             if rng.random::<bool>() {
-                first_genome.crossover_gene(&mut second_genome, i)?;
+                first_genome
+                    .crossover_gene(&mut second_genome, i)
+                    .map_err(CrossoverGeneError::Crossover)?;
             }
         }
 
@@ -76,8 +81,9 @@ where
     G: Crossover,
 {
     type Output = G;
+    type Error = <Self as Recombinator<[G; 2]>>::Error;
 
-    fn recombine(&self, genomes: (G, G), rng: &mut ThreadRng) -> Result<Self::Output> {
+    fn recombine(&self, genomes: (G, G), rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
         self.recombine(<[G; 2]>::from(genomes), rng)
     }
 }

--- a/packages/push/Cargo.toml
+++ b/packages/push/Cargo.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 num-traits = { workspace = true }
 rand = { workspace = true , features = ["alloc"] }
 thiserror = { workspace = true }
+miette = { workspace = true }
 
 ec-core = { workspace = true }
 ec-linear = { workspace = true }
@@ -33,7 +34,7 @@ macro_railroad_annotation = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
 
 [dev-dependencies]
-anyhow = { workspace = true }
+miette = { workspace = true, features = ["fancy"]}
 clap = { version = "4.5.1", features = ["derive"] }
 proptest = { workspace = true }
 test-strategy = { workspace = true }

--- a/packages/push/Cargo.toml
+++ b/packages/push/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true , features = ["alloc"] }
 thiserror = { workspace = true }
@@ -34,6 +33,7 @@ macro_railroad_annotation = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 clap = { version = "4.5.1", features = ["derive"] }
 proptest = { workspace = true }
 test-strategy = { workspace = true }

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -33,7 +33,7 @@ use push::{
     instruction::{FloatInstruction, PushInstruction, variable_name::VariableName},
     push_vm::{HasStack, State, program::PushProgram, push_state::PushState},
 };
-use rand::{prelude::Distribution, thread_rng};
+use rand::{prelude::Distribution, rng};
 
 use crate::args::{CliArgs, RunModel};
 
@@ -113,7 +113,7 @@ fn main() -> Result<()> {
         ..
     } = CliArgs::parse();
 
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     // Inputs from -4 (inclusive) to 4 (exclusive) in increments of 0.25.
     let training_cases = (-4 * 4..4 * 4)

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -6,9 +6,6 @@
 
 pub mod args;
 
-use std::ops::Not;
-
-use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::collection::ConvertToCollectionGenerator,
@@ -25,6 +22,7 @@ use ec_core::{
     uniform_distribution_of,
 };
 use ec_linear::mutator::umad::Umad;
+use miette::ensure;
 use num_traits::Float;
 use ordered_float::OrderedFloat;
 use push::{
@@ -103,7 +101,7 @@ fn score_genome(
         .collect()
 }
 
-fn main() -> Result<()> {
+fn main() -> miette::Result<()> {
     // FIXME: Respect the max_genome_length input
     let CliArgs {
         run_model,
@@ -157,7 +155,10 @@ fn main() -> Result<()> {
         .into_collection_generator(population_size)
         .sample(&mut rng);
 
-    ensure!(population.is_empty().not());
+    ensure!(
+        !population.is_empty(),
+        "An initial populaiton is always required"
+    );
 
     let best = Best.select(&population, &mut rng)?;
     println!("Best initial individual is {best}");

--- a/packages/push/examples/median/main.rs
+++ b/packages/push/examples/median/main.rs
@@ -30,7 +30,7 @@ use push::{
 use rand::{
     Rng,
     distr::{Distribution, Uniform},
-    thread_rng,
+    rng,
 };
 use strum::IntoEnumIterator;
 
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
         ..
     } = CliArgs::parse();
 
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     let training_cases = Uniform::new(lower_input_bound, upper_input_bound)?
         .sample_iter(&mut rng)

--- a/packages/push/examples/median/main.rs
+++ b/packages/push/examples/median/main.rs
@@ -1,8 +1,5 @@
 pub mod args;
 
-use std::ops::Not;
-
-use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::{collection::ConvertToCollectionGenerator, conversion::IntoDistribution},
@@ -18,6 +15,7 @@ use ec_core::{
     test_results::{self, TestResults},
 };
 use ec_linear::mutator::umad::Umad;
+use miette::{IntoDiagnostic, ensure};
 use push::{
     evaluation::{Case, Cases, WithTargetFn},
     genome::plushy::{GeneGenerator, Plushy},
@@ -70,7 +68,7 @@ impl Distribution<Input> for Uniform<i64> {
 //
 // This problem is quite easy if you have both `Min` and `Max` instructions, but
 // can be more difficult without those instruction.
-fn main() -> Result<()> {
+fn main() -> miette::Result<()> {
     let CliArgs {
         run_model,
         population_size,
@@ -85,7 +83,8 @@ fn main() -> Result<()> {
 
     let mut rng = rng();
 
-    let training_cases = Uniform::new(lower_input_bound, upper_input_bound)?
+    let training_cases = Uniform::new(lower_input_bound, upper_input_bound)
+        .into_diagnostic()?
         .sample_iter(&mut rng)
         .take(num_training_cases)
         .with_target_fn(Input::median);
@@ -105,7 +104,10 @@ fn main() -> Result<()> {
         .into_collection_generator(population_size)
         .sample(&mut rng);
 
-    ensure!(population.is_empty().not());
+    ensure!(
+        !population.is_empty(),
+        "An initial populaiton is always required"
+    );
 
     let best = Best.select(&population, &mut rng)?;
     println!("Best initial individual is {best}");

--- a/packages/push/examples/simple_regression/main.rs
+++ b/packages/push/examples/simple_regression/main.rs
@@ -36,7 +36,7 @@ use push::{
     instruction::{FloatInstruction, PushInstruction, variable_name::VariableName},
     push_vm::{HasStack, State, program::PushProgram, push_state::PushState},
 };
-use rand::{distr::Distribution, thread_rng};
+use rand::{distr::Distribution, rng};
 
 use crate::args::{CliArgs, RunModel};
 
@@ -116,7 +116,7 @@ fn main() -> Result<()> {
         ..
     } = CliArgs::parse();
 
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     // Inputs from -4 (inclusive) to 4 (exclusive) in increments of 0.25.
     let training_cases = (-4 * 4..4 * 4)

--- a/packages/push/examples/simple_regression/main.rs
+++ b/packages/push/examples/simple_regression/main.rs
@@ -6,9 +6,6 @@
 
 pub mod args;
 
-use std::ops::Not;
-
-use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::collection::ConvertToCollectionGenerator,
@@ -28,6 +25,7 @@ use ec_core::{
     uniform_distribution_of,
 };
 use ec_linear::mutator::umad::Umad;
+use miette::ensure;
 use num_traits::Float;
 use ordered_float::OrderedFloat;
 use push::{
@@ -106,7 +104,7 @@ fn score_genome(
         .collect()
 }
 
-fn main() -> Result<()> {
+fn main() -> miette::Result<()> {
     // FIXME: Respect the max_genome_length input
     let CliArgs {
         run_model,
@@ -155,7 +153,10 @@ fn main() -> Result<()> {
         .into_collection_generator(population_size)
         .sample(&mut rng);
 
-    ensure!(population.is_empty().not());
+    ensure!(
+        !population.is_empty(),
+        "An initial populaiton is always required"
+    );
 
     let best = Best.select(&population, &mut rng)?;
     println!("Best initial individual is {best}");

--- a/packages/push/examples/smallest/main.rs
+++ b/packages/push/examples/smallest/main.rs
@@ -1,8 +1,5 @@
 pub mod args;
 
-use std::ops::Not;
-
-use anyhow::{Result, ensure};
 use clap::Parser;
 use ec_core::{
     distributions::{collection::ConvertToCollectionGenerator, conversion::IntoDistribution},
@@ -18,6 +15,7 @@ use ec_core::{
     test_results::{self, TestResults},
 };
 use ec_linear::mutator::umad::Umad;
+use miette::{IntoDiagnostic, ensure};
 use push::{
     evaluation::{Case, Cases, WithTargetFn},
     genome::plushy::{GeneGenerator, Plushy},
@@ -75,7 +73,7 @@ struct Output(i64);
 //
 // This problem is quite easy if you have a `Min` instruction, but can be
 // more a bit more difficult without that instruction.
-fn main() -> Result<()> {
+fn main() -> miette::Result<()> {
     let CliArgs {
         run_model,
         population_size,
@@ -90,7 +88,8 @@ fn main() -> Result<()> {
 
     let mut rng = rng();
 
-    let training_cases = Uniform::new(lower_input_bound, upper_input_bound)?
+    let training_cases = Uniform::new(lower_input_bound, upper_input_bound)
+        .into_diagnostic()?
         .sample_iter(&mut rng)
         .take(num_training_cases)
         .with_target_fn(Input::smallest);
@@ -110,7 +109,10 @@ fn main() -> Result<()> {
         .into_collection_generator(population_size)
         .sample(&mut rng);
 
-    ensure!(population.is_empty().not());
+    ensure!(
+        !population.is_empty(),
+        "An initial populaiton is always required"
+    );
 
     let best = Best.select(&population, &mut rng)?;
     println!("Best initial individual is {best}");

--- a/packages/push/examples/smallest/main.rs
+++ b/packages/push/examples/smallest/main.rs
@@ -29,7 +29,7 @@ use push::{
 };
 use rand::{
     distr::{Distribution, Uniform},
-    thread_rng,
+    rng,
 };
 use strum::IntoEnumIterator;
 
@@ -88,7 +88,7 @@ fn main() -> Result<()> {
         ..
     } = CliArgs::parse();
 
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     let training_cases = Uniform::new(lower_input_bound, upper_input_bound)?
         .sample_iter(&mut rng)

--- a/packages/push/src/genome/plushy.rs
+++ b/packages/push/src/genome/plushy.rs
@@ -245,17 +245,13 @@ impl FromIterator<PushGene> for Plushy {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod test {
     use ec_core::{
         distributions::collection::ConvertToCollectionGenerator, operator::mutator::Mutator,
         uniform_distribution_of,
     };
     use ec_linear::mutator::umad::Umad;
-    use rand::thread_rng;
+    use rand::rng;
 
     use super::*;
     use crate::{
@@ -265,7 +261,7 @@ mod test {
 
     #[test]
     fn generator() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let plushy: Plushy = uniform_distribution_of![<PushInstruction>
             IntInstruction::Add,
             IntInstruction::Subtract,
@@ -283,7 +279,7 @@ mod test {
                 runners in ci"]
     #[test]
     fn umad() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let instruction_options = uniform_distribution_of![<PushGene> VariableName::from("x")];
 

--- a/packages/push/src/instruction/instruction_error.rs
+++ b/packages/push/src/instruction/instruction_error.rs
@@ -1,15 +1,26 @@
+use miette::Diagnostic;
+
 use super::IntInstructionError;
 use crate::push_vm::stack::StackError;
 
 /// An error that can occur when performing a `PushInstruction`.
-#[derive(thiserror::Error, Debug, Eq, PartialEq)]
+#[derive(thiserror::Error, Debug, Eq, PartialEq, Diagnostic)]
 pub enum PushInstructionError {
     /// Stack errors can be things like stack over- or underflows.
     #[error(transparent)]
-    StackError(#[from] StackError),
+    StackError(
+        #[from]
+        #[diagnostic_source]
+        StackError,
+    ),
     #[error("Exceeded the maximum step limit {step_limit}")]
+    #[diagnostic(help = "You might want to increase your step limit.")]
     StepLimitExceeded { step_limit: usize },
     /// Int errors can be things like integer overflows.
     #[error(transparent)]
-    Int(#[from] IntInstructionError),
+    Int(
+        #[from]
+        #[diagnostic_source]
+        IntInstructionError,
+    ),
 }

--- a/packages/push/src/instruction/instruction_error.rs
+++ b/packages/push/src/instruction/instruction_error.rs
@@ -14,7 +14,13 @@ pub enum PushInstructionError {
         StackError,
     ),
     #[error("Exceeded the maximum step limit {step_limit}")]
-    #[diagnostic(help = "You might want to increase your step limit.")]
+    // The `StepLimitExceeded` variant is usually not seen by the user as it is
+    // typically processed by the interpreter, and a value from the appropriate
+    // stack is returned.
+    #[diagnostic(
+        help = "You might want to increase your step limit if {step_limit} seems too low, or else \
+                an infinite (or very large) loop may have occurred."
+    )]
     StepLimitExceeded { step_limit: usize },
     /// Int errors can be things like integer overflows.
     #[error(transparent)]

--- a/packages/push/src/instruction/int/mod.rs
+++ b/packages/push/src/instruction/int/mod.rs
@@ -1,6 +1,7 @@
 mod abs;
 mod negate;
 
+use miette::Diagnostic;
 use strum_macros::EnumIter;
 
 use self::{abs::Abs, negate::Negate};
@@ -64,9 +65,13 @@ impl From<IntInstruction> for PushInstruction {
     }
 }
 
-#[derive(thiserror::Error, Debug, Eq, PartialEq)]
+#[derive(thiserror::Error, Debug, Eq, PartialEq, Diagnostic)]
 pub enum IntInstructionError {
     #[error("Integer arithmetic overflow for instruction {op}")]
+    #[diagnostic(
+        help = "If you run into this too often you might want to use the saturating or wrapping \
+                arithmetic instruction set instead."
+    )]
     Overflow {
         op: IntInstruction,
         // I liked the idea of keeping track of the arguments to the instruction

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -1,4 +1,5 @@
 use collectable::TryExtend;
+use miette::Diagnostic;
 
 use crate::error::{Error, InstructionResult, MapInstructionError};
 
@@ -83,14 +84,16 @@ pub trait HasStack<T> {
     }
 }
 
-#[derive(thiserror::Error, Debug, Eq, PartialEq)]
+#[derive(thiserror::Error, Debug, Eq, PartialEq, Diagnostic)]
 pub enum StackError {
     #[error("Requested {num_requested} elements from stack with {num_present} elements.")]
+    #[diagnostic(severity(Warning))]
     Underflow {
         num_requested: usize,
         num_present: usize,
     },
     #[error("Pushed onto full stack of type {stack_type}.")]
+    #[diagnostic(help = "You might want to increase your stack size", severity(Warning))]
     Overflow { stack_type: &'static str },
 }
 

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -93,7 +93,13 @@ pub enum StackError {
         num_present: usize,
     },
     #[error("Pushed onto full stack of type {stack_type}.")]
-    #[diagnostic(help = "You might want to increase your stack size", severity(Warning))]
+    // The `Overflow` variant is usually not seen by the user as it is
+    // typically processed by the interpreter, and a value from the appropriate
+    // stack is returned.
+    #[diagnostic(
+        help = "You might want to increase your stack size if it seems to low",
+        severity(Warning)
+    )]
     Overflow { stack_type: &'static str },
 }
 


### PR DESCRIPTION
This migrates the remaining code inside the lib crates away from `anyhow`.
As part of the migration I've also ran `cargo update` to update the dependencies to the latest semver-compatible versions, so the following changes might also be observed inside this pr:
- Migrating away from deprecated `rand` code
- Updating the Cargo.lock

Notes / Fixmes (Create issues for this if not fixed by time of merging this pr), checkmarks indicate fixed:

- [x] Potentially breaking: This currently "dealt with" error types in the `map` operator by just returning the error from the applied operator directly. This isn't ideal, as this loses context we had before (using .context) of where the error occurred. Instead, create a simple newtype error wrapper (with a  '#[from]` impl) for the error which adds some context. 

