### PR TITLE
Remove useless conversion to same type (nightly clippy lint fix)

### DIFF
--- a/packages/push/src/instruction/int/mod.rs
+++ b/packages/push/src/instruction/int/mod.rs
@@ -198,7 +198,7 @@ where
                         .map_err(PushInstructionError::from)
                         .map(|(&x, &y)| {
                             let y: u32 = y.try_into().ok()?;
-                            x.checked_pow(y).map(i64::from)
+                            x.checked_pow(y)
                         })
                         .and_then(|v| {
                             v.ok_or(IntInstructionError::Overflow { op: *self })


### PR DESCRIPTION
This fixes a new clippy lint that popped up in recent nightly ci runs. Together with #305 this will fix all the broken nightly clippy lints.