### PR TITLE
Add readme placeholders

### DIFF
--- a/packages/ec-core/README.md
+++ b/packages/ec-core/README.md
@@ -1,0 +1,13 @@
+# ec-core
+
+This crate is a part of the [unhindered-ec](https://unhindered.ec) project.
+
+This crate provides core evolutionary computation functionality, such as interfaces for
+- Individuals
+- Generations
+- Scorers
+- Mutators
+- Recombinators
+- ...
+
+

--- a/packages/ec-linear/README.md
+++ b/packages/ec-linear/README.md
@@ -1,0 +1,5 @@
+# ec-linear
+
+This crate is a part of the [unhindered-ec](https://unhindered.ec) project.
+
+This crate provides implementations for basic linear evolution such as on bitstrings.

--- a/packages/ec-macros/README.md
+++ b/packages/ec-macros/README.md
@@ -1,0 +1,5 @@
+# ec-macros
+
+This crate is a part of the [unhindered-ec](https://unhindered.ec) project.
+
+Macros to be used primarily with the `ec-core` crate of the same project - please do not depend on this directly and instead use the re-exports from `ec-core` instead.

--- a/packages/push-macros/README.md
+++ b/packages/push-macros/README.md
@@ -1,0 +1,5 @@
+# push-macros
+
+This crate is a part of the [unhindered-ec](https://unhindered.ec) project.
+
+Macros to be used with the `push` crate of the same project - please do not depend on this directly and instead use the re-exports from push instead.

--- a/packages/push/README.md
+++ b/packages/push/README.md
@@ -1,0 +1,5 @@
+# push
+
+This crate is a part of the [unhindered-ec](https://unhindered.ec) project.
+
+This crate provides abstractions for basic push-based evolution, such as a push interpreter and basic integer and boolean instructions, as well as an interface to create your own.


### PR DESCRIPTION
This adds some basic readme placeholders since we need those to publish the crates as packages to a (local) registry. We should definitely create some more proper ones sometime soon.