### PR TITLE
Move from static `ThreadRng` parameter to generic `R: Rng + ?Sized`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ name = "ec-core"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "ec_macros",
  "itertools 0.13.0",
  "macro_railroad_annotation",
  "miette",
@@ -369,6 +370,16 @@ dependencies = [
  "rand 0.9.0-beta.1",
  "static_assertions",
  "thiserror",
+]
+
+[[package]]
+name = "ec_macros"
+version = "0.1.0"
+dependencies = [
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "proptest",
  "rand 0.9.0-beta.1",
  "rayon",
+ "static_assertions",
  "test-strategy",
  "thiserror",
 ]
@@ -366,6 +367,7 @@ dependencies = [
  "miette",
  "num-traits",
  "rand 0.9.0-beta.1",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -861,6 +863,7 @@ dependencies = [
  "proptest",
  "push_macros",
  "rand 0.9.0-beta.1",
+ "static_assertions",
  "strum",
  "strum_macros",
  "test-case",
@@ -1127,6 +1130,12 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ criterion = "0.5.1"
 miette = "7.4.0"
 test-case = "3.3.1"
 polonius-the-crab = "0.4.2"
+static_assertions = "1.1.0"
 
 ec-core = { path = "packages/ec-core" }
 ec-linear = { path = "packages/ec-linear" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ ec-core = { path = "packages/ec-core" }
 ec-linear = { path = "packages/ec-linear" }
 push = { path = "packages/push" }
 push_macros = { path = "packages/push-macros" }
+ec_macros = { path = "packages/ec-macros" }
 
 
 [workspace.lints.clippy]

--- a/packages/ec-core/Cargo.toml
+++ b/packages/ec-core/Cargo.toml
@@ -28,6 +28,7 @@ macro_railroad_annotation = { workspace = true }
 thiserror = { workspace = true }
 miette = { workspace = true }
 polonius-the-crab = { workspace = true }
+static_assertions = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["alloc", "small_rng"] }
@@ -35,6 +36,10 @@ criterion = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
 proptest = { workspace = true }
 test-strategy = { workspace = true }
+
+[features]
+default = ["erased"]
+erased = []
 
 [lints]
 workspace = true

--- a/packages/ec-core/Cargo.toml
+++ b/packages/ec-core/Cargo.toml
@@ -40,6 +40,8 @@ test-strategy = { workspace = true }
 
 [features]
 default = ["erased"]
+# This enables dyn-compatible versions of dyn-incompatible
+# traits in this library.
 erased = []
 
 [lints]

--- a/packages/ec-core/Cargo.toml
+++ b/packages/ec-core/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = { workspace = true }
 miette = { workspace = true }
 polonius-the-crab = { workspace = true }
 static_assertions = { workspace = true }
+ec_macros = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["alloc", "small_rng"] }

--- a/packages/ec-core/src/child_maker.rs
+++ b/packages/ec-core/src/child_maker.rs
@@ -1,4 +1,13 @@
-use rand::rngs::ThreadRng;
+#[cfg(feature = "erased")]
+use std::{
+    cell::{Ref, RefMut},
+    rc::Rc,
+    sync::Arc,
+};
+
+use rand::Rng;
+#[cfg(feature = "erased")]
+use rand::RngCore;
 
 use crate::{operator::selector::Selector, population::Population};
 
@@ -23,46 +32,109 @@ where
     ///
     /// This can return errors if any aspect of creating this child fail.
     /// That can include constructing or scoring the genome.
-    fn make_child(
+    fn make_child<R: Rng + ?Sized>(
         &self,
-        rng: &mut ThreadRng,
+        rng: &mut R,
         population: &P,
         selector: &S,
     ) -> Result<P::Individual, Self::Error>;
 }
 
-impl<P, S, T> ChildMaker<P, S> for &T
+#[cfg(feature = "erased")]
+pub trait DynChildMaker<P, S, E = Box<dyn std::error::Error + Send + Sync>>
 where
     P: Population,
     S: Selector<P>,
-    T: ChildMaker<P, S>,
 {
-    type Error = T::Error;
-
-    fn make_child(
+    /// # Errors
+    ///
+    /// This can return errors if any aspect of creating this child fail.
+    /// That can include constructing or scoring the genome.
+    fn dyn_make_child(
         &self,
-        rng: &mut ThreadRng,
+        rng: &mut dyn RngCore,
         population: &P,
         selector: &S,
-    ) -> Result<<P as Population>::Individual, Self::Error> {
-        (**self).make_child(rng, population, selector)
-    }
+    ) -> Result<P::Individual, E>;
 }
 
-impl<P, S, T> ChildMaker<P, S> for &mut T
+#[cfg(feature = "erased")]
+static_assertions::assert_obj_safe!(DynChildMaker<(), ()>);
+
+#[cfg(feature = "erased")]
+impl<T, P, S, E> DynChildMaker<P, S, E> for T
 where
+    T: ChildMaker<P, S, Error: Into<E>>,
     P: Population,
     S: Selector<P>,
-    T: ChildMaker<P, S>,
 {
-    type Error = T::Error;
-
-    fn make_child(
+    fn dyn_make_child(
         &self,
-        rng: &mut ThreadRng,
+        rng: &mut dyn RngCore,
         population: &P,
         selector: &S,
-    ) -> Result<<P as Population>::Individual, Self::Error> {
-        (**self).make_child(rng, population, selector)
+    ) -> Result<<P as Population>::Individual, E> {
+        self.make_child(rng, population, selector)
+            .map_err(Into::into)
     }
 }
+
+#[cfg(feature = "erased")]
+macro_rules! dyn_child_maker_impl {
+    ($t: ty) => {
+        #[cfg(feature = "erased")]
+        impl<P, S, E> ChildMaker<P, S> for $t
+        where
+            P: Population,
+            S: Selector<P>
+        {
+            type Error = E;
+
+            fn make_child<R: Rng + ?Sized>(
+                &self,
+                mut rng: &mut R,
+                population: &P,
+                selector: &S,
+            ) -> Result<P::Individual, Self::Error> {
+                (**self).dyn_make_child(&mut rng, population, selector)
+            }
+        }
+    };
+    ($($t: ty),+ $(,)?) => {
+        $(dyn_child_maker_impl!($t);)+
+    }
+}
+
+#[cfg(feature = "erased")]
+// TODO: Create a macro to do this in a nicer way without needing to manually
+// repeat all the pointer types everywhere we provide a type erased trait
+dyn_child_maker_impl!(
+    &dyn DynChildMaker<P, S, E>,
+    &(dyn DynChildMaker<P, S, E> + Send),
+    &(dyn DynChildMaker<P, S, E> + Sync),
+    &(dyn DynChildMaker<P, S, E> + Send + Sync),
+    &mut dyn DynChildMaker<P, S, E>,
+    &mut (dyn DynChildMaker<P, S, E> + Send),
+    &mut (dyn DynChildMaker<P, S, E> + Sync),
+    &mut (dyn DynChildMaker<P, S, E> + Send + Sync),
+    Box<dyn DynChildMaker<P, S, E>>,
+    Box<dyn DynChildMaker<P, S, E> + Send>,
+    Box<dyn DynChildMaker<P, S, E> + Sync>,
+    Box<dyn DynChildMaker<P, S, E> + Send + Sync>,
+    Arc<dyn DynChildMaker<P, S, E>>,
+    Arc<dyn DynChildMaker<P, S, E> + Send>,
+    Arc<dyn DynChildMaker<P, S, E> + Sync>,
+    Arc<dyn DynChildMaker<P, S, E> + Send + Sync>,
+    Rc<dyn DynChildMaker<P, S, E>>,
+    Rc<dyn DynChildMaker<P, S, E> + Send>,
+    Rc<dyn DynChildMaker<P, S, E> + Sync>,
+    Rc<dyn DynChildMaker<P, S, E> + Send + Sync>,
+    Ref<'_, dyn DynChildMaker<P, S, E>>,
+    Ref<'_, dyn DynChildMaker<P, S, E> + Send>,
+    Ref<'_, dyn DynChildMaker<P, S, E> + Sync>,
+    Ref<'_, dyn DynChildMaker<P, S, E> + Send + Sync>,
+    RefMut<'_, dyn DynChildMaker<P, S, E>>,
+    RefMut<'_, dyn DynChildMaker<P, S, E> + Send>,
+    RefMut<'_, dyn DynChildMaker<P, S, E> + Sync>,
+    RefMut<'_, dyn DynChildMaker<P, S, E> + Send + Sync>,
+);

--- a/packages/ec-core/src/child_maker/erased.rs
+++ b/packages/ec-core/src/child_maker/erased.rs
@@ -3,6 +3,53 @@ use rand::{Rng, RngCore};
 use super::ChildMaker;
 use crate::{operator::selector::Selector, population::Population};
 
+/// Erased
+/// ([dyn-compatible](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility))
+/// version of the [`ChildMaker`] trait
+///
+/// # How does this work?
+///
+/// The `erased` pattern in rust aids in type-erasure for traits
+/// that aren't themselves dyn-compatible by declaring a dyn-compatible
+/// extension trait wrapper for the original trait and blanket-implementing
+/// that for all types which implement the original trait.
+///
+/// In this case, the trait [`DynChildMaker`] can be seen as a dyn-compatible
+/// version of the [`ChildMaker`] trait, and any `T: ChildMaker` can also be
+/// interpreted as [`T: DynChildMaker`]
+///
+/// This allows you to use `dyn DynChildMaker<>` trait objects to perform type
+/// erasure on types implementing the [`ChildMaker`] trait.
+///
+/// # When to use it?
+///
+/// The original trait most of the time has a reason for not beeing
+/// dyn-compatible. As such, usually the erased variants of traits come with
+/// performance tradeoffs, and [`DynChildMaker`] is of course no exception
+/// either, since it introduces additonal indirection and vtable-lookups.
+///
+/// Please prefer the [`ChildMaker`] trait whenever possible.
+///
+/// # How to use it?
+///
+/// tl;dr: use [`dyn DynChildMaker<>`](DynChildMaker) instead of `dyn
+/// ChildMaker<>` and still use all the usual [`ChildMaker`] methods elsewhere.
+///
+/// This trait tries to provide some useful ergonomics to ease the interaction
+/// with existing [`ChildMaker`] code.
+/// For example, many common pointer types in Rust pointing to a [`dyn
+/// DynChildMaker<I>`](DynChildMaker) also implement the [`ChildMaker`] trait
+/// themselves, so you most likely do not need to interact with this trait
+/// directly.
+///
+/// For example: [`Box<dyn DynChildMaker<>>`] implements
+/// [`ChildMaker<>`](ChildMaker) and as such you can directly call
+/// [`.make_child()`](ChildMaker::make_child) on it and do not need to use
+/// [`DynChildMaker::dyn_make_child`].
+///
+/// This also means, any [`Box<dyn DynChildMaker<()>>`] can be passed to generic
+/// functions expecting an [`ChildMaker`], like `fn foo(t: impl
+/// ChildMaker<>);`.
 pub trait DynChildMaker<P, S, E = Box<dyn std::error::Error + Send + Sync>>
 where
     P: Population,

--- a/packages/ec-core/src/child_maker/erased.rs
+++ b/packages/ec-core/src/child_maker/erased.rs
@@ -1,37 +1,8 @@
-use rand::Rng;
+use rand::{Rng, RngCore};
 
+use super::ChildMaker;
 use crate::{operator::selector::Selector, population::Population};
 
-// TODO: esitsu@Twitch: "In my world the ChildMaker becomes
-//   an operator that scores". So this could just be
-//   something that takes a `genome` and returns a
-//   scored `Individual`. That would be a lot cleaner.
-// #[deprecated(note = "Turn this into a genome->Individual operator")]
-pub trait ChildMaker<P, S>
-where
-    P: Population,
-    S: Selector<P>,
-{
-    type Error;
-
-    // TODO: Instead of passing 2/3 of  Generation` to this function, is there a
-    // trait  we can have `Generation` implement, and pass in a reference to
-    // something implementing  that trait instead? The trait would presumably
-    // implement the `get_parent()` method  or similar.
-    //
-    /// # Errors
-    ///
-    /// This can return errors if any aspect of creating this child fail.
-    /// That can include constructing or scoring the genome.
-    fn make_child<R: Rng + ?Sized>(
-        &self,
-        rng: &mut R,
-        population: &P,
-        selector: &S,
-    ) -> Result<P::Individual, Self::Error>;
-}
-
-#[cfg(feature = "erased")]
 pub trait DynChildMaker<P, S, E = Box<dyn std::error::Error + Send + Sync>>
 where
     P: Population,
@@ -43,16 +14,14 @@ where
     /// That can include constructing or scoring the genome.
     fn dyn_make_child(
         &self,
-        rng: &mut dyn rand::RngCore,
+        rng: &mut dyn RngCore,
         population: &P,
         selector: &S,
     ) -> Result<P::Individual, E>;
 }
 
-#[cfg(feature = "erased")]
 static_assertions::assert_obj_safe!(DynChildMaker<(), ()>);
 
-#[cfg(feature = "erased")]
 impl<T, P, S, E> DynChildMaker<P, S, E> for T
 where
     T: ChildMaker<P, S, Error: Into<E>>,
@@ -61,7 +30,7 @@ where
 {
     fn dyn_make_child(
         &self,
-        rng: &mut dyn rand::RngCore,
+        rng: &mut dyn RngCore,
         population: &P,
         selector: &S,
     ) -> Result<<P as Population>::Individual, E> {
@@ -70,7 +39,6 @@ where
     }
 }
 
-#[cfg(feature = "erased")]
 #[ec_macros::dyn_ref_impls]
 impl<P, S, E> ChildMaker<P, S> for &dyn DynChildMaker<P, S, E>
 where

--- a/packages/ec-core/src/child_maker/mod.rs
+++ b/packages/ec-core/src/child_maker/mod.rs
@@ -1,0 +1,37 @@
+use rand::Rng;
+
+use crate::{operator::selector::Selector, population::Population};
+
+#[cfg(feature = "erased")]
+mod erased;
+#[cfg(feature = "erased")]
+pub use erased::*;
+
+// TODO: esitsu@Twitch: "In my world the ChildMaker becomes
+//   an operator that scores". So this could just be
+//   something that takes a `genome` and returns a
+//   scored `Individual`. That would be a lot cleaner.
+// #[deprecated(note = "Turn this into a genome->Individual operator")]
+pub trait ChildMaker<P, S>
+where
+    P: Population,
+    S: Selector<P>,
+{
+    type Error;
+
+    // TODO: Instead of passing 2/3 of  Generation` to this function, is there a
+    // trait  we can have `Generation` implement, and pass in a reference to
+    // something implementing  that trait instead? The trait would presumably
+    // implement the `get_parent()` method  or similar.
+    //
+    /// # Errors
+    ///
+    /// This can return errors if any aspect of creating this child fail.
+    /// That can include constructing or scoring the genome.
+    fn make_child<R: Rng + ?Sized>(
+        &self,
+        rng: &mut R,
+        population: &P,
+        selector: &S,
+    ) -> Result<P::Individual, Self::Error>;
+}

--- a/packages/ec-core/src/child_maker/mod.rs
+++ b/packages/ec-core/src/child_maker/mod.rs
@@ -12,6 +12,18 @@ pub use erased::*;
 //   something that takes a `genome` and returns a
 //   scored `Individual`. That would be a lot cleaner.
 // #[deprecated(note = "Turn this into a genome->Individual operator")]
+/// [`ChildMaker`] trait
+///
+/// # [dyn-compatability](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility)
+///
+/// This trait is **not** dyn-compatible. As such please
+/// try to avoid the need for trait objects whenever you can.
+///
+/// If you can't get around the usage of trait objects, you can
+/// use the [`DynChildMaker`] trait, which is available if you compile
+/// this crate with the `erased` feature.
+///
+/// Please see its documentation for further details on its usage.
 pub trait ChildMaker<P, S>
 where
     P: Population,

--- a/packages/ec-core/src/distributions/choices.rs
+++ b/packages/ec-core/src/distributions/choices.rs
@@ -8,6 +8,8 @@ pub trait ChoicesDistribution {
     fn num_choices(&self) -> NonZeroUsize;
 }
 
+static_assertions::assert_obj_safe!(ChoicesDistribution);
+
 impl<T> ChoicesDistribution for Slice<'_, T> {
     fn num_choices(&self) -> NonZeroUsize {
         self.num_choices()

--- a/packages/ec-core/src/distributions/conversion.rs
+++ b/packages/ec-core/src/distributions/conversion.rs
@@ -17,6 +17,8 @@ pub trait IntoDistribution<Element> {
     fn into_distribution(self) -> Result<Self::Distribution, Self::Error>;
 }
 
+static_assertions::assert_obj_safe!(IntoDistribution<(), Distribution = (), Error = ()>);
+
 pub trait ToDistribution<'a, Element> {
     type Distribution: Distribution<Element>;
     type Error;
@@ -28,6 +30,8 @@ pub trait ToDistribution<'a, Element> {
     /// returned
     fn to_distribution(&'a self) -> Result<Self::Distribution, Self::Error>;
 }
+
+static_assertions::assert_obj_safe!(ToDistribution<(), Distribution = (), Error = ()>);
 
 impl<U> IntoDistribution<U> for Vec<U>
 where

--- a/packages/ec-core/src/genome.rs
+++ b/packages/ec-core/src/genome.rs
@@ -1,3 +1,4 @@
 pub trait Genome {
     type Gene;
 }
+static_assertions::assert_obj_safe!(Genome<Gene = ()>);

--- a/packages/ec-core/src/individual/mod.rs
+++ b/packages/ec-core/src/individual/mod.rs
@@ -8,3 +8,5 @@ pub trait Individual {
     fn genome(&self) -> &Self::Genome;
     fn test_results(&self) -> &Self::TestResults;
 }
+
+static_assertions::assert_obj_safe!(Individual<Genome = (), TestResults = ()>);

--- a/packages/ec-core/src/individual/scorer.rs
+++ b/packages/ec-core/src/individual/scorer.rs
@@ -5,6 +5,8 @@ pub trait Scorer<G> {
     fn score(&self, genome: &G) -> Self::Score;
 }
 
+static_assertions::assert_obj_safe!(Scorer<(), Score = ()>);
+
 #[derive(Clone, Copy)]
 pub struct FnScorer<T>(pub T);
 

--- a/packages/ec-core/src/operator/composable/and.rs
+++ b/packages/ec-core/src/operator/composable/and.rs
@@ -1,4 +1,4 @@
-use rand::rngs::ThreadRng;
+use rand::Rng;
 
 use super::{super::Operator, Composable};
 
@@ -70,7 +70,7 @@ where
     type Output = (F::Output, G::Output);
     type Error = AndError<F::Error, G::Error>;
 
-    fn apply(&self, x: A, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
+    fn apply<R: Rng + ?Sized>(&self, x: A, rng: &mut R) -> Result<Self::Output, Self::Error> {
         let f_value = self.f.apply(x.clone(), rng).map_err(AndError::First)?;
         let g_value = self.g.apply(x, rng).map_err(AndError::Second)?;
         Ok((f_value, g_value))

--- a/packages/ec-core/src/operator/composable/map.rs
+++ b/packages/ec-core/src/operator/composable/map.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 use super::Composable;
 use crate::operator::Operator;
 
@@ -50,10 +52,10 @@ where
     type Output = [F::Output; 2];
     type Error = MapError<F::Error>;
 
-    fn apply(
+    fn apply<R: Rng + ?Sized>(
         &self,
         [x, y]: [Input; 2],
-        rng: &mut rand::rngs::ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         let first_result = self.f.apply(x, rng).map_err(|e| MapError(e, 0))?;
         let second_result = self.f.apply(y, rng).map_err(|e| MapError(e, 1))?;
@@ -68,10 +70,10 @@ where
     type Output = (F::Output, F::Output);
     type Error = MapError<F::Error>;
 
-    fn apply(
+    fn apply<R: Rng + ?Sized>(
         &self,
         (x, y): (Input, Input),
-        rng: &mut rand::rngs::ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         let first_result = self.f.apply(x, rng).map_err(|e| MapError(e, 0))?;
         let second_result = self.f.apply(y, rng).map_err(|e| MapError(e, 1))?;
@@ -86,10 +88,10 @@ where
     type Output = Vec<F::Output>;
     type Error = MapError<F::Error>;
 
-    fn apply(
+    fn apply<R: Rng + ?Sized>(
         &self,
         input: Vec<Input>,
-        rng: &mut rand::rngs::ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         input
             .into_iter()

--- a/packages/ec-core/src/operator/composable/mod.rs
+++ b/packages/ec-core/src/operator/composable/mod.rs
@@ -63,6 +63,8 @@ pub trait Composable {
     // }
 }
 
+static_assertions::assert_obj_safe!(Composable);
+
 pub trait Wrappable<T> {
     type Context;
 

--- a/packages/ec-core/src/operator/composable/repeat_with.rs
+++ b/packages/ec-core/src/operator/composable/repeat_with.rs
@@ -1,5 +1,7 @@
 use std::iter;
 
+use rand::Rng;
+
 use super::Composable;
 use crate::operator::Operator;
 
@@ -24,10 +26,10 @@ where
     type Output = [F::Output; N];
     type Error = F::Error;
 
-    fn apply(
+    fn apply<R: Rng + ?Sized>(
         &self,
         input: Input,
-        rng: &mut rand::rngs::ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         Ok(iter::repeat_with(|| self.f.apply(input.clone(), rng))
             .take(N)
@@ -63,10 +65,10 @@ mod tests {
         type Output = i32;
         type Error = Infallible;
 
-        fn apply(
+        fn apply<R: Rng + ?Sized>(
             &self,
             input: i32,
-            _: &mut rand::rngs::ThreadRng,
+            _: &mut R,
         ) -> Result<Self::Output, Self::Error> {
             Ok(input + 1)
         }
@@ -96,10 +98,10 @@ mod tests {
         type Output = i32;
         type Error = Infallible;
 
-        fn apply(
+        fn apply<R: Rng + ?Sized>(
             &self,
             range: Range<i32>,
-            rng: &mut rand::rngs::ThreadRng,
+            rng: &mut R,
         ) -> Result<Self::Output, Self::Error> {
             Ok(rng.random_range(range))
         }

--- a/packages/ec-core/src/operator/composable/then.rs
+++ b/packages/ec-core/src/operator/composable/then.rs
@@ -1,4 +1,4 @@
-use rand::rngs::ThreadRng;
+use rand::Rng;
 
 use super::{super::Operator, Composable};
 
@@ -66,7 +66,7 @@ where
     type Output = G::Output;
     type Error = ThenError<F::Error, G::Error>;
 
-    fn apply(&self, x: A, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
+    fn apply<R: Rng + ?Sized>(&self, x: A, rng: &mut R) -> Result<Self::Output, Self::Error> {
         let f_result = self.f.apply(x, rng).map_err(ThenError::First)?;
         self.g.apply(f_result, rng).map_err(ThenError::Second)
     }
@@ -91,7 +91,11 @@ pub mod tests {
         type Output = i32;
         type Error = Infallible;
 
-        fn apply(&self, input: i32, _: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
+        fn apply<R: Rng + ?Sized>(
+            &self,
+            input: i32,
+            _: &mut R,
+        ) -> Result<Self::Output, Self::Error> {
             Ok(input + 1)
         }
     }
@@ -102,7 +106,11 @@ pub mod tests {
         type Output = i32;
         type Error = Infallible;
 
-        fn apply(&self, input: i32, _: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
+        fn apply<R: Rng + ?Sized>(
+            &self,
+            input: i32,
+            _: &mut R,
+        ) -> Result<Self::Output, Self::Error> {
             Ok(input * 2)
         }
     }

--- a/packages/ec-core/src/operator/constant.rs
+++ b/packages/ec-core/src/operator/constant.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use rand::rngs::ThreadRng;
+use rand::Rng;
 
 use super::{Composable, Operator};
 
@@ -49,7 +49,7 @@ where
 
     /// Always return the value stored in the [`Operator`] regardless of the
     /// input value (of type `S`).
-    fn apply(&self, _: S, _: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
+    fn apply<R: Rng + ?Sized>(&self, _: S, _: &mut R) -> Result<Self::Output, Self::Error> {
         Ok(self.value.clone())
     }
 }

--- a/packages/ec-core/src/operator/erased.rs
+++ b/packages/ec-core/src/operator/erased.rs
@@ -1,0 +1,45 @@
+use std::error::Error as StdError;
+
+use rand::{Rng, RngCore};
+
+use super::{Composable, Operator};
+
+pub trait DynOperator<Input, Error = Box<dyn StdError + Send + Sync>>: Composable {
+    type Output;
+
+    /// # Errors
+    /// This will return an error if there's some problem applying the operator.
+    /// Given how general this concept is, there's no good way of saying here
+    /// what that might be.
+    fn dyn_apply(&self, input: Input, rng: &mut dyn RngCore) -> Result<Self::Output, Error>;
+}
+
+impl<T, I, E> DynOperator<I, E> for T
+where
+    T: Operator<I, Error: Into<E>>,
+{
+    type Output = T::Output;
+
+    fn dyn_apply(&self, input: I, rng: &mut dyn RngCore) -> Result<Self::Output, E> {
+        self.apply(input, rng).map_err(Into::into)
+    }
+}
+
+static_assertions::assert_obj_safe!(DynOperator<(), (), Output = ()>);
+
+#[ec_macros::dyn_ref_impls]
+impl<I, E, O> Composable for &dyn DynOperator<I, E, Output = O> {}
+
+#[ec_macros::dyn_ref_impls]
+impl<I, E, O> Operator<I> for &dyn DynOperator<I, E, Output = O> {
+    type Error = E;
+    type Output = O;
+
+    fn apply<R: Rng + ?Sized>(
+        &self,
+        input: I,
+        mut rng: &mut R,
+    ) -> Result<Self::Output, Self::Error> {
+        (**self).dyn_apply(input, &mut rng)
+    }
+}

--- a/packages/ec-core/src/operator/erased.rs
+++ b/packages/ec-core/src/operator/erased.rs
@@ -4,6 +4,52 @@ use rand::{Rng, RngCore};
 
 use super::{Composable, Operator};
 
+/// Erased
+/// ([dyn-compatible](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility))
+/// version of the [`Operator`] trait
+///
+/// # How does this work?
+///
+/// The `erased` pattern in rust aids in type-erasure for traits
+/// that aren't themselves dyn-compatible by declaring a dyn-compatible
+/// extension trait wrapper for the original trait and blanket-implementing
+/// that for all types which implement the original trait.
+///
+/// In this case, the trait [`DynOperator`] can be seen as a dyn-compatible
+/// version of the [`Operator`] trait, and any `T: Operator` can also be
+/// interpreted as [`T: DynOperator`]
+///
+/// This allows you to use `dyn DynOperator<I>` trait objects to perform type
+/// erasure on types implementing the [`Operator`] trait.
+///
+/// # When to use it?
+///
+/// The original trait most of the time has a reason for not beeing
+/// dyn-compatible. As such, usually the erased variants of traits come with
+/// performance tradeoffs, and [`DynOperator`] is of course no exception either,
+/// since it introduces additonal indirection and vtable-lookups.
+///
+/// Please prefer the [`Operator`] trait whenever possible.
+///
+/// # How to use it?
+///
+/// tl;dr: use `dyn DynOperator<>` instead of `dyn Operator<I>` and still use
+/// all the usual [`Operator`] methods elsewhere.
+///
+/// This trait tries to provide some useful ergonomics to ease the interaction
+/// with existing [`Operator`] code.
+/// For example, many common pointer types in Rust pointing to a [`dyn
+/// DynOperator<I>`](DynOperator) also implement the [`Operator`] trait
+/// themselves, so you most likely do not need to interact with this trait
+/// directly.
+///
+/// For example: `Box<dyn DynOperator<()>>` implements
+/// [`Operator<()>`](Operator) and as such you can directly call
+/// [`.apply()`](Operator::apply) on it and do not need to use
+/// [`DynOperator::dyn_apply`].
+///
+/// This also means, any [`Box<dyn DynOperator<()>>`] can be passed to generic
+/// functions expecting an [`Operator`], like `fn foo(t: impl Operator<()>);`.
 pub trait DynOperator<Input, Error = Box<dyn StdError + Send + Sync>>: Composable {
     type Output;
 

--- a/packages/ec-core/src/operator/genome_extractor.rs
+++ b/packages/ec-core/src/operator/genome_extractor.rs
@@ -1,5 +1,7 @@
 use std::convert::Infallible;
 
+use rand::Rng;
+
 use super::{Composable, Operator};
 use crate::individual::Individual;
 
@@ -16,7 +18,7 @@ use crate::individual::Individual;
 /// extract the genome from an individual and mutate it.
 ///
 /// ```
-/// # use rand::{rngs::ThreadRng, rng, Rng};
+/// # use rand::{rng, Rng};
 /// # use ec_core::{
 /// #     individual::ec::EcIndividual,
 /// #     operator::{
@@ -34,10 +36,10 @@ use crate::individual::Individual;
 /// impl Mutator<Genome<bool>> for FlipOne {
 ///     type Error = Infallible;
 ///
-///     fn mutate(
+///     fn mutate<R: Rng + ?Sized>(
 ///         &self,
 ///         mut genome: Genome<bool>,
-///         rng: &mut ThreadRng,
+///         rng: &mut R,
 ///     ) -> Result<Genome<bool>, Self::Error> {
 ///         let index = rng.random_range(0..genome.len());
 ///         genome[index] = !genome[index];
@@ -73,10 +75,10 @@ where
     type Output = I::Genome;
     type Error = Infallible;
 
-    fn apply(
+    fn apply<R: Rng + ?Sized>(
         &self,
         individual: &I,
-        _: &mut rand::rngs::ThreadRng,
+        _: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         Ok(individual.genome().clone())
     }
@@ -88,7 +90,7 @@ impl Composable for GenomeExtractor {}
 mod tests {
     use std::convert::Infallible;
 
-    use rand::{Rng, rng, rngs::ThreadRng};
+    use rand::{Rng, rng};
 
     use super::GenomeExtractor;
     use crate::{
@@ -104,10 +106,11 @@ mod tests {
 
     impl Mutator<Genome<bool>> for FlipOne {
         type Error = Infallible;
-        fn mutate(
+
+        fn mutate<R: Rng + ?Sized>(
             &self,
             mut genome: Genome<bool>,
-            rng: &mut ThreadRng,
+            rng: &mut R,
         ) -> Result<Genome<bool>, Self::Error> {
             let index = rng.random_range(0..genome.len());
             genome[index] = !genome[index];

--- a/packages/ec-core/src/operator/genome_scorer.rs
+++ b/packages/ec-core/src/operator/genome_scorer.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 use super::{Composable, Operator, composable::Wrappable};
 use crate::{
     individual::{ec::EcIndividual, scorer::Scorer},
@@ -27,19 +29,19 @@ impl<G, S> Wrappable<G> for GenomeScorer<G, S> {
 }
 
 // scorer: &Genome -> TestResults<R>
-impl<'pop, GM, S, R, P> Operator<&'pop P> for GenomeScorer<GM, S>
+impl<'pop, GM, S, P> Operator<&'pop P> for GenomeScorer<GM, S>
 where
     P: Population,
     GM: Operator<&'pop P>,
-    S: Scorer<GM::Output, Score = R>,
+    S: Scorer<GM::Output>,
 {
     type Output = EcIndividual<GM::Output, S::Score>;
     type Error = GM::Error;
 
-    fn apply(
+    fn apply<R: Rng + ?Sized>(
         &self,
         population: &'pop P,
-        rng: &mut rand::rngs::ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         let genome = self.genome_maker.apply(population, rng)?;
         let score = self.scorer.score(&genome);

--- a/packages/ec-core/src/operator/identity.rs
+++ b/packages/ec-core/src/operator/identity.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use rand::rngs::ThreadRng;
+use rand::Rng;
 
 use super::{Composable, Operator};
 
@@ -34,7 +34,7 @@ impl<T> Operator<T> for Identity {
     type Error = Infallible;
 
     /// Always return the input value.
-    fn apply(&self, input: T, _: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
+    fn apply<R: Rng + ?Sized>(&self, input: T, _: &mut R) -> Result<Self::Output, Self::Error> {
         Ok(input)
     }
 }

--- a/packages/ec-core/src/operator/mod.rs
+++ b/packages/ec-core/src/operator/mod.rs
@@ -5,7 +5,16 @@
 //! Explain the use of wrappers, and why blanket
 //! implementations weren't feasible.
 
-use rand::rngs::ThreadRng;
+#[cfg(feature = "erased")]
+use std::{
+    cell::{Ref, RefMut},
+    rc::Rc,
+    sync::Arc,
+};
+
+use rand::Rng;
+#[cfg(feature = "erased")]
+use rand::RngCore;
 
 pub mod composable;
 pub mod constant;
@@ -26,5 +35,95 @@ pub trait Operator<Input>: Composable {
     /// This will return an error if there's some problem applying the operator.
     /// Given how general this concept is, there's no good way of saying here
     /// what that might be.
-    fn apply(&self, input: Input, rng: &mut ThreadRng) -> Result<Self::Output, Self::Error>;
+    fn apply<R: Rng + ?Sized>(
+        &self,
+        input: Input,
+        rng: &mut R,
+    ) -> Result<Self::Output, Self::Error>;
 }
+
+#[cfg(feature = "erased")]
+pub trait DynOperator<Input, Error = Box<dyn std::error::Error + Send + Sync>>: Composable {
+    type Output;
+
+    /// # Errors
+    /// This will return an error if there's some problem applying the operator.
+    /// Given how general this concept is, there's no good way of saying here
+    /// what that might be.
+    fn dyn_apply(&self, input: Input, rng: &mut dyn RngCore) -> Result<Self::Output, Error>;
+}
+
+#[cfg(feature = "erased")]
+impl<T, I, E> DynOperator<I, E> for T
+where
+    T: Operator<I, Error: Into<E>>,
+{
+    type Output = T::Output;
+
+    fn dyn_apply(&self, input: I, rng: &mut dyn RngCore) -> Result<Self::Output, E> {
+        self.apply(input, rng).map_err(Into::into)
+    }
+}
+
+#[cfg(feature = "erased")]
+static_assertions::assert_obj_safe!(DynOperator<(), (), Output = ()>);
+
+#[cfg(feature = "erased")]
+macro_rules! dyn_operator_impl {
+    ($t: ty) => {
+        #[cfg(feature = "erased")]
+        impl<I, E, O> Operator<I> for $t
+        {
+            type Error = E;
+            type Output = O;
+
+            fn apply<R: Rng + ?Sized>(
+                &self,
+                input: I,
+                mut rng: &mut R,
+            ) -> Result<Self::Output, Self::Error> {
+                (**self).dyn_apply(input, &mut rng)
+            }
+        }
+
+        #[cfg(feature = "erased")]
+        impl<I,E,O> Composable for $t {}
+    };
+    ($($t: ty),+ $(,)?) => {
+        $(dyn_operator_impl!($t);)+
+    }
+}
+
+#[cfg(feature = "erased")]
+// TODO: Create a macro to do this in a nicer way without needing to manually
+// repeat all the pointer types everywhere we provide a type erased trait
+dyn_operator_impl!(
+    &dyn DynOperator<I, E, Output = O>,
+    &(dyn DynOperator<I, E, Output = O> + Send),
+    &(dyn DynOperator<I, E, Output = O> + Sync),
+    &(dyn DynOperator<I, E, Output = O> + Send + Sync),
+    &mut dyn DynOperator<I, E, Output = O>,
+    &mut (dyn DynOperator<I, E, Output = O> + Send),
+    &mut (dyn DynOperator<I, E, Output = O> + Sync),
+    &mut (dyn DynOperator<I, E, Output = O> + Send + Sync),
+    Box<dyn DynOperator<I, E, Output = O>>,
+    Box<dyn DynOperator<I, E, Output = O> + Send>,
+    Box<dyn DynOperator<I, E, Output = O> + Sync>,
+    Box<dyn DynOperator<I, E, Output = O> + Send + Sync>,
+    Arc<dyn DynOperator<I, E, Output = O>>,
+    Arc<dyn DynOperator<I, E, Output = O> + Send>,
+    Arc<dyn DynOperator<I, E, Output = O> + Sync>,
+    Arc<dyn DynOperator<I, E, Output = O> + Send + Sync>,
+    Rc<dyn DynOperator<I, E, Output = O>>,
+    Rc<dyn DynOperator<I, E, Output = O> + Send>,
+    Rc<dyn DynOperator<I, E, Output = O> + Sync>,
+    Rc<dyn DynOperator<I, E, Output = O> + Send + Sync>,
+    Ref<'_, dyn DynOperator<I, E, Output = O>>,
+    Ref<'_, dyn DynOperator<I, E, Output = O> + Send>,
+    Ref<'_, dyn DynOperator<I, E, Output = O> + Sync>,
+    Ref<'_, dyn DynOperator<I, E, Output = O> + Send + Sync>,
+    RefMut<'_, dyn DynOperator<I, E, Output = O>>,
+    RefMut<'_, dyn DynOperator<I, E, Output = O> + Send>,
+    RefMut<'_, dyn DynOperator<I, E, Output = O> + Sync>,
+    RefMut<'_, dyn DynOperator<I, E, Output = O> + Send + Sync>,
+);

--- a/packages/ec-core/src/operator/mod.rs
+++ b/packages/ec-core/src/operator/mod.rs
@@ -5,16 +5,7 @@
 //! Explain the use of wrappers, and why blanket
 //! implementations weren't feasible.
 
-#[cfg(feature = "erased")]
-use std::{
-    cell::{Ref, RefMut},
-    rc::Rc,
-    sync::Arc,
-};
-
 use rand::Rng;
-#[cfg(feature = "erased")]
-use rand::RngCore;
 
 pub mod composable;
 pub mod constant;
@@ -50,7 +41,7 @@ pub trait DynOperator<Input, Error = Box<dyn std::error::Error + Send + Sync>>: 
     /// This will return an error if there's some problem applying the operator.
     /// Given how general this concept is, there's no good way of saying here
     /// what that might be.
-    fn dyn_apply(&self, input: Input, rng: &mut dyn RngCore) -> Result<Self::Output, Error>;
+    fn dyn_apply(&self, input: Input, rng: &mut dyn rand::RngCore) -> Result<Self::Output, Error>;
 }
 
 #[cfg(feature = "erased")]
@@ -60,7 +51,7 @@ where
 {
     type Output = T::Output;
 
-    fn dyn_apply(&self, input: I, rng: &mut dyn RngCore) -> Result<Self::Output, E> {
+    fn dyn_apply(&self, input: I, rng: &mut dyn rand::RngCore) -> Result<Self::Output, E> {
         self.apply(input, rng).map_err(Into::into)
     }
 }
@@ -69,61 +60,20 @@ where
 static_assertions::assert_obj_safe!(DynOperator<(), (), Output = ()>);
 
 #[cfg(feature = "erased")]
-macro_rules! dyn_operator_impl {
-    ($t: ty) => {
-        #[cfg(feature = "erased")]
-        impl<I, E, O> Operator<I> for $t
-        {
-            type Error = E;
-            type Output = O;
-
-            fn apply<R: Rng + ?Sized>(
-                &self,
-                input: I,
-                mut rng: &mut R,
-            ) -> Result<Self::Output, Self::Error> {
-                (**self).dyn_apply(input, &mut rng)
-            }
-        }
-
-        #[cfg(feature = "erased")]
-        impl<I,E,O> Composable for $t {}
-    };
-    ($($t: ty),+ $(,)?) => {
-        $(dyn_operator_impl!($t);)+
-    }
-}
+#[ec_macros::dyn_ref_impls]
+impl<I, E, O> Composable for &dyn DynOperator<I, E, Output = O> {}
 
 #[cfg(feature = "erased")]
-// TODO: Create a macro to do this in a nicer way without needing to manually
-// repeat all the pointer types everywhere we provide a type erased trait
-dyn_operator_impl!(
-    &dyn DynOperator<I, E, Output = O>,
-    &(dyn DynOperator<I, E, Output = O> + Send),
-    &(dyn DynOperator<I, E, Output = O> + Sync),
-    &(dyn DynOperator<I, E, Output = O> + Send + Sync),
-    &mut dyn DynOperator<I, E, Output = O>,
-    &mut (dyn DynOperator<I, E, Output = O> + Send),
-    &mut (dyn DynOperator<I, E, Output = O> + Sync),
-    &mut (dyn DynOperator<I, E, Output = O> + Send + Sync),
-    Box<dyn DynOperator<I, E, Output = O>>,
-    Box<dyn DynOperator<I, E, Output = O> + Send>,
-    Box<dyn DynOperator<I, E, Output = O> + Sync>,
-    Box<dyn DynOperator<I, E, Output = O> + Send + Sync>,
-    Arc<dyn DynOperator<I, E, Output = O>>,
-    Arc<dyn DynOperator<I, E, Output = O> + Send>,
-    Arc<dyn DynOperator<I, E, Output = O> + Sync>,
-    Arc<dyn DynOperator<I, E, Output = O> + Send + Sync>,
-    Rc<dyn DynOperator<I, E, Output = O>>,
-    Rc<dyn DynOperator<I, E, Output = O> + Send>,
-    Rc<dyn DynOperator<I, E, Output = O> + Sync>,
-    Rc<dyn DynOperator<I, E, Output = O> + Send + Sync>,
-    Ref<'_, dyn DynOperator<I, E, Output = O>>,
-    Ref<'_, dyn DynOperator<I, E, Output = O> + Send>,
-    Ref<'_, dyn DynOperator<I, E, Output = O> + Sync>,
-    Ref<'_, dyn DynOperator<I, E, Output = O> + Send + Sync>,
-    RefMut<'_, dyn DynOperator<I, E, Output = O>>,
-    RefMut<'_, dyn DynOperator<I, E, Output = O> + Send>,
-    RefMut<'_, dyn DynOperator<I, E, Output = O> + Sync>,
-    RefMut<'_, dyn DynOperator<I, E, Output = O> + Send + Sync>,
-);
+#[ec_macros::dyn_ref_impls]
+impl<I, E, O> Operator<I> for &dyn DynOperator<I, E, Output = O> {
+    type Error = E;
+    type Output = O;
+
+    fn apply<R: Rng + ?Sized>(
+        &self,
+        input: I,
+        mut rng: &mut R,
+    ) -> Result<Self::Output, Self::Error> {
+        (**self).dyn_apply(input, &mut rng)
+    }
+}

--- a/packages/ec-core/src/operator/mod.rs
+++ b/packages/ec-core/src/operator/mod.rs
@@ -23,6 +23,17 @@ pub mod selector;
 
 pub use composable::Composable;
 
+/// Operator trait
+///
+/// # [dyn-compatibility](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility)
+/// This trait is **not** dyn-compatible. As such please
+/// try to avoid the need for trait objects whenever you can.
+///
+/// If you can't get around the usage of trait objects, you can
+/// use the [`DynOperator`] trait, which is available if you compile
+/// this crate with the `erased` feature.
+///
+/// Please see its documentation for further details on its usage.
 pub trait Operator<Input>: Composable {
     type Output;
     type Error;

--- a/packages/ec-core/src/operator/mod.rs
+++ b/packages/ec-core/src/operator/mod.rs
@@ -7,6 +7,11 @@
 
 use rand::Rng;
 
+#[cfg(feature = "erased")]
+mod erased;
+#[cfg(feature = "erased")]
+pub use erased::*;
+
 pub mod composable;
 pub mod constant;
 pub mod genome_extractor;
@@ -31,49 +36,4 @@ pub trait Operator<Input>: Composable {
         input: Input,
         rng: &mut R,
     ) -> Result<Self::Output, Self::Error>;
-}
-
-#[cfg(feature = "erased")]
-pub trait DynOperator<Input, Error = Box<dyn std::error::Error + Send + Sync>>: Composable {
-    type Output;
-
-    /// # Errors
-    /// This will return an error if there's some problem applying the operator.
-    /// Given how general this concept is, there's no good way of saying here
-    /// what that might be.
-    fn dyn_apply(&self, input: Input, rng: &mut dyn rand::RngCore) -> Result<Self::Output, Error>;
-}
-
-#[cfg(feature = "erased")]
-impl<T, I, E> DynOperator<I, E> for T
-where
-    T: Operator<I, Error: Into<E>>,
-{
-    type Output = T::Output;
-
-    fn dyn_apply(&self, input: I, rng: &mut dyn rand::RngCore) -> Result<Self::Output, E> {
-        self.apply(input, rng).map_err(Into::into)
-    }
-}
-
-#[cfg(feature = "erased")]
-static_assertions::assert_obj_safe!(DynOperator<(), (), Output = ()>);
-
-#[cfg(feature = "erased")]
-#[ec_macros::dyn_ref_impls]
-impl<I, E, O> Composable for &dyn DynOperator<I, E, Output = O> {}
-
-#[cfg(feature = "erased")]
-#[ec_macros::dyn_ref_impls]
-impl<I, E, O> Operator<I> for &dyn DynOperator<I, E, Output = O> {
-    type Error = E;
-    type Output = O;
-
-    fn apply<R: Rng + ?Sized>(
-        &self,
-        input: I,
-        mut rng: &mut R,
-    ) -> Result<Self::Output, Self::Error> {
-        (**self).dyn_apply(input, &mut rng)
-    }
 }

--- a/packages/ec-core/src/operator/mutator/erased.rs
+++ b/packages/ec-core/src/operator/mutator/erased.rs
@@ -1,0 +1,33 @@
+use rand::{Rng, RngCore};
+
+use super::Mutator;
+
+#[cfg(feature = "erased")]
+pub trait DynMutator<G, E = Box<dyn std::error::Error + Send + Sync>> {
+    /// # Errors
+    ///
+    /// This will return an error if there is an error mutating the given
+    /// genome. This will usually be because the given `genome` is invalid in
+    /// some way, thus making the mutation impossible.
+    fn dyn_mutate(&self, genome: G, rng: &mut dyn RngCore) -> Result<G, E>;
+}
+
+static_assertions::assert_obj_safe!(DynMutator<()>);
+
+impl<T, G, E> DynMutator<G, E> for T
+where
+    T: Mutator<G, Error: Into<E>>,
+{
+    fn dyn_mutate(&self, genome: G, rng: &mut dyn RngCore) -> Result<G, E> {
+        self.mutate(genome, rng).map_err(Into::into)
+    }
+}
+
+#[ec_macros::dyn_ref_impls]
+impl<G, E> Mutator<G> for &dyn DynMutator<G, E> {
+    type Error = E;
+
+    fn mutate<R: Rng + ?Sized>(&self, genome: G, mut rng: &mut R) -> Result<G, Self::Error> {
+        (**self).dyn_mutate(genome, &mut rng)
+    }
+}

--- a/packages/ec-core/src/operator/mutator/erased.rs
+++ b/packages/ec-core/src/operator/mutator/erased.rs
@@ -2,7 +2,52 @@ use rand::{Rng, RngCore};
 
 use super::Mutator;
 
-#[cfg(feature = "erased")]
+/// Erased
+/// ([dyn-compatible](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility))
+/// version of the [`Mutator`] trait
+///
+/// # How does this work?
+///
+/// The `erased` pattern in rust aids in type-erasure for traits
+/// that aren't themselves dyn-compatible by declaring a dyn-compatible
+/// extension trait wrapper for the original trait and blanket-implementing
+/// that for all types which implement the original trait.
+///
+/// In this case, the trait [`DynMutator`] can be seen as a dyn-compatible
+/// version of the [`Mutator`] trait, and any `T: Mutator` can also be
+/// interpreted as [`T: DynMutator`]
+///
+/// This allows you to use `dyn DynMutator<I>` trait objects to perform type
+/// erasure on types implementing the [`Mutator`] trait.
+///
+/// # When to use it?
+///
+/// The original trait most of the time has a reason for not beeing
+/// dyn-compatible. As such, usually the erased variants of traits come with
+/// performance tradeoffs, and [`DynMutator`] is of course no exception either,
+/// since it introduces additonal indirection and vtable-lookups.
+///
+/// Please prefer the [`Mutator`] trait whenever possible.
+///
+/// # How to use it?
+///
+/// tl;dr: use `dyn DynMutator<>` instead of `dyn Mutator<>` and still use
+/// all the usual [`Mutator`] methods elsewhere.
+///
+/// This trait tries to provide some useful ergonomics to ease the interaction
+/// with existing [`Mutator`] code.
+/// For example, many common pointer types in Rust pointing to a [`dyn
+/// DynMutator<>`](DynMutator) also implement the [`Mutator`] trait
+/// themselves, so you most likely do not need to interact with this trait
+/// directly.
+///
+/// For example: `Box<dyn DynMutator<>>` implements
+/// [`Mutator<>`](Mutator) and as such you can directly call
+/// [`.mutate()`](Mutator::mutate) on it and do not need to use
+/// [`DynMutator::dyn_mutate`].
+///
+/// This also means, any `Box<dyn DynMutator<>>` can be passed to generic
+/// functions expecting an [`Mutator`], like `fn foo(t: impl Mutator<>);`.
 pub trait DynMutator<G, E = Box<dyn std::error::Error + Send + Sync>> {
     /// # Errors
     ///

--- a/packages/ec-core/src/operator/mutator/mod.rs
+++ b/packages/ec-core/src/operator/mutator/mod.rs
@@ -19,6 +19,17 @@ pub use erased::*;
 /// See [`Mutate`] for a wrapper that converts a `Mutator` into an [`Operator`],
 /// allowing mutators to be used in chains of operators.
 ///
+/// # [dyn-compatibility](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility)
+///
+/// This trait is **not** dyn-compatible. As such please
+/// try to avoid the need for trait objects whenever you can.
+///
+/// If you can't get around the usage of trait objects, you can
+/// use the [`DynMutator`] trait, which is available if you compile
+/// this crate with the `erased` feature.
+///
+/// Please see its documentation for further details on its usage.
+///
 /// # Examples
 ///
 /// In this example, we define a `Mutator` that flips one random bit in a

--- a/packages/ec-core/src/operator/mutator/mod.rs
+++ b/packages/ec-core/src/operator/mutator/mod.rs
@@ -2,6 +2,11 @@ use rand::Rng;
 
 use super::{Composable, Operator};
 
+#[cfg(feature = "erased")]
+mod erased;
+#[cfg(feature = "erased")]
+pub use erased::*;
+
 /// Mutate a genome of type `G` generating a new
 /// genome of the same type (`G`).
 ///
@@ -63,39 +68,6 @@ pub trait Mutator<G> {
     /// genome. This will usually be because the given `genome` is invalid in
     /// some way, thus making the mutation impossible.
     fn mutate<R: Rng + ?Sized>(&self, genome: G, rng: &mut R) -> Result<G, Self::Error>;
-}
-
-#[cfg(feature = "erased")]
-pub trait DynMutator<G, E = Box<dyn std::error::Error + Send + Sync>> {
-    /// # Errors
-    ///
-    /// This will return an error if there is an error mutating the given
-    /// genome. This will usually be because the given `genome` is invalid in
-    /// some way, thus making the mutation impossible.
-    fn dyn_mutate(&self, genome: G, rng: &mut dyn rand::RngCore) -> Result<G, E>;
-}
-
-#[cfg(feature = "erased")]
-static_assertions::assert_obj_safe!(DynMutator<()>);
-
-#[cfg(feature = "erased")]
-impl<T, G, E> DynMutator<G, E> for T
-where
-    T: Mutator<G, Error: Into<E>>,
-{
-    fn dyn_mutate(&self, genome: G, rng: &mut dyn rand::RngCore) -> Result<G, E> {
-        self.mutate(genome, rng).map_err(Into::into)
-    }
-}
-
-#[cfg(feature = "erased")]
-#[ec_macros::dyn_ref_impls]
-impl<G, E> Mutator<G> for &dyn DynMutator<G, E> {
-    type Error = E;
-
-    fn mutate<R: Rng + ?Sized>(&self, genome: G, mut rng: &mut R) -> Result<G, Self::Error> {
-        (**self).dyn_mutate(genome, &mut rng)
-    }
 }
 
 /// A wrapper that converts a [`Mutator`] into an [`Operator`].

--- a/packages/ec-core/src/operator/recombinator/erased.rs
+++ b/packages/ec-core/src/operator/recombinator/erased.rs
@@ -2,6 +2,53 @@ use rand::{Rng, RngCore};
 
 use super::Recombinator;
 
+/// Erased
+/// ([dyn-compatible](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility))
+/// version of the [`Recombinator`] trait
+///
+/// # How does this work?
+///
+/// The `erased` pattern in rust aids in type-erasure for traits
+/// that aren't themselves dyn-compatible by declaring a dyn-compatible
+/// extension trait wrapper for the original trait and blanket-implementing
+/// that for all types which implement the original trait.
+///
+/// In this case, the trait [`DynRecombinator`] can be seen as a dyn-compatible
+/// version of the [`Recombinator`] trait, and any `T: Recombinator` can also be
+/// interpreted as [`T: DynRecombinator`]
+///
+/// This allows you to use `dyn DynRecombinator<I>` trait objects to perform
+/// type erasure on types implementing the [`Recombinator`] trait.
+///
+/// # When to use it?
+///
+/// The original trait most of the time has a reason for not beeing
+/// dyn-compatible. As such, usually the erased variants of traits come with
+/// performance tradeoffs, and [`DynRecombinator`] is of course no exception
+/// either, since it introduces additonal indirection and vtable-lookups.
+///
+/// Please prefer the [`Recombinator`] trait whenever possible.
+///
+/// # How to use it?
+///
+/// tl;dr: use `dyn DynRecombinator<>` instead of `dyn Recombinator<>` and still
+/// use all the usual [`Recombinator`] methods elsewhere.
+///
+/// This trait tries to provide some useful ergonomics to ease the interaction
+/// with existing [`Recombinator`] code.
+/// For example, many common pointer types in Rust pointing to a [`dyn
+/// DynRecombinator<>`](DynRecombinator) also implement the [`Recombinator`]
+/// trait themselves, so you most likely do not need to interact with this trait
+/// directly.
+///
+/// For example: `Box<dyn DynRecombinator<>>` implements
+/// [`Recombinator<>`](Recombinator) and as such you can directly call
+/// [`.recombine()`](Recombinator::recombine) on it and do not need to use
+/// [`DynRecombinator::dyn_recombine`].
+///
+/// This also means, any `Box<dyn DynRecombinator<>>` can be passed to generic
+/// functions expecting an [`Recombinator`], like `fn foo(t: impl
+/// Recombinator<>);`.
 pub trait DynRecombinator<GS, E = Box<dyn std::error::Error + Send + Sync>> {
     type Output;
 

--- a/packages/ec-core/src/operator/recombinator/erased.rs
+++ b/packages/ec-core/src/operator/recombinator/erased.rs
@@ -1,0 +1,39 @@
+use rand::{Rng, RngCore};
+
+use super::Recombinator;
+
+pub trait DynRecombinator<GS, E = Box<dyn std::error::Error + Send + Sync>> {
+    type Output;
+
+    /// Recombine the given `genomes` returning a new genome of type `Output`.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if there is an error recombining the given
+    /// parent genomes. This will usually be because the given `genomes` are
+    /// invalid in some way, thus making recombination impossible.
+    fn dyn_recombine(&self, genomes: GS, rng: &mut dyn RngCore) -> Result<Self::Output, E>;
+}
+
+static_assertions::assert_obj_safe!(DynRecombinator<(), Output = ()>);
+
+impl<T, GS, E> DynRecombinator<GS, E> for T
+where
+    T: Recombinator<GS, Error: Into<E>>,
+{
+    type Output = T::Output;
+
+    fn dyn_recombine(&self, genomes: GS, rng: &mut dyn RngCore) -> Result<Self::Output, E> {
+        self.recombine(genomes, rng).map_err(Into::into)
+    }
+}
+
+#[ec_macros::dyn_ref_impls]
+impl<GS, O, E> Recombinator<GS> for &dyn DynRecombinator<GS, E, Output = O> {
+    type Output = O;
+    type Error = E;
+
+    fn recombine<R: Rng + ?Sized>(&self, genomes: GS, mut rng: &mut R) -> Result<Self::Output, E> {
+        (**self).dyn_recombine(genomes, &mut rng)
+    }
+}

--- a/packages/ec-core/src/operator/recombinator/mod.rs
+++ b/packages/ec-core/src/operator/recombinator/mod.rs
@@ -29,6 +29,17 @@ pub use erased::*;
 /// See [`Recombine`] for a wrapper that converts a `Recombinator` into an
 /// [`Operator`], allowing recombinators to be used in chains of operators.
 ///
+/// # [dyn-compatibility](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility)
+///
+/// This trait is **not** dyn-compatible. As such please
+/// try to avoid the need for trait objects whenever you can.
+///
+/// If you can't get around the usage of trait objects, you can
+/// use the [`DynRecombinator`] trait, which is available if you compile
+/// this crate with the `erased` feature.
+///
+/// Please see its documentation for further details on its usage.
+///
 /// # Examples
 ///
 /// In this example, we define a `Recombinator` that swaps one randomly

--- a/packages/ec-core/src/operator/selector/best.rs
+++ b/packages/ec-core/src/operator/selector/best.rs
@@ -1,4 +1,4 @@
-use rand::rngs::ThreadRng;
+use rand::Rng;
 
 use super::{Selector, error::EmptyPopulation};
 use crate::population::Population;
@@ -14,10 +14,10 @@ where
 {
     type Error = EmptyPopulation;
 
-    fn select<'pop>(
+    fn select<'pop, R: Rng + ?Sized>(
         &self,
         population: &'pop P,
-        _: &mut ThreadRng,
+        _: &mut R,
     ) -> Result<&'pop P::Individual, Self::Error> {
         population.into_iter().max().ok_or(EmptyPopulation)
     }

--- a/packages/ec-core/src/operator/selector/erased.rs
+++ b/packages/ec-core/src/operator/selector/erased.rs
@@ -3,7 +3,52 @@ use rand::{Rng, RngCore};
 use super::Selector;
 use crate::population::Population;
 
-/// Object-safe version of the [`Selector`] trait.
+/// Erased
+/// ([dyn-compatible](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility))
+/// version of the [`Selector`] trait
+///
+/// # How does this work?
+///
+/// The `erased` pattern in rust aids in type-erasure for traits
+/// that aren't themselves dyn-compatible by declaring a dyn-compatible
+/// extension trait wrapper for the original trait and blanket-implementing
+/// that for all types which implement the original trait.
+///
+/// In this case, the trait [`DynSelector`] can be seen as a dyn-compatible
+/// version of the [`Selector`] trait, and any `T: Selector` can also be
+/// interpreted as [`T: DynSelector`]
+///
+/// This allows you to use `dyn DynSelector<I>` trait objects to perform type
+/// erasure on types implementing the [`Selector`] trait.
+///
+/// # When to use it?
+///
+/// The original trait most of the time has a reason for not beeing
+/// dyn-compatible. As such, usually the erased variants of traits come with
+/// performance tradeoffs, and [`DynSelector`] is of course no exception either,
+/// since it introduces additonal indirection and vtable-lookups.
+///
+/// Please prefer the [`Selector`] trait whenever possible.
+///
+/// # How to use it?
+///
+/// tl;dr: use `dyn DynSelector<>` instead of `dyn Selector<>` and still use
+/// all the usual [`Selector`] methods elsewhere.
+///
+/// This trait tries to provide some useful ergonomics to ease the interaction
+/// with existing [`Selector`] code.
+/// For example, many common pointer types in Rust pointing to a [`dyn
+/// DynSelector<>`](DynSelector) also implement the [`Selector`] trait
+/// themselves, so you most likely do not need to interact with this trait
+/// directly.
+///
+/// For example: `Box<dyn DynSelector<>>` implements
+/// [`Selector<>`](Selector) and as such you can directly call
+/// [`.select()`](Selector::select) on it and do not need to use
+/// [`DynSelector::dyn_select`].
+///
+/// This also means, any `Box<dyn DynSelector<>>` can be passed to generic
+/// functions expecting an [`Selector`], like `fn foo(t: impl Selector<>);`.
 pub trait DynSelector<P, Error = Box<dyn std::error::Error + Send + Sync>>
 where
     P: Population,

--- a/packages/ec-core/src/operator/selector/erased.rs
+++ b/packages/ec-core/src/operator/selector/erased.rs
@@ -1,0 +1,60 @@
+use rand::{Rng, RngCore};
+
+use super::Selector;
+use crate::population::Population;
+
+/// Object-safe version of the [`Selector`] trait.
+pub trait DynSelector<P, Error = Box<dyn std::error::Error + Send + Sync>>
+where
+    P: Population,
+{
+    /// Select an individual from the given `population`, in a dyn compatible
+    /// fashion
+    ///
+    /// You should probably not use this directly and instead rely on the
+    /// `Selector` implementations on all common pointer types in rust
+    /// pointing to a object of this trait.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if there's some problem selecting. That will
+    /// usually be because the population is empty or not large enough for
+    /// the desired selector.
+    fn dyn_select<'pop>(
+        &self,
+        population: &'pop P,
+        rng: &mut dyn RngCore,
+    ) -> Result<&'pop P::Individual, Error>;
+}
+
+static_assertions::assert_obj_safe!(DynSelector<()>);
+
+impl<P, T, E> DynSelector<P, E> for T
+where
+    P: Population,
+    T: Selector<P, Error: Into<E>>,
+{
+    fn dyn_select<'pop>(
+        &self,
+        population: &'pop P,
+        rng: &mut dyn RngCore,
+    ) -> Result<&'pop <P as Population>::Individual, E> {
+        self.select(population, rng).map_err(Into::into)
+    }
+}
+
+#[ec_macros::dyn_ref_impls]
+impl<P, E> Selector<P> for &dyn DynSelector<P, E>
+where
+    P: Population,
+{
+    type Error = E;
+
+    fn select<'pop, R: Rng + ?Sized>(
+        &self,
+        population: &'pop P,
+        mut rng: &mut R,
+    ) -> Result<&'pop <P as Population>::Individual, Self::Error> {
+        (**self).dyn_select(population, &mut rng)
+    }
+}

--- a/packages/ec-core/src/operator/selector/lexicase.rs
+++ b/packages/ec-core/src/operator/selector/lexicase.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, mem::swap, ops::Not};
 
-use rand::{prelude::SliceRandom, rngs::ThreadRng};
+use rand::{Rng, prelude::SliceRandom};
 
 use super::{Selector, error::EmptyPopulation};
 use crate::{individual::Individual, population::Population, test_results::TestResults};
@@ -17,7 +17,7 @@ impl Lexicase {
     }
 }
 
-impl<P, R> Selector<P> for Lexicase
+impl<P, Res> Selector<P> for Lexicase
 where
     P: Population,
     // TODO: We don't really use the iterator here as we immediately
@@ -31,15 +31,15 @@ where
     //   bare `Vec`s and will be forced to wrap them like we currently
     //   do with `VecPop`.
     for<'pop> &'pop P: IntoIterator<Item = &'pop P::Individual>,
-    P::Individual: Individual<TestResults = TestResults<R>>,
-    R: Ord,
+    P::Individual: Individual<TestResults = TestResults<Res>>,
+    Res: Ord,
 {
     type Error = EmptyPopulation;
 
-    fn select<'pop>(
+    fn select<'pop, R: Rng + ?Sized>(
         &self,
         population: &'pop P,
-        rng: &mut ThreadRng,
+        rng: &mut R,
     ) -> Result<&'pop P::Individual, Self::Error> {
         // Candidate set is initially the whole population.
         // Shuffle the (indices of the) test cases.

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -3,8 +3,12 @@ use rand::Rng;
 use super::{Composable, Operator};
 use crate::population::Population;
 
-pub mod best;
 #[cfg(feature = "erased")]
+mod erased;
+#[cfg(feature = "erased")]
+pub use erased::*;
+
+pub mod best;
 pub mod dyn_weighted;
 pub mod error;
 pub mod lexicase;
@@ -78,66 +82,6 @@ where
         population: &'pop P,
         rng: &mut R,
     ) -> Result<&'pop P::Individual, Self::Error>;
-}
-
-#[cfg(feature = "erased")]
-/// Object-safe version of the [`Selector`] trait.
-pub trait DynSelector<P, Error = Box<dyn std::error::Error + Send + Sync>>
-where
-    P: Population,
-{
-    /// Select an individual from the given `population`, in a dyn compatible
-    /// fashion
-    ///
-    /// You should probably not use this directly and instead rely on the
-    /// `Selector` implementations on all common pointer types in rust
-    /// pointing to a object of this trait.
-    ///
-    /// # Errors
-    ///
-    /// This will return an error if there's some problem selecting. That will
-    /// usually be because the population is empty or not large enough for
-    /// the desired selector.
-    fn dyn_select<'pop>(
-        &self,
-        population: &'pop P,
-        rng: &mut dyn rand::RngCore,
-    ) -> Result<&'pop P::Individual, Error>;
-}
-
-#[cfg(feature = "erased")]
-static_assertions::assert_obj_safe!(DynSelector<()>);
-
-#[cfg(feature = "erased")]
-impl<P, T, E> DynSelector<P, E> for T
-where
-    P: Population,
-    T: Selector<P, Error: Into<E>>,
-{
-    fn dyn_select<'pop>(
-        &self,
-        population: &'pop P,
-        rng: &mut dyn rand::RngCore,
-    ) -> Result<&'pop <P as Population>::Individual, E> {
-        self.select(population, rng).map_err(Into::into)
-    }
-}
-
-#[cfg(feature = "erased")]
-#[ec_macros::dyn_ref_impls]
-impl<P, E> Selector<P> for &dyn DynSelector<P, E>
-where
-    P: Population,
-{
-    type Error = E;
-
-    fn select<'pop, R: Rng + ?Sized>(
-        &self,
-        population: &'pop P,
-        mut rng: &mut R,
-    ) -> Result<&'pop <P as Population>::Individual, Self::Error> {
-        (**self).dyn_select(population, &mut rng)
-    }
 }
 
 /// A wrapper that converts a `Selector` into an `Operator`.

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -23,6 +23,17 @@ pub use error::EmptyPopulation;
 /// See [`Select`] for a wrapper that converts a `Selector` into an
 /// [`Operator`], allowing selectors to be used in chains of operators.
 ///
+/// # [dyn-compatibility](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility)
+///
+/// This trait is **not** dyn-compatible. As such please
+/// try to avoid the need for trait objects whenever you can.
+///
+/// If you can't get around the usage of trait objects, you can
+/// use the [`DynSelector`] trait, which is available if you compile
+/// this crate with the `erased` feature.
+///
+/// Please see its documentation for further details on its usage.
+///
 /// # Examples
 ///
 /// In this example we use the `[Best]` selector to choose the

--- a/packages/ec-core/src/operator/selector/random.rs
+++ b/packages/ec-core/src/operator/selector/random.rs
@@ -1,4 +1,4 @@
-use rand::{prelude::IndexedRandom, rngs::ThreadRng};
+use rand::{Rng, prelude::IndexedRandom};
 
 use super::{Selector, error::EmptyPopulation};
 use crate::population::Population;
@@ -12,10 +12,10 @@ where
 {
     type Error = EmptyPopulation;
 
-    fn select<'pop>(
+    fn select<'pop, R: Rng + ?Sized>(
         &self,
         population: &'pop P,
-        rng: &mut ThreadRng,
+        rng: &mut R,
     ) -> Result<&'pop P::Individual, Self::Error> {
         population.as_ref().choose(rng).ok_or(EmptyPopulation)
     }

--- a/packages/ec-core/src/operator/selector/tournament.rs
+++ b/packages/ec-core/src/operator/selector/tournament.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroUsize;
 
 use miette::Diagnostic;
-use rand::{prelude::IndexedRandom, rngs::ThreadRng};
+use rand::{Rng, prelude::IndexedRandom};
 
 use super::Selector;
 use crate::population::Population;
@@ -79,10 +79,10 @@ where
 {
     type Error = TournamentSizeError;
 
-    fn select<'pop>(
+    fn select<'pop, R: Rng + ?Sized>(
         &self,
         population: &'pop P,
-        rng: &mut ThreadRng,
+        rng: &mut R,
     ) -> Result<&'pop P::Individual, Self::Error> {
         if population.size() < self.size.into() {
             return Err(TournamentSizeError::new(self.size, population.size()));

--- a/packages/ec-core/src/operator/selector/worst.rs
+++ b/packages/ec-core/src/operator/selector/worst.rs
@@ -1,4 +1,4 @@
-use rand::rngs::ThreadRng;
+use rand::Rng;
 
 use super::{Selector, error::EmptyPopulation};
 use crate::population::Population;
@@ -14,10 +14,10 @@ where
 {
     type Error = EmptyPopulation;
 
-    fn select<'pop>(
+    fn select<'pop, R: Rng + ?Sized>(
         &self,
         population: &'pop P,
-        _: &mut ThreadRng,
+        _: &mut R,
     ) -> Result<&'pop P::Individual, Self::Error> {
         population.into_iter().min().ok_or(EmptyPopulation)
     }

--- a/packages/ec-core/src/population.rs
+++ b/packages/ec-core/src/population.rs
@@ -8,6 +8,8 @@ pub trait Population {
     fn size(&self) -> usize;
 }
 
+static_assertions::assert_obj_safe!(Population<Individual = ()>);
+
 impl<T, I> Population for T
 where
     // An alternative would be `T: Deref<[T]>` but this also supports

--- a/packages/ec-core/src/weighted/mod.rs
+++ b/packages/ec-core/src/weighted/mod.rs
@@ -1,4 +1,5 @@
 use error::{SelectionError, ZeroWeight};
+use rand::Rng;
 use with_weight::WithWeight;
 
 use crate::{operator::selector::Selector, population::Population};
@@ -33,10 +34,10 @@ where
 {
     type Error = SelectionError<T::Error>;
 
-    fn select<'pop>(
+    fn select<'pop, R: Rng + ?Sized>(
         &self,
         population: &'pop P,
-        rng: &mut rand::prelude::ThreadRng,
+        rng: &mut R,
     ) -> Result<&'pop <P as Population>::Individual, Self::Error> {
         if self.weight == 0 {
             return Err(ZeroWeight.into());

--- a/packages/ec-core/src/weighted/weighted_pair.rs
+++ b/packages/ec-core/src/weighted/weighted_pair.rs
@@ -1,4 +1,7 @@
-use rand::distr::{Bernoulli, Distribution};
+use rand::{
+    Rng,
+    distr::{Bernoulli, Distribution},
+};
 
 use super::{
     error::{SelectionError, WeightSumOverflow, WeightedPairError, ZeroWeight},
@@ -52,10 +55,10 @@ where
 {
     type Error = SelectionError<WeightedPairError<A::Error, B::Error>>;
 
-    fn select<'pop>(
+    fn select<'pop, R: Rng + ?Sized>(
         &self,
         population: &'pop P,
-        rng: &mut rand::prelude::ThreadRng,
+        rng: &mut R,
     ) -> Result<&'pop <P as Population>::Individual, Self::Error> {
         let Some(distr) = self.distr else {
             return Err(ZeroWeight.into());

--- a/packages/ec-core/src/weighted/with_weight.rs
+++ b/packages/ec-core/src/weighted/with_weight.rs
@@ -2,3 +2,5 @@
 pub trait WithWeight {
     fn weight(&self) -> u32;
 }
+
+static_assertions::assert_obj_safe!(WithWeight);

--- a/packages/ec-linear/Cargo.toml
+++ b/packages/ec-linear/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 [dependencies]
 num-traits = { workspace = true }
 rand = { workspace = true, features = ["alloc"] }
+static_assertions = { workspace = true }
 
 ec-core = { workspace = true }
 

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -5,7 +5,7 @@ use ec_core::{
     genome::Genome,
 };
 use miette::Diagnostic;
-use rand::{Rng, distr::StandardUniform, prelude::Distribution, rngs::ThreadRng};
+use rand::{Rng, distr::StandardUniform, prelude::Distribution};
 
 use super::Linear;
 use crate::recombinator::crossover::Crossover;
@@ -47,13 +47,17 @@ where
 }
 
 impl Bitstring {
-    pub fn random(num_bits: usize, rng: &mut ThreadRng) -> Self {
+    pub fn random<R: Rng + ?Sized>(num_bits: usize, rng: &mut R) -> Self {
         StandardUniform
             .into_collection_generator(num_bits)
             .sample(rng)
     }
 
-    pub fn random_with_probability(num_bits: usize, probability: f64, rng: &mut ThreadRng) -> Self {
+    pub fn random_with_probability<R: Rng + ?Sized>(
+        num_bits: usize,
+        probability: f64,
+        rng: &mut R,
+    ) -> Self {
         BoolGenerator::new(probability)
             .into_collection_generator(num_bits)
             .sample(rng)

--- a/packages/ec-linear/src/genome/mod.rs
+++ b/packages/ec-linear/src/genome/mod.rs
@@ -8,3 +8,5 @@ pub trait Linear: Genome {
 
     fn gene_mut(&mut self, index: usize) -> Option<&mut Self::Gene>;
 }
+
+static_assertions::assert_obj_safe!(Linear<Gene = ()>);

--- a/packages/ec-linear/src/mutator/with_one_over_length.rs
+++ b/packages/ec-linear/src/mutator/with_one_over_length.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, ops::Not};
 use ec_core::operator::mutator::Mutator;
 use miette::Diagnostic;
 use num_traits::ToPrimitive;
-use rand::rngs::ThreadRng;
+use rand::Rng;
 
 use super::with_rate::WithRate;
 use crate::genome::Linear;
@@ -21,7 +21,7 @@ where
 {
     type Error = GenomeSizeConversionError;
 
-    fn mutate(&self, genome: Vec<T>, rng: &mut ThreadRng) -> Result<Vec<T>, Self::Error> {
+    fn mutate<R: Rng + ?Sized>(&self, genome: Vec<T>, rng: &mut R) -> Result<Vec<T>, Self::Error> {
         let genome_length = genome
             .len()
             .to_f32()
@@ -43,7 +43,7 @@ where
 {
     type Error = GenomeSizeConversionError;
 
-    fn mutate(&self, genome: T, rng: &mut ThreadRng) -> Result<T, Self::Error> {
+    fn mutate<R: Rng + ?Sized>(&self, genome: T, rng: &mut R) -> Result<T, Self::Error> {
         let genome_length = genome
             .size()
             .to_f32()

--- a/packages/ec-linear/src/mutator/with_rate.rs
+++ b/packages/ec-linear/src/mutator/with_rate.rs
@@ -1,7 +1,7 @@
 use std::{convert::Infallible, ops::Not};
 
 use ec_core::operator::mutator::Mutator;
-use rand::{Rng, rngs::ThreadRng};
+use rand::Rng;
 
 use crate::genome::Linear;
 
@@ -17,7 +17,7 @@ where
 {
     type Error = Infallible;
 
-    fn mutate(&self, genome: Vec<T>, rng: &mut ThreadRng) -> Result<Vec<T>, Self::Error> {
+    fn mutate<R: Rng + ?Sized>(&self, genome: Vec<T>, rng: &mut R) -> Result<Vec<T>, Self::Error> {
         Ok(genome
             .into_iter()
             .map(|bit| {
@@ -37,7 +37,8 @@ where
     T::Gene: Not<Output = T::Gene>,
 {
     type Error = Infallible;
-    fn mutate(&self, genome: T, rng: &mut ThreadRng) -> Result<T, Self::Error> {
+
+    fn mutate<R: Rng + ?Sized>(&self, genome: T, rng: &mut R) -> Result<T, Self::Error> {
         Ok(genome
             .into_iter()
             .map(|bit| {

--- a/packages/ec-linear/src/recombinator/two_point_xo.rs
+++ b/packages/ec-linear/src/recombinator/two_point_xo.rs
@@ -1,5 +1,5 @@
 use ec_core::operator::recombinator::Recombinator;
-use rand::{Rng, rngs::ThreadRng};
+use rand::Rng;
 
 use super::{
     crossover::Crossover,
@@ -14,10 +14,10 @@ impl<T> Recombinator<[Vec<T>; 2]> for TwoPointXo {
     type Output = Vec<T>;
     type Error = DifferentGenomeLength;
 
-    fn recombine(
+    fn recombine<R: Rng + ?Sized>(
         &self,
         [mut first_genome, mut second_genome]: [Vec<T>; 2],
-        rng: &mut ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         let len = first_genome.len();
         if len != second_genome.len() {
@@ -39,10 +39,10 @@ impl<T> Recombinator<(Vec<T>, Vec<T>)> for TwoPointXo {
     type Output = Vec<T>;
     type Error = <Self as Recombinator<[Vec<T>; 2]>>::Error;
 
-    fn recombine(
+    fn recombine<R: Rng + ?Sized>(
         &self,
         genomes: (Vec<T>, Vec<T>),
-        rng: &mut ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         self.recombine(<[Vec<T>; 2]>::from(genomes), rng)
     }
@@ -67,10 +67,10 @@ where
     type Output = G;
     type Error = CrossoverGeneError<G::SegmentCrossoverError>;
 
-    fn recombine(
+    fn recombine<R: Rng + ?Sized>(
         &self,
         [mut first_genome, mut second_genome]: [G; 2],
-        rng: &mut ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         let len = first_genome.size();
         if len != second_genome.size() {
@@ -97,7 +97,11 @@ where
     type Output = G;
     type Error = <Self as Recombinator<[G; 2]>>::Error;
 
-    fn recombine(&self, genomes: (G, G), rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
+    fn recombine<R: Rng + ?Sized>(
+        &self,
+        genomes: (G, G),
+        rng: &mut R,
+    ) -> Result<Self::Output, Self::Error> {
         self.recombine(<[G; 2]>::from(genomes), rng)
     }
 }

--- a/packages/ec-linear/src/recombinator/uniform_xo.rs
+++ b/packages/ec-linear/src/recombinator/uniform_xo.rs
@@ -1,5 +1,5 @@
 use ec_core::operator::recombinator::Recombinator;
-use rand::{Rng, rngs::ThreadRng};
+use rand::Rng;
 
 use super::{
     crossover::Crossover,
@@ -14,10 +14,10 @@ impl<T: Clone> Recombinator<[Vec<T>; 2]> for UniformXo {
     type Output = Vec<T>;
     type Error = DifferentGenomeLength;
 
-    fn recombine(
+    fn recombine<R: Rng + ?Sized>(
         &self,
         [first_genome, second_genome]: [Vec<T>; 2],
-        rng: &mut ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         let len = first_genome.len();
         if len != second_genome.len() {
@@ -39,10 +39,10 @@ impl<T: Clone> Recombinator<(Vec<T>, Vec<T>)> for UniformXo {
     type Output = Vec<T>;
     type Error = <Self as Recombinator<[Vec<T>; 2]>>::Error;
 
-    fn recombine(
+    fn recombine<R: Rng + ?Sized>(
         &self,
         genomes: (Vec<T>, Vec<T>),
-        rng: &mut ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         self.recombine(<[Vec<T>; 2]>::from(genomes), rng)
     }
@@ -55,10 +55,10 @@ where
     type Output = G;
     type Error = CrossoverGeneError<G::GeneCrossoverError>;
 
-    fn recombine(
+    fn recombine<R: Rng + ?Sized>(
         &self,
         [mut first_genome, mut second_genome]: [G; 2],
-        rng: &mut ThreadRng,
+        rng: &mut R,
     ) -> Result<Self::Output, Self::Error> {
         let len = first_genome.size();
         if len != second_genome.size() {
@@ -83,7 +83,11 @@ where
     type Output = G;
     type Error = <Self as Recombinator<[G; 2]>>::Error;
 
-    fn recombine(&self, genomes: (G, G), rng: &mut ThreadRng) -> Result<Self::Output, Self::Error> {
+    fn recombine<R: Rng + ?Sized>(
+        &self,
+        genomes: (G, G),
+        rng: &mut R,
+    ) -> Result<Self::Output, Self::Error> {
         self.recombine(<[G; 2]>::from(genomes), rng)
     }
 }

--- a/packages/ec-macros/Cargo.toml
+++ b/packages/ec-macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ec_macros"
+version = { workspace = true }
+authors = { workspace = true }
+description = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+categories = ["development-tools"]
+# keywords = ["push", "proc-macros", "builder-pattern"]
+readme = "README.md"
+publish = false
+
+[lib]
+proc-macro=true
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+manyhow = "0.11.4"
+proc-macro2 = "1.0.81"
+quote = "1.0.33"
+syn = { version = "2.0.58", features = ["full", "printing"] }

--- a/packages/ec-macros/src/lib.rs
+++ b/packages/ec-macros/src/lib.rs
@@ -1,0 +1,89 @@
+#![doc(test(attr(warn(unused))))]
+
+use quote::quote;
+use syn::TypeReference;
+
+mod modification;
+use modification::*;
+
+wrap_modification!(Pointer; ty ; &#ty);
+wrap_modification!(MutPointer; ty ; &mut #ty);
+wrap_modification!(Arc; ty ; std::sync::Arc<#ty>);
+wrap_modification!(Rc; ty ; std::rc::Rc<#ty>);
+wrap_modification!(Ref; ty ; std::cell::Ref<'_,#ty>);
+wrap_modification!(RefMut; ty ; std::cell::RefMut<'_,#ty>);
+wrap_modification!(BoxMod; ty ; Box<#ty>);
+
+static PRELIMINARY_MODIFICATIONS: fn() -> Vec<Box<dyn Modification>> = || {
+    vec![
+        Box::new(Passthrough),
+        Box::new(AddAutoTraits(syn::parse_quote!(Send))),
+        Box::new(AddAutoTraits(syn::parse_quote!(Sync))),
+        Box::new(AddAutoTraits(syn::parse_quote!(Send + Sync))),
+    ]
+};
+
+static MUT_ALTERNATIVES: fn() -> Vec<Box<dyn Modification>> =
+    || vec![Box::new(MutPointer), Box::new(RefMut), Box::new(BoxMod)];
+
+static SHARED_ALTERNATIVES: fn() -> Vec<Box<dyn Modification>> = || {
+    vec![
+        Box::new(Pointer),
+        Box::new(MutPointer),
+        Box::new(RefMut),
+        Box::new(BoxMod),
+        Box::new(Arc),
+        Box::new(Rc),
+        Box::new(Ref),
+    ]
+};
+
+/// Annotate your trait impl for a reference type with this to automatically
+/// generate impls for a predefined set of compatible smart pointer types as
+/// well, as well as for the same type and the bounds `Send` and `Sync` or any
+/// combination
+///
+/// This is usually used to generate normal trait impls for corresponding trait
+/// objects of erased variants of the trait
+#[manyhow::manyhow(proc_macro_attribute)]
+pub fn dyn_ref_impls(a: proc_macro2::TokenStream, tokens: syn::ItemImpl) -> manyhow::Result {
+    manyhow::ensure!(a.is_empty(), a, "Expected no inputs");
+
+    match tokens.trait_ {
+        Some((None, _, _)) => {}
+        _ => manyhow::bail!(tokens, "Only non-negative trait impls are supported"),
+    }
+
+    let ty = tokens.self_ty.clone();
+
+    let (modifications, ty) = match *ty {
+        syn::Type::Reference(TypeReference {
+            mutability: Some(_),
+            elem,
+            ..
+        }) => (MUT_ALTERNATIVES, *elem),
+        syn::Type::Reference(TypeReference {
+            mutability: None,
+            elem,
+            ..
+        }) => (SHARED_ALTERNATIVES, *elem),
+        _ => manyhow::bail!(
+            ty,
+            "Only reference types (&, &mut) are supported at the moment"
+        ),
+    };
+
+    let prelim_mods = PRELIMINARY_MODIFICATIONS();
+    let modifications = modifications();
+
+    let out = modifications
+        .iter()
+        .flat_map(|m| prelim_mods.iter().map(|s1m| m.apply(s1m.apply(ty.clone()))))
+        .map(|t| {
+            let mut out = tokens.clone();
+            out.self_ty = Box::new(t);
+            out
+        });
+
+    Ok(quote! {#(#out)*})
+}

--- a/packages/ec-macros/src/modification.rs
+++ b/packages/ec-macros/src/modification.rs
@@ -1,0 +1,35 @@
+use syn::{Token, TypeParamBound, punctuated::Punctuated};
+
+pub trait Modification {
+    fn apply(&self, ty: syn::Type) -> syn::Type;
+}
+
+#[derive(Clone)]
+pub struct Passthrough;
+impl Modification for Passthrough {
+    fn apply(&self, ty: syn::Type) -> syn::Type {
+        ty
+    }
+}
+
+#[derive(Clone)]
+pub struct AddAutoTraits(pub Punctuated<TypeParamBound, Token![+]>);
+impl Modification for AddAutoTraits {
+    fn apply(&self, ty: syn::Type) -> syn::Type {
+        let bounds = &self.0;
+        syn::parse_quote!((#ty + #bounds))
+    }
+}
+
+macro_rules! wrap_modification {
+    ($i: ident; $tp:ident; $($t:tt)*) => {
+        #[derive(Clone)]
+        struct $i;
+        impl Modification for $i {
+            fn apply(&self, $tp: syn::Type) -> syn::Type {
+                syn::parse_quote!($($t)*)
+            }
+        }
+    }
+}
+pub(crate) use wrap_modification;

--- a/packages/push/Cargo.toml
+++ b/packages/push/Cargo.toml
@@ -19,6 +19,7 @@ num-traits = { workspace = true }
 rand = { workspace = true , features = ["alloc"] }
 thiserror = { workspace = true }
 miette = { workspace = true }
+static_assertions = { workspace = true }
 
 ec-core = { workspace = true }
 ec-linear = { workspace = true }

--- a/packages/push/src/error/into_state.rs
+++ b/packages/push/src/error/into_state.rs
@@ -1,3 +1,5 @@
 pub trait IntoState<S> {
     fn into_state(self) -> S;
 }
+
+static_assertions::assert_obj_safe!(IntoState<()>);

--- a/packages/push/src/error/mod.rs
+++ b/packages/push/src/error/mod.rs
@@ -30,6 +30,8 @@ pub trait MapInstructionError<S, E> {
     fn map_err_into(self) -> InstructionResult<S, E>;
 }
 
+static_assertions::assert_obj_safe!(MapInstructionError<(),()>);
+
 // MizardX@Twitch's initial suggestion here had `E2` as a generic on the
 // _function_ `map_err_into()` instead of at the `impl` level. That provided
 // some additional flexibility, although it wasn't clear that we would use it.

--- a/packages/push/src/error/stateful.rs
+++ b/packages/push/src/error/stateful.rs
@@ -12,6 +12,8 @@ mod private {
 
 pub trait ErrorSeverity: private::SealedMarker {}
 
+static_assertions::assert_obj_safe!(ErrorSeverity);
+
 #[derive(Debug)]
 pub struct Fatal;
 impl ErrorSeverity for Fatal {}

--- a/packages/push/src/error/try_recover.rs
+++ b/packages/push/src/error/try_recover.rs
@@ -7,3 +7,5 @@ pub trait TryRecover<T> {
     /// type.
     fn try_recover(self) -> Result<T, Self::Error>;
 }
+
+static_assertions::assert_obj_safe!(TryRecover<(), Error = ()>);

--- a/packages/push/src/instruction/mod.rs
+++ b/packages/push/src/instruction/mod.rs
@@ -47,6 +47,8 @@ pub trait Instruction<S> {
     fn perform(&self, state: S) -> InstructionResult<S, Self::Error>;
 }
 
+static_assertions::assert_obj_safe!(Instruction<(), Error = ()>);
+
 impl<S, E> Instruction<S> for Box<dyn Instruction<S, Error = E>> {
     type Error = E;
 
@@ -105,6 +107,8 @@ pub trait NumOpens {
         0
     }
 }
+
+static_assertions::assert_obj_safe!(NumOpens);
 
 impl NumOpens for PushInstruction {
     fn num_opens(&self) -> usize {

--- a/packages/push/src/push_vm/mod.rs
+++ b/packages/push/src/push_vm/mod.rs
@@ -9,7 +9,6 @@ pub mod stack;
 
 pub use self::stack::HasStack;
 
-// Need an associated error trait
 pub trait State: Sized {
     type Instruction: Instruction<Self>;
 

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -113,6 +113,8 @@ pub trait StackType {
     type Type;
 }
 
+static_assertions::assert_obj_safe!(StackType<Type = ()>);
+
 impl<T> StackType for Stack<T> {
     type Type = T;
 }


### PR DESCRIPTION
This removes all the hardcoded `ThreadRng` parameters in our library code. 

~~Since those traits might now loose Object-Safety, we need erased variants for them. This doesn't add any Erased traits for now, see the next commit for that.~~ Edit: now included

This also adds a feature `erased` to all crates that need type erased traits, which can be used to optionally enable them. Since we kind of hand-rolled an erased type for the DynWeighted Selector previously, this moves the DynWeighted selector behind that feature flag and uses our newly created erased variant of selector as well.