### PR TITLE
Change stack try_extend impl to avoid additional heap allocations 

### DIFF
--- a/packages/push-macros/src/push_state/printing/generate_builder.rs
+++ b/packages/push-macros/src/push_state/printing/generate_builder.rs
@@ -299,7 +299,7 @@ pub fn generate_builder(
                                 ::std::iter::DoubleEndedIterator +
                                 ::std::iter::ExactSizeIterator,
                         {
-                            self.partial_state.#field.try_extend(values)?;
+                            self.partial_state.#field.push_many(values)?;
 
                             ::std::result::Result::Ok(#builder_name {
                                 partial_state: self.partial_state,
@@ -564,7 +564,7 @@ pub fn generate_builder(
                 self
                     .partial_state
                     .#exec_stack_ident
-                    .try_extend(::std::iter::IntoIterator::into_iter(program)
+                    .push_many(::std::iter::IntoIterator::into_iter(program)
                     .map(::std::convert::Into::into))?;
                 ::std::result::Result::Ok(#builder_name {
                     partial_state: self.partial_state,

--- a/packages/push/src/push_vm/program.rs
+++ b/packages/push/src/push_vm/program.rs
@@ -78,7 +78,7 @@ where
     fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
         // If the size of the block + the size of the exec stack exceed the max stack
         // size then we generate a fatal error.
-        if let Err(err) = state.stack_mut::<I>().try_extend(self.iter().cloned()) {
+        if let Err(err) = state.stack_mut::<I>().push_many(self.iter().cloned()) {
             return Err(Error::fatal(state, err));
         }
         Ok(state)


### PR DESCRIPTION
This also prevents deadlocks/crashes/oom errors in case of infinite or very large iterators