### PR TITLE
Make `WeightedPair<A,B>` and `Weighted<T>` struct items private

### DIFF
--- a/packages/ec-core/src/weighted/mod.rs
+++ b/packages/ec-core/src/weighted/mod.rs
@@ -11,8 +11,8 @@ pub mod with_weighted_item;
 
 #[derive(Debug)]
 pub struct Weighted<T> {
-    pub(crate) item: T,
-    pub(crate) weight: u32,
+    item: T,
+    weight: u32,
 }
 
 impl<T> Weighted<T> {

--- a/packages/ec-core/src/weighted/weighted_pair.rs
+++ b/packages/ec-core/src/weighted/weighted_pair.rs
@@ -11,10 +11,10 @@ use crate::{operator::selector::Selector, population::Population};
 
 #[derive(Debug)]
 pub struct WeightedPair<A, B> {
-    pub(crate) a: A,
-    pub(crate) b: B,
-    pub(crate) distr: Option<Bernoulli>,
-    pub(crate) weight_sum: u32,
+    a: A,
+    b: B,
+    distr: Option<Bernoulli>,
+    weight_sum: u32,
 }
 
 impl<A, B> WeightedPair<A, B> {


### PR DESCRIPTION
All the struct items inside the two structs mentioned above were previously made `pub(crate)`. I think we accidentally introduced that during the restructuring of a non-dyn weighted selector into a more general weighted type, but never noticed that we actually don't need them to be `pub(crate)` anymore.

Making them private reduces the risk of accidental breakages through unintended direct member accesses outside the module where the structs are declared.

Closes #328 and #327