### PR TITLE
Disable unwrap lint in tests, remove manual expect's

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -17,3 +17,6 @@ allowed-duplicate-crates = [
   "windows_x86_64_gnullvm",
   "windows_x86_64_msvc"
 ]
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true

--- a/packages/ec-core/src/distributions/one_of_macro.rs
+++ b/packages/ec-core/src/distributions/one_of_macro.rs
@@ -75,10 +75,6 @@ macro_rules! uniform_distribution_of {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod test {
     use crate::distributions::conversion::IntoDistribution;
 

--- a/packages/ec-core/src/operator/composable/repeat_with.rs
+++ b/packages/ec-core/src/operator/composable/repeat_with.rs
@@ -52,10 +52,6 @@ impl<F, const N: usize> Composable for RepeatWith<F, N> {}
     reason = "The tradeoff safety <> ease of writing arguably lies on the ease of writing side \
               for test code."
 )]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use std::{convert::Infallible, ops::Range};
 

--- a/packages/ec-core/src/operator/composable/then.rs
+++ b/packages/ec-core/src/operator/composable/then.rs
@@ -40,10 +40,6 @@ impl<F, G> Composable for Then<F, G> {}
     reason = "The tradeoff safety <> ease of writing arguably lies on the ease of writing side \
               for test code."
 )]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 pub mod tests {
     use std::convert::Infallible;
 

--- a/packages/ec-core/src/operator/genome_extractor.rs
+++ b/packages/ec-core/src/operator/genome_extractor.rs
@@ -80,7 +80,6 @@ where
 
 impl Composable for GenomeExtractor {}
 
-#[expect(clippy::unwrap_used, reason = "panicking is appropriate in tests")]
 #[cfg(test)]
 mod tests {
     use rand::{Rng, rngs::ThreadRng, thread_rng};

--- a/packages/ec-core/src/operator/mutator/mod.rs
+++ b/packages/ec-core/src/operator/mutator/mod.rs
@@ -256,10 +256,6 @@ where
     }
 }
 
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 #[cfg(test)]
 mod tests {
     use rand::{Rng, rngs::ThreadRng, thread_rng};

--- a/packages/ec-core/src/operator/recombinator/mod.rs
+++ b/packages/ec-core/src/operator/recombinator/mod.rs
@@ -309,10 +309,6 @@ where
     }
 }
 
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;

--- a/packages/ec-core/src/operator/selector/best.rs
+++ b/packages/ec-core/src/operator/selector/best.rs
@@ -24,10 +24,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use test_strategy::proptest;
 

--- a/packages/ec-core/src/operator/selector/dyn_weighted.rs
+++ b/packages/ec-core/src/operator/selector/dyn_weighted.rs
@@ -103,10 +103,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use itertools::Itertools;
     use test_strategy::proptest;

--- a/packages/ec-core/src/operator/selector/lexicase.rs
+++ b/packages/ec-core/src/operator/selector/lexicase.rs
@@ -101,10 +101,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use std::iter::once;
 

--- a/packages/ec-core/src/operator/selector/mod.rs
+++ b/packages/ec-core/src/operator/selector/mod.rs
@@ -283,10 +283,6 @@ where
     }
 }
 
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 #[cfg(test)]
 mod tests {
     use anyhow::Context;

--- a/packages/ec-core/src/operator/selector/random.rs
+++ b/packages/ec-core/src/operator/selector/random.rs
@@ -22,10 +22,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use test_strategy::proptest;
 

--- a/packages/ec-core/src/operator/selector/tournament.rs
+++ b/packages/ec-core/src/operator/selector/tournament.rs
@@ -99,11 +99,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "`max()` and `min()` can fail if the list of individuals is empty, but we know that \
-              can't happen so we'll unwrap"
-)]
 mod tests {
     use std::{num::NonZeroUsize, ops::Not};
 

--- a/packages/ec-core/src/operator/selector/worst.rs
+++ b/packages/ec-core/src/operator/selector/worst.rs
@@ -24,10 +24,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use test_strategy::proptest;
 

--- a/packages/ec-core/src/weighted/weighted_pair.rs
+++ b/packages/ec-core/src/weighted/weighted_pair.rs
@@ -70,10 +70,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use itertools::Itertools;
     use test_strategy::proptest;

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -109,10 +109,6 @@ where
     reason = "The tradeoff safety <> ease of writing arguably lies on the ease of writing side \
               for test code."
 )]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod test {
     use ec_core::uniform_distribution_of;
     use rand::thread_rng;

--- a/packages/ec-linear/src/mutator/with_one_over_length.rs
+++ b/packages/ec-linear/src/mutator/with_one_over_length.rs
@@ -46,10 +46,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use std::iter::zip;
 

--- a/packages/ec-linear/src/mutator/with_rate.rs
+++ b/packages/ec-linear/src/mutator/with_rate.rs
@@ -54,10 +54,6 @@ impl WithRate {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use std::iter::zip;
 

--- a/packages/push/benches/regression-evaluation.rs
+++ b/packages/push/benches/regression-evaluation.rs
@@ -1,7 +1,4 @@
-#![expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in benches"
-)]
+#![cfg(test)]
 #![expect(
     clippy::arithmetic_side_effects,
     reason = "The tradeoff safety <> ease of writing arguably lies on the ease of writing side \

--- a/packages/push/src/genome/plushy.rs
+++ b/packages/push/src/genome/plushy.rs
@@ -245,10 +245,6 @@ impl FromIterator<PushGene> for Plushy {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod test {
     use ec_core::{
         distributions::collection::ConvertToCollectionGenerator, operator::mutator::Mutator,

--- a/packages/push/src/instruction/bool.rs
+++ b/packages/push/src/instruction/bool.rs
@@ -107,10 +107,6 @@ impl From<BoolInstruction> for PushInstruction {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod property_tests {
     use proptest::prop_assert_eq;
     use strum::IntoEnumIterator;

--- a/packages/push/src/instruction/exec/dup_block.rs
+++ b/packages/push/src/instruction/exec/dup_block.rs
@@ -82,10 +82,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use super::DupBlock;
     use crate::{

--- a/packages/push/src/instruction/exec/ifelse.rs
+++ b/packages/push/src/instruction/exec/ifelse.rs
@@ -150,10 +150,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use super::IfElse;
     use crate::{

--- a/packages/push/src/instruction/exec/noop.rs
+++ b/packages/push/src/instruction/exec/noop.rs
@@ -28,10 +28,6 @@ impl<S> Instruction<S> for Noop {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use super::Noop;
     use crate::{

--- a/packages/push/src/instruction/exec/unless.rs
+++ b/packages/push/src/instruction/exec/unless.rs
@@ -110,10 +110,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use super::Unless;
     use crate::{

--- a/packages/push/src/instruction/exec/when.rs
+++ b/packages/push/src/instruction/exec/when.rs
@@ -111,10 +111,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use super::When;
     use crate::{

--- a/packages/push/src/instruction/int/abs.rs
+++ b/packages/push/src/instruction/int/abs.rs
@@ -91,10 +91,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
     use proptest::prop_assert_eq;
     use test_strategy::proptest;

--- a/packages/push/src/instruction/int/negate.rs
+++ b/packages/push/src/instruction/int/negate.rs
@@ -91,10 +91,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod tests {
 
     use proptest::prop_assert_eq;

--- a/packages/push/src/instruction/variable_name.rs
+++ b/packages/push/src/instruction/variable_name.rs
@@ -24,10 +24,6 @@ impl Display for VariableName {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 pub(crate) mod variable_name_test {
     use std::collections::HashMap;
 

--- a/packages/push/src/push_vm/program.rs
+++ b/packages/push/src/push_vm/program.rs
@@ -97,10 +97,6 @@ impl Instruction<PushState> for PushProgram {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod test {
     use super::PushProgram;
     use crate::{

--- a/packages/push/src/push_vm/push_state.rs
+++ b/packages/push/src/push_vm/push_state.rs
@@ -107,10 +107,6 @@ impl State for PushState {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod simple_check {
     use ordered_float::OrderedFloat;
 

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -542,10 +542,6 @@ where
 // correct `Underflow` and `Overflow` errors.
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in unit tests"
-)]
 mod test {
     use super::{Stack, StackError};
 

--- a/packages/push/tests/float.rs
+++ b/packages/push/tests/float.rs
@@ -1,9 +1,5 @@
 #![cfg(test)]
 #![expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in integration tests"
-)]
-#![expect(
     clippy::arithmetic_side_effects,
     reason = "The tradeoff safety <> ease of writing arguably lies on the ease of writing side \
               for test code."

--- a/packages/push/tests/int.rs
+++ b/packages/push/tests/int.rs
@@ -1,8 +1,4 @@
 #![cfg(test)]
-#![expect(
-    clippy::unwrap_used,
-    reason = "Panicking is the best way to deal with errors in integration tests"
-)]
 
 use proptest::prop_assert_eq;
 use push::{


### PR DESCRIPTION
Removes the expects for unwrap lints all over the place and instead allows unwraps in tests using the corresponding clippy config option