### PR TITLE
Update `rand` to `beta.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
  "num-traits",
  "polonius-the-crab",
  "proptest",
- "rand 0.9.0-beta.1",
+ "rand 0.9.0-beta.3",
  "rayon",
  "static_assertions",
  "test-strategy",
@@ -367,7 +367,7 @@ dependencies = [
  "ec-core",
  "miette",
  "num-traits",
- "rand 0.9.0-beta.1",
+ "rand 0.9.0-beta.3",
  "static_assertions",
  "thiserror",
 ]
@@ -873,7 +873,7 @@ dependencies = [
  "ordered-float",
  "proptest",
  "push_macros",
- "rand 0.9.0-beta.1",
+ "rand 0.9.0-beta.3",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0-beta.1"
+version = "0.9.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8478de76992f2825a1052cc2ae9d1401cdb62687761d4100ddd69a73dc3dc48"
+checksum = "6fccbfebb3972a41a31c605a59207d9fba5489b9a87d9d87024cb6df73a32ec7"
 dependencies = [
  "rand_chacha 0.9.0-beta.1",
  "rand_core 0.9.0-beta.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ debug = true
 
 [workspace.dependencies]
 clap = "4.5.1"
-rand = "0.9.0-alpha.2"
+rand = "0.9.0-beta.3"
 num-traits = "0.2.18"
 thiserror = "1.0.69"
 itertools = "0.13.0"

--- a/packages/ec-core/src/distributions/choices.rs
+++ b/packages/ec-core/src/distributions/choices.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroUsize;
 
-use rand::distr::Slice;
+use rand::distr::slice::Choose;
 
 /// A Distribution which knows how many choices are selcted from
 pub trait ChoicesDistribution {
@@ -10,7 +10,7 @@ pub trait ChoicesDistribution {
 
 static_assertions::assert_obj_safe!(ChoicesDistribution);
 
-impl<T> ChoicesDistribution for Slice<'_, T> {
+impl<T> ChoicesDistribution for Choose<'_, T> {
     fn num_choices(&self) -> NonZeroUsize {
         self.num_choices()
     }

--- a/packages/ec-core/src/distributions/conversion.rs
+++ b/packages/ec-core/src/distributions/conversion.rs
@@ -1,4 +1,4 @@
-use rand::{distr::Slice, prelude::Distribution};
+use rand::{distr::slice::Choose, prelude::Distribution};
 
 use super::wrappers::{
     owned::OneOfCloning,
@@ -46,7 +46,7 @@ where
 }
 
 impl<'a, U> IntoDistribution<&'a U> for &'a Vec<U> {
-    type Distribution = Slice<'a, U>;
+    type Distribution = Choose<'a, U>;
 
     type Error = EmptySlice;
 
@@ -84,11 +84,11 @@ impl<'a, U> ToDistribution<'a, &'a U> for Vec<U>
 where
     U: 'a,
 {
-    type Distribution = Slice<'a, U>;
+    type Distribution = Choose<'a, U>;
     type Error = EmptySlice;
 
     fn to_distribution(&'a self) -> Result<Self::Distribution, Self::Error> {
-        Slice::new(self).map_err(|_| EmptySlice)
+        Choose::new(self).map_err(|_| EmptySlice)
     }
 }
 
@@ -105,7 +105,7 @@ where
 }
 
 impl<'a, U, const N: usize> IntoDistribution<&'a U> for &'a [U; N] {
-    type Distribution = Slice<'a, U>;
+    type Distribution = Choose<'a, U>;
 
     type Error = EmptySlice;
 
@@ -143,21 +143,21 @@ impl<'a, U, const N: usize> ToDistribution<'a, &'a U> for [U; N]
 where
     U: 'a,
 {
-    type Distribution = Slice<'a, U>;
+    type Distribution = Choose<'a, U>;
     type Error = EmptySlice;
 
     fn to_distribution(&'a self) -> Result<Self::Distribution, Self::Error> {
-        Slice::new(self).map_err(|_| EmptySlice)
+        Choose::new(self).map_err(|_| EmptySlice)
     }
 }
 
 impl<'a, T> IntoDistribution<&'a T> for &'a [T] {
-    type Distribution = Slice<'a, T>;
+    type Distribution = Choose<'a, T>;
 
     type Error = EmptySlice;
 
     fn into_distribution(self) -> Result<Self::Distribution, Self::Error> {
-        Slice::new(self).map_err(|_| EmptySlice)
+        Choose::new(self).map_err(|_| EmptySlice)
     }
 }
 
@@ -175,12 +175,12 @@ where
 }
 
 impl<'a, T> ToDistribution<'a, &'a T> for [T] {
-    type Distribution = Slice<'a, T>;
+    type Distribution = Choose<'a, T>;
 
     type Error = EmptySlice;
 
     fn to_distribution(&'a self) -> Result<Self::Distribution, Self::Error> {
-        Slice::new(self).map_err(|_| EmptySlice)
+        Choose::new(self).map_err(|_| EmptySlice)
     }
 }
 

--- a/packages/ec-core/src/distributions/conversion.rs
+++ b/packages/ec-core/src/distributions/conversion.rs
@@ -1,8 +1,8 @@
 use rand::{distr::slice::Choose, prelude::Distribution};
 
 use super::wrappers::{
+    choose_cloning::{ChooseCloning, EmptySlice},
     owned::OneOfCloning,
-    slice_cloning::{EmptySlice, SliceCloning},
 };
 
 pub trait IntoDistribution<Element> {
@@ -59,7 +59,7 @@ impl<'a, U> IntoDistribution<U> for &'a Vec<U>
 where
     U: Clone,
 {
-    type Distribution = SliceCloning<'a, U>;
+    type Distribution = ChooseCloning<'a, U>;
 
     type Error = EmptySlice;
 
@@ -72,11 +72,11 @@ impl<'a, U> ToDistribution<'a, U> for Vec<U>
 where
     U: 'a + Clone,
 {
-    type Distribution = SliceCloning<'a, U>;
+    type Distribution = ChooseCloning<'a, U>;
     type Error = EmptySlice;
 
     fn to_distribution(&'a self) -> Result<Self::Distribution, Self::Error> {
-        SliceCloning::new(self)
+        ChooseCloning::new(self)
     }
 }
 
@@ -118,7 +118,7 @@ impl<'a, U, const N: usize> IntoDistribution<U> for &'a [U; N]
 where
     U: Clone,
 {
-    type Distribution = SliceCloning<'a, U>;
+    type Distribution = ChooseCloning<'a, U>;
 
     type Error = EmptySlice;
 
@@ -131,11 +131,11 @@ impl<'a, U, const N: usize> ToDistribution<'a, U> for [U; N]
 where
     U: 'a + Clone,
 {
-    type Distribution = SliceCloning<'a, U>;
+    type Distribution = ChooseCloning<'a, U>;
     type Error = EmptySlice;
 
     fn to_distribution(&'a self) -> Result<Self::Distribution, Self::Error> {
-        SliceCloning::new(self)
+        ChooseCloning::new(self)
     }
 }
 
@@ -165,12 +165,12 @@ impl<'a, T> IntoDistribution<T> for &'a [T]
 where
     T: Clone,
 {
-    type Distribution = SliceCloning<'a, T>;
+    type Distribution = ChooseCloning<'a, T>;
 
     type Error = EmptySlice;
 
     fn into_distribution(self) -> Result<Self::Distribution, Self::Error> {
-        SliceCloning::new(self)
+        ChooseCloning::new(self)
     }
 }
 
@@ -188,11 +188,11 @@ impl<'a, T> ToDistribution<'a, T> for [T]
 where
     T: Clone + 'a,
 {
-    type Distribution = SliceCloning<'a, T>;
+    type Distribution = ChooseCloning<'a, T>;
 
     type Error = EmptySlice;
 
     fn to_distribution(&'a self) -> Result<Self::Distribution, Self::Error> {
-        SliceCloning::new(self)
+        ChooseCloning::new(self)
     }
 }

--- a/packages/ec-core/src/distributions/wrappers/choose_cloning.rs
+++ b/packages/ec-core/src/distributions/wrappers/choose_cloning.rs
@@ -8,14 +8,14 @@ use crate::distributions::choices::ChoicesDistribution;
 /// Generate a random element from an array of options, cloning the choosen
 /// element.
 #[derive(Debug, Clone, Copy)]
-pub struct SliceCloning<'a, T>(Choose<'a, T>);
+pub struct ChooseCloning<'a, T>(Choose<'a, T>);
 
 #[derive(Debug, Clone, Copy, thiserror::Error, Diagnostic)]
 #[error("Tried to create a `distributions::Slice` with an empty slice")]
 #[diagnostic(help = "Ensure your slice has at least length one.")]
 pub struct EmptySlice;
 
-impl<'a, T> SliceCloning<'a, T> {
+impl<'a, T> ChooseCloning<'a, T> {
     /// Create a new `Slice` instance which samples uniformly from the slice.
     /// Returns `Err` if the slice is empty.
     ///
@@ -26,13 +26,13 @@ impl<'a, T> SliceCloning<'a, T> {
     }
 }
 
-impl<T> ChoicesDistribution for SliceCloning<'_, T> {
+impl<T> ChoicesDistribution for ChooseCloning<'_, T> {
     fn num_choices(&self) -> NonZeroUsize {
         self.0.num_choices()
     }
 }
 
-impl<T> Distribution<T> for SliceCloning<'_, T>
+impl<T> Distribution<T> for ChooseCloning<'_, T>
 where
     T: Clone,
 {

--- a/packages/ec-core/src/distributions/wrappers/mod.rs
+++ b/packages/ec-core/src/distributions/wrappers/mod.rs
@@ -1,2 +1,2 @@
+pub mod choose_cloning;
 pub mod owned;
-pub mod slice_cloning;

--- a/packages/ec-core/src/distributions/wrappers/owned.rs
+++ b/packages/ec-core/src/distributions/wrappers/owned.rs
@@ -2,13 +2,13 @@ use std::{borrow::Borrow, marker::PhantomData, num::NonZeroUsize};
 
 use rand::{distr::Uniform, prelude::Distribution};
 
-use crate::distributions::{choices::ChoicesDistribution, wrappers::slice_cloning::EmptySlice};
+use crate::distributions::{choices::ChoicesDistribution, wrappers::choose_cloning::EmptySlice};
 
 /// Generate a random element from a collection of options, cloning the chosen
 /// element.
 ///
 /// The [`OneOfCloning`] struct takes ownership of the collection; the
-/// [`SliceCloning`](super::slice_cloning::SliceCloning) struct allows one to
+/// [`ChooseCloning`](super::choose_cloning::ChooseCloning) struct allows one to
 /// borrow the collection.
 #[derive(Debug, PartialEq, Eq)]
 pub struct OneOfCloning<T, U> {
@@ -42,7 +42,7 @@ where
     /// #    choices::ChoicesDistribution,
     /// #    wrappers::{
     /// #       owned::OneOfCloning,
-    /// #       slice_cloning::EmptySlice,
+    /// #       choose_cloning::EmptySlice,
     /// #    },
     /// # };
     /// #

--- a/packages/ec-core/src/distributions/wrappers/slice_cloning.rs
+++ b/packages/ec-core/src/distributions/wrappers/slice_cloning.rs
@@ -1,14 +1,14 @@
 use std::num::NonZeroUsize;
 
 use miette::Diagnostic;
-use rand::{distr::Slice, prelude::Distribution};
+use rand::{distr::slice::Choose, prelude::Distribution};
 
 use crate::distributions::choices::ChoicesDistribution;
 
 /// Generate a random element from an array of options, cloning the choosen
 /// element.
 #[derive(Debug, Clone, Copy)]
-pub struct SliceCloning<'a, T>(Slice<'a, T>);
+pub struct SliceCloning<'a, T>(Choose<'a, T>);
 
 #[derive(Debug, Clone, Copy, thiserror::Error, Diagnostic)]
 #[error("Tried to create a `distributions::Slice` with an empty slice")]
@@ -22,7 +22,7 @@ impl<'a, T> SliceCloning<'a, T> {
     /// # Errors
     /// - [`EmptySlice`] if the passed in slice is empty
     pub fn new(slice: &'a [T]) -> Result<Self, EmptySlice> {
-        Ok(Self(Slice::new(slice).map_err(|_| EmptySlice)?))
+        Ok(Self(Choose::new(slice).map_err(|_| EmptySlice)?))
     }
 }
 


### PR DESCRIPTION
This also required changing references to `rand::distr::Slice` to `rand::distr::slice::Choose`, and is a requirement to publish the local packages to a (local) registry.