### PR TITLE
Make `ec-macros` publishable

### DIFF
--- a/packages/ec-macros/Cargo.toml
+++ b/packages/ec-macros/Cargo.toml
@@ -10,7 +10,6 @@ license = { workspace = true }
 categories = ["development-tools"]
 # keywords = ["push", "proc-macros", "builder-pattern"]
 readme = "README.md"
-publish = false
 
 [lib]
 proc-macro=true

--- a/packages/ec-macros/Cargo.toml
+++ b/packages/ec-macros/Cargo.toml
@@ -8,7 +8,12 @@ repository = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 categories = ["development-tools"]
-# keywords = ["push", "proc-macros", "builder-pattern"]
+keywords = [
+    "evolutionary-computation-macros",
+    "genetic",
+    "genetic-algorithm",
+    "framework",
+]
 readme = "README.md"
 
 [lib]


### PR DESCRIPTION
Removes `publish = false` from the ec_macros package, such that we can publish it to a (local) registry