### PR TITLE
Implement Population trait via a blanket impl for any objects that have a sized iterator from it's reference and not just for `Vec<T>`

### DIFF
--- a/packages/ec-core/src/operator/selector/best.rs
+++ b/packages/ec-core/src/operator/selector/best.rs
@@ -39,10 +39,7 @@ mod tests {
 
     #[test]
     fn can_select_twice() {
-        // Currently `.select()` can't take an array, so we need to make this a `Vec`.
-        // Once we've generalized `.select()` appropriately we can change this to be
-        // an array. See #259
-        let pop = vec![5, 8, 9, 6, 3, 2, 0];
+        let pop = [5, 8, 9, 6, 3, 2, 0];
         let mut rng = rand::rng();
         assert_eq!(&9, Best.select(&pop, &mut rng).unwrap());
         assert_eq!(&9, Best.select(&pop, &mut rng).unwrap());

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -27,7 +27,7 @@ pub use error::EmptyPopulation;
 /// # use ec_core::operator::selector::{best::Best, Selector};
 /// # use rand::rng;
 /// #
-/// let population = vec![5, 8, 9, 2, 3, 6];
+/// let population = [5, 8, 9, 2, 3, 6];
 /// let winner = Best.select(&population, &mut rng())?;
 /// assert_eq!(*winner, 9);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -42,19 +42,19 @@ pub use error::EmptyPopulation;
 /// #
 /// struct First;
 ///
-/// impl Selector<Vec<u8>> for First {
+/// impl<const N: usize> Selector<[u8; N]> for First {
 ///     type Error = EmptyPopulation;
 ///
 ///     fn select<'pop>(
 ///         &self,
-///         population: &'pop Vec<u8>,
+///         population: &'pop [u8; N],
 ///         _: &mut ThreadRng,
 ///     ) -> Result<&'pop u8, Self::Error> {
 ///         population.first().ok_or(EmptyPopulation)
 ///     }
 /// }
 ///
-/// let population = vec![5, 8, 9];
+/// let population = [5, 8, 9];
 /// let choice = First.select(&population, &mut rng())?;
 /// assert_eq!(*choice, 5);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -101,12 +101,12 @@ where
 /// #
 /// struct First; // Simple selector that always returns the first element in a vector.
 ///
-/// impl<T> Selector<Vec<T>> for First {
+/// impl<T, const N: usize> Selector<[T; N]> for First {
 ///     type Error = EmptyPopulation;
 ///
 ///     fn select<'pop>(
 ///         &self,
-///         population: &'pop Vec<T>,
+///         population: &'pop [T; N],
 ///         _: &mut ThreadRng,
 ///     ) -> Result<&'pop T, Self::Error> {
 ///         population.first().ok_or(EmptyPopulation)
@@ -115,7 +115,7 @@ where
 ///
 /// // Create a `Select` operator from the `First` selector
 /// let select = Select::new(First);
-/// let population: Vec<u8> = vec![5, 8, 9];
+/// let population = [5u8, 8, 9];
 ///
 /// // Selectors return references to the individuals they choose, so we
 /// // get a `&u8` back from `select` and `apply`.
@@ -142,12 +142,12 @@ where
 /// #
 /// # struct First; // Simple selector that always returns the first element in a vector.
 /// #
-/// # impl<T> Selector<Vec<T>> for First {
+/// # impl<T, const N: usize> Selector<[T;N]> for First {
 /// #    type Error = EmptyPopulation;
 /// #
 /// #    fn select<'pop>(
 /// #        &self,
-/// #        population: &'pop Vec<T>,
+/// #        population: &'pop [T;N],
 /// #        _: &mut ThreadRng,
 /// #    ) -> Result<&'pop T, Self::Error> {
 /// #        population
@@ -175,7 +175,7 @@ where
 ///
 /// let select = Select::new(First);
 /// let chain = select.then(StrLen);
-/// let population: Vec<String> = vec!["Hello".to_string(), "World".to_string()];
+/// let population = ["Hello".to_string(), "World".to_string()];
 ///
 /// // The `StrLen` operator will take the `&String` returned by the `First`
 /// // selector and return its length.
@@ -197,12 +197,12 @@ where
 /// #
 /// # struct First; // Simple selector that always returns the first element in a vector.
 /// #
-/// # impl<T> Selector<Vec<T>> for First {
+/// # impl<T, const N:usize> Selector<[T;N]> for First {
 /// #    type Error = EmptyPopulation;
 /// #
 /// #    fn select<'pop>(
 /// #        &self,
-/// #        population: &'pop Vec<T>,
+/// #        population: &'pop [T;N],
 /// #        _: &mut ThreadRng,
 /// #    ) -> Result<&'pop T, Self::Error> {
 /// #        population
@@ -225,7 +225,7 @@ where
 /// #
 /// let ref_select = Select::new(&First);
 /// let chain = ref_select.then(StrLen);
-/// let population: Vec<String> = vec!["Hello".to_string(), "World".to_string()];
+/// let population = ["Hello".to_string(), "World".to_string()];
 /// let choice_length: usize = chain.apply(&population, &mut rng())?;
 /// assert_eq!(choice_length, 5);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -289,12 +289,12 @@ mod tests {
     // A simple `Selector`` that always returns the first item in a vector.
     struct First;
 
-    impl<T> Selector<Vec<T>> for First {
+    impl<T, const N: usize> Selector<[T; N]> for First {
         type Error = EmptyPopulation;
 
         fn select<'pop>(
             &self,
-            population: &'pop Vec<T>,
+            population: &'pop [T; N],
             _: &mut ThreadRng,
         ) -> Result<&'pop T, Self::Error> {
             population.first().ok_or(EmptyPopulation)
@@ -320,7 +320,7 @@ mod tests {
 
     #[test]
     fn can_implement_simple_selector() {
-        let population = vec![5, 8, 9];
+        let population = [5, 8, 9];
         let choice = First.select(&population, &mut rng()).unwrap();
         assert_eq!(*choice, 5);
     }
@@ -328,7 +328,7 @@ mod tests {
     #[test]
     fn can_wrap_selector() {
         let select = Select::new(First);
-        let population = vec![5, 8, 9];
+        let population = [5, 8, 9];
         let choice = select.apply(&population, &mut rng()).unwrap();
         assert_eq!(*choice, 5);
     }
@@ -338,7 +338,7 @@ mod tests {
         // Make sure that we can pass a reference to a selector to `Select` and
         // still successfully select values.
         let select = Select::new(&First);
-        let population = vec![5, 8, 9];
+        let population = [5, 8, 9];
         let choice = select.apply(&population, &mut rng()).unwrap();
         assert_eq!(*choice, 5);
     }
@@ -348,7 +348,7 @@ mod tests {
         let select = Select::new(First);
         let double = StrLen;
         let chain = select.then(double);
-        let population: Vec<String> = vec!["Hello".to_string(), "World!".to_string()];
+        let population = ["Hello".to_string(), "World!".to_string()];
         let length_of_choice: usize = chain.apply(&population, &mut rng()).unwrap();
         assert_eq!(length_of_choice, 5);
     }
@@ -360,7 +360,7 @@ mod tests {
         let select = Select::new(&First);
         let double = StrLen;
         let chain = select.then(double);
-        let population: Vec<String> = vec!["Hello".to_string(), "World!".to_string()];
+        let population = ["Hello".to_string(), "World!".to_string()];
         let length_of_choice: usize = chain.apply(&population, &mut rng()).unwrap();
         assert_eq!(length_of_choice, 5);
     }

--- a/packages/ec-core/src/operator/selector/tournament.rs
+++ b/packages/ec-core/src/operator/selector/tournament.rs
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn tournament_size_larger_than_population() {
-        let pop: Vec<i32> = vec![0];
+        let pop = [0];
         let mut rng = rand::rng();
         let selector = Tournament::of_size::<2>();
         assert!(matches!(

--- a/packages/ec-core/src/population.rs
+++ b/packages/ec-core/src/population.rs
@@ -12,6 +12,17 @@ impl<T, I> Population for T
 where
     // An alternative would be `T: Deref<[T]>` but this also supports
     // hashsets, etc.
+    //
+    // This might look a bit confusing but essentially what this bound
+    // combination does is require both a `iter(&self) -> impl Iterator<Item
+    // = &T>` as well as a `into_iter(self) -> impl Iterator<Item = T>`
+    // method on the collection implementing population,
+    // which enables us to get the size of the collection without consuming
+    // it (through the `.iter()` method, since it takes `&self`) as well
+    // as turning this population into an iterator.
+    //
+    // Just requiring `.into_iter()` wouldn't work, since we don't want to
+    // consume the population to implement the `.size()` method.
     for<'a> &'a T: IntoIterator<Item = &'a I, IntoIter: ExactSizeIterator>,
     T: IntoIterator<Item = I>,
 {

--- a/packages/ec-core/src/population.rs
+++ b/packages/ec-core/src/population.rs
@@ -8,11 +8,17 @@ pub trait Population {
     fn size(&self) -> usize;
 }
 
-impl<I> Population for Vec<I> {
+impl<T, I> Population for T
+where
+    // An alternative would be `T: Deref<[T]>` but this also supports
+    // hashsets, etc.
+    for<'a> &'a T: IntoIterator<Item = &'a I, IntoIter: ExactSizeIterator>,
+    T: IntoIterator<Item = I>,
+{
     type Individual = I;
 
     fn size(&self) -> usize {
-        self.len()
+        self.into_iter().len()
     }
 }
 

--- a/packages/ec-core/src/test_results.rs
+++ b/packages/ec-core/src/test_results.rs
@@ -312,41 +312,35 @@ mod test_results_from_vec {
 
     #[test]
     fn create_test_results_from_errors() {
-        let errors = vec![5, 8, 0, 9];
-        let test_results: TestResults<Error<i32>> = errors.clone().into();
-        assert_eq!(
-            test_results.results.iter().map(|r| r.0).collect::<Vec<_>>(),
-            errors
-        );
+        let errors = [5, 8, 0, 9];
+        let test_results: TestResults<Error<i32>> = errors.into();
+        assert!(test_results.results.iter().map(|r| r.0).eq(errors));
         assert_eq!(test_results.total_result, errors.into_iter().sum());
     }
 
     #[test]
     fn create_test_results_from_scores() {
-        let scores = vec![5, 8, 0, 9];
-        let test_results: TestResults<Score<i32>> = scores.clone().into();
-        assert_eq!(
-            test_results.results.iter().map(|r| r.0).collect::<Vec<_>>(),
-            scores
-        );
+        let scores = [5, 8, 0, 9];
+        let test_results: TestResults<Score<i32>> = scores.into();
+        assert!(test_results.results.iter().map(|r| r.0).eq(scores));
         assert_eq!(test_results.total_result, scores.into_iter().sum());
     }
 
     #[test]
     fn create_test_results_from_iter_errors() {
-        let errors = vec![5, 8, 0, 9];
+        let errors = [5, 8, 0, 9];
         let results = errors.iter().copied().map(Error::from);
         let test_results: TestResults<Error<i32>> = results.clone().collect();
-        assert_eq!(test_results.results, results.collect::<Vec<_>>());
+        assert!(test_results.results.into_iter().eq(results));
         assert_eq!(test_results.total_result, errors.into_iter().sum());
     }
 
     #[test]
     fn create_test_results_from_iter_scores() {
-        let scores = vec![5, 8, 0, 9];
+        let scores = [5, 8, 0, 9];
         let results = scores.iter().copied().map(Score::from);
         let test_results: TestResults<Score<i32>> = results.clone().collect();
-        assert_eq!(test_results.results, results.collect::<Vec<_>>());
+        assert!(test_results.results.into_iter().eq(results));
         assert_eq!(test_results.total_result, scores.into_iter().sum());
     }
 }

--- a/packages/ec-core/src/weighted/weighted_pair.rs
+++ b/packages/ec-core/src/weighted/weighted_pair.rs
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn zero_weight_sum_error() {
-        let pop = vec![5, 8, 9, 6, 3, 2, 0];
+        let pop = [5, 8, 9, 6, 3, 2, 0];
         let mut rng = rand::rng();
         let weighted = Weighted::new(Best, 0)
             .with_item_and_weight(Worst, 0)

--- a/packages/push/src/push_vm/push_state.rs
+++ b/packages/push/src/push_vm/push_state.rs
@@ -171,8 +171,8 @@ mod simple_check {
         let state = state.run_to_completion().unwrap();
 
         assert!(state.exec.is_empty());
-        assert_eq!(&state.int, &vec![5, 17]);
-        assert_eq!(&state.bool, &vec![true, false]);
-        assert_eq!(&state.float, &vec![OrderedFloat(13.0)]);
+        assert_eq!(&state.int, &[5, 17]);
+        assert_eq!(&state.bool, &[true, false]);
+        assert_eq!(&state.float, &[OrderedFloat(13.0)]);
     }
 }

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -420,12 +420,12 @@ impl<T> Stack<T> {
     /// let mut stack: Stack<i64> = Stack::default();
     /// assert_eq!(stack.size(), 0);
     ///
-    /// stack.push_many(vec![5, 8, 9])?;
+    /// stack.push_many([5, 8, 9])?;
     /// // Now the top of the stack is 5, followed by 8, then 9 at the bottom.
     /// assert_eq!(stack.size(), 3);
     /// assert_eq!(stack.top()?, &5);
     ///
-    /// stack.push_many(vec![6, 3])?;
+    /// stack.push_many([6, 3])?;
     /// // Now the top of the stack is 6 and the whole stack is 6, 3, 5, 8, 9.
     /// assert_eq!(stack.size(), 5);
     /// assert_eq!(stack.top()?, &6);

--- a/packages/push/tests/float.rs
+++ b/packages/push/tests/float.rs
@@ -38,7 +38,7 @@ fn add() {
     let y = OrderedFloat(512.825);
     let state = PushState::builder()
         .with_max_stack_size(2)
-        .with_float_values(vec![x, y])
+        .with_float_values([x, y])
         .unwrap()
         .with_no_program()
         .build();
@@ -54,10 +54,10 @@ fn overflow_bool_stack() {
         // Set the max stack size to 2 so we can cause it to overflow.
         .with_max_stack_size(2)
         // Push two copies of x so we can call `FloatInstruction::Equal`
-        .with_float_values(vec![x, x])
+        .with_float_values([x, x])
         .unwrap()
         // Now fill the boolean stack so that it overflows when we check the floats for equality
-        .with_bool_values(vec![false, false])
+        .with_bool_values([false, false])
         .unwrap()
         .with_no_program()
         .build();


### PR DESCRIPTION
Also removes some superfluous collects using iterator equality and some unneeded vecs in other places