### PR TITLE
Build rustdoc in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,17 @@ jobs:
           components: clippy
           toolchain: nightly
       - run: chmod +x scripts/cargo-rustdoc-clippy && export PATH="$(pwd)/scripts/:$PATH" && cargo rustdoc-clippy -- -Dwarnings
+  rustdoc:
+    name: rustdoc
+    runs-on: ubuntu-latest
+    steps:
+        # tag: v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+        # date: 2024-12-16
+      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
+        with:
+          components: rustc
+          toolchain: nightly
+      - run: RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --no-deps --document-private-items


### PR DESCRIPTION
This enables us to check for broken intra-doc links inside our documentation.

Closes #213 