### PR TITLE
Add `TestResults::len(&self) -> usize` method

### DIFF
--- a/packages/ec-core/src/operator/selector/lexicase.rs
+++ b/packages/ec-core/src/operator/selector/lexicase.rs
@@ -244,7 +244,7 @@ mod tests {
 
         population.push(winning_individual);
 
-        let num_test_cases = population[0].test_results.results.len();
+        let num_test_cases = population[0].test_results.len();
         let lexicase = Lexicase::new(num_test_cases);
         let mut rng = rand::thread_rng();
 

--- a/packages/ec-core/src/test_results.rs
+++ b/packages/ec-core/src/test_results.rs
@@ -240,6 +240,18 @@ pub struct TestResults<R> {
     pub total_result: R,
 }
 
+impl<R> TestResults<R> {
+    /// Get the number of test results
+    pub fn len(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Check if no test results were stored
+    pub fn is_empty(&self) -> bool {
+        self.results.is_empty()
+    }
+}
+
 impl<R: Ord> Ord for TestResults<R> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.total_result.cmp(&other.total_result)


### PR DESCRIPTION
Also adds the `is_empty()` method on the same type since clippy complains if we have a `len()` without a `.is_empty()`

Closes #238 