### PR TITLE
Implement a character type and instruction set

### DIFF
--- a/packages/push/proptest-regressions/instruction/char/ascii_from_wrapping_float.txt
+++ b/packages/push/proptest-regressions/instruction/char/ascii_from_wrapping_float.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4558e09fe1ad1cad9c047fa72ed424d1200559e969abd9a7f04a73746182e25e # shrinks to input = _AsciiFromWrappingFloatProptestArgs { x: 0.0 }

--- a/packages/push/proptest-regressions/instruction/char/ascii_from_wrapping_integer.txt
+++ b/packages/push/proptest-regressions/instruction/char/ascii_from_wrapping_integer.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 11e86b0b0c09c0479f9ff39c31d9d5889ad6ef2b7b3b72a4b7c77bca0241d3ec # shrinks to input = _AsciiFromWrappingIntegerProptestArgs { x: 0 }

--- a/packages/push/proptest-regressions/instruction/char/is_alphabetic.txt
+++ b/packages/push/proptest-regressions/instruction/char/is_alphabetic.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 1afe3dd96bf6098d8d0529fc9800f4e6babe8ea15a4f41aed851d090721ce6a5 # shrinks to input = _IsLetterArgs { c: '¡' }

--- a/packages/push/src/instruction/char/ascii_from_wrapping_float.rs
+++ b/packages/push/src/instruction/char/ascii_from_wrapping_float.rs
@@ -1,0 +1,166 @@
+use ordered_float::OrderedFloat;
+
+use crate::{
+    error::InstructionResult,
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{HasStack, stack::PushOnto},
+};
+
+/// An instruction that takes the top value from the `f64` stack and
+/// converts it to an ASCII `char`, modding it by 128 to ensure that
+/// the resulting value is a legal ASCII character code.
+///
+/// By using `.euclid_rem()` to compute the modulus, we're guaranteed
+/// that we can interpret any value on the `f64` as a legal ASCII character
+/// code. An alternative would be to have this instruction "fail"
+/// in some way if the value on the `f64` stack was outside the range
+/// 0..128, presumably by either skipping the instruction or
+/// generating a fatal error and terminating program evaluation. Neither of
+/// these options seem terribly reasonable from an evolutionary standpoint.
+/// Skipping would leave the value on the `f64` stack, which would
+/// be quite "surprising" and almost certainly lead to unexpected behavior.
+/// Failing doesn't seem to be in the spirit of Push, where we try to make
+/// sure almost every instruction "succeeds" in some reasonable way.
+///
+/// # Inputs
+///
+/// The `CharInstruction::AsciiFromWrappingFloat` instruction takes the
+/// following inputs:
+///    - `f64` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::AsciiFromWrappingFloat` instruction takes the top
+/// value of the `f64` stack and converts it to an ASCII character after taking
+/// it modulo 128 to ensure that it's a legal ASCII character code.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`f64` stack" column indicates the value of the top of the `f64`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack after the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `f64` stack  | `char` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists | ASCII char | ✅ | |
+/// | missing | nothing is pushed onto the `char` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `f64` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct AsciiFromWrappingFloat;
+
+impl<S> Instruction<S> for AsciiFromWrappingFloat
+where
+    S: Clone + HasStack<OrderedFloat<f64>> + HasStack<char>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
+        let float_stack = state.stack::<OrderedFloat<f64>>();
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "We know that after taking `.rem_euclid(128)`, the value will be in the \
+                      range 0..128 and will fit in a `u8`."
+        )]
+        #[expect(
+            clippy::as_conversions,
+            reason = "We know that the value is in the range 0..128 and thus can be converted \
+                      safely to a `u8` and then to a `char`."
+        )]
+        let ascii_character = float_stack
+            .top()
+            .map(|x| ((x.0 as i128).rem_euclid(128)) as u8 as char);
+        ascii_character.push_onto(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ordered_float::OrderedFloat;
+    use proptest::prop_assert_eq;
+    use test_strategy::proptest;
+
+    use super::*;
+    use crate::push_vm::push_state::PushState;
+
+    #[test]
+    fn ascii_from_wrapping_float() {
+        let input = OrderedFloat(65.0);
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_float_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = AsciiFromWrappingFloat.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), 'A');
+    }
+
+    #[test]
+    fn ascii_from_wrapping_float_overflow() {
+        let input = OrderedFloat(128.0);
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_float_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = AsciiFromWrappingFloat.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), '\0');
+    }
+
+    #[test]
+    fn ascii_from_wrapping_float_underflow() {
+        let input = OrderedFloat(-1.0);
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_float_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = AsciiFromWrappingFloat.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), '\u{7f}');
+    }
+
+    #[expect(
+        clippy::as_conversions,
+        reason = "We know that the value is in the range 0..128 so these conversions are safe."
+    )]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "We know that after taking `.rem_euclid(128)`, the value will be in the range \
+                  0..128 and will fit in a `u8`."
+    )]
+    #[proptest]
+    fn ascii_from_wrapping_float_proptest(x: f64) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_float_values(std::iter::once(OrderedFloat(x)))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = AsciiFromWrappingFloat.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 1);
+        let top_char = *result.stack::<char>().top().unwrap();
+        let top_char_ascii = top_char as u8;
+        prop_assert_eq!(top_char_ascii, (x as i128).rem_euclid(128) as u8);
+    }
+}

--- a/packages/push/src/instruction/char/ascii_from_wrapping_float.rs
+++ b/packages/push/src/instruction/char/ascii_from_wrapping_float.rs
@@ -73,8 +73,8 @@ where
 {
     type Error = PushInstructionError;
 
-    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
-        let float_stack = state.stack_mut::<OrderedFloat<f64>>();
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
+        let float_stack = state.stack::<OrderedFloat<f64>>();
         #[expect(
             clippy::cast_possible_truncation,
             reason = "We know that after taking `.rem_euclid(128)`, the value will be in the \

--- a/packages/push/src/instruction/char/ascii_from_wrapping_float.rs
+++ b/packages/push/src/instruction/char/ascii_from_wrapping_float.rs
@@ -103,12 +103,20 @@ mod tests {
     use super::*;
     use crate::push_vm::push_state::PushState;
 
+    // .with_max_stack_size(1000)
+    //     .with_program(program.to_vec())?
+    //     .with_int_input("a", a)
+    //     .with_int_input("b", b)
+    //     .with_int_input("c", c)
+    //     .with_instruction_step_limit(1_000)
+
     /// Performing `AsciiFromWrappingFloat` when the `f64` stack is empty
     /// should return a recoverable error with the state unchanged.
     #[test]
     fn ascii_from_wrapping_integer_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_char_values(['a', 'b', 'c'])
             .unwrap()
             .with_bool_values([true, false])
@@ -126,6 +134,7 @@ mod tests {
     fn ascii_from_wrapping_float() {
         let input = OrderedFloat(65.0);
         let state = PushState::builder()
+            .with_instruction_step_limit(1_000)
             .with_max_stack_size(1)
             .with_float_values(std::iter::once(input))
             .unwrap()
@@ -141,6 +150,7 @@ mod tests {
         let input = OrderedFloat(128.0);
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_float_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -154,6 +164,7 @@ mod tests {
     fn ascii_from_wrapping_float_underflow() {
         let input = OrderedFloat(-1.0);
         let state = PushState::builder()
+            .with_instruction_step_limit(1_000)
             .with_max_stack_size(1)
             .with_float_values(std::iter::once(input))
             .unwrap()
@@ -177,6 +188,7 @@ mod tests {
     fn ascii_from_wrapping_float_proptest(x: f64) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_float_values(std::iter::once(OrderedFloat(x)))
             .unwrap()
             .with_no_program()

--- a/packages/push/src/instruction/char/ascii_from_wrapping_integer.rs
+++ b/packages/push/src/instruction/char/ascii_from_wrapping_integer.rs
@@ -71,8 +71,8 @@ where
 {
     type Error = PushInstructionError;
 
-    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
-        let int_stack = state.stack_mut::<i64>();
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
+        let int_stack = state.stack::<i64>();
         #[expect(
             clippy::cast_possible_truncation,
             reason = "We know that after taking `.rem_euclid(128)`, the value will be in the \

--- a/packages/push/src/instruction/char/ascii_from_wrapping_integer.rs
+++ b/packages/push/src/instruction/char/ascii_from_wrapping_integer.rs
@@ -1,0 +1,161 @@
+use crate::{
+    error::InstructionResult,
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{HasStack, stack::PushOnto},
+};
+
+/// An instruction that takes the top value from the `i64` stack and
+/// converts it to an ASCII `char`, modding it by 128 to ensure that
+/// the resulting value is a legal ASCII character code.
+///
+/// By using `.euclid_rem()` to compute the modulus, we're guaranteed
+/// that we can interpret any value on the `i64` as a legal ASCII character
+/// code. An alternative would be to have this instruction "fail"
+/// in some way if the value on the `i64` stack was outside the range
+/// 0..128, presumably by either skipping the instruction or
+/// generating a fatal error and terminating program evaluation. Neither of
+/// these options seem terribly reasonable from an evolutionary standpoint.
+/// Skipping would leave the value on the `i64` stack, which would
+/// be quite "surprising" and almost certainly lead to unexpected behavior.
+/// Failing doesn't seem to be in the spirit of Push, where we try to make
+/// sure almost every instruction "succeeds" in some reasonable way.
+///
+/// # Inputs
+///
+/// The `CharInstruction::AsciiFromWrappingInteger` instruction takes the
+/// following inputs:
+///    - `i64` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::AsciiFromWrappingInteger` instruction takes the top
+/// value of the `i64` stack and converts it to an ASCII character after taking
+/// it modulo 128 to ensure that it's a legal ASCII character code.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`i64` stack" column indicates the value of the top of the `i64`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack after the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `i64` stack  | `char` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists | ASCII char | ✅ | |
+/// | missing | nothing is pushed onto the `char` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `i64` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct AsciiFromWrappingInteger;
+
+impl<S> Instruction<S> for AsciiFromWrappingInteger
+where
+    S: Clone + HasStack<i64> + HasStack<char>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
+        let int_stack = state.stack::<i64>();
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "We know that after taking `.rem_euclid(128)`, the value will be in the \
+                      range 0..128 and will fit in a `u8`."
+        )]
+        #[expect(
+            clippy::as_conversions,
+            reason = "We know that the value is in the range 0..128 and thus can be converted \
+                      safely to a `u8` and then to a `char`."
+        )]
+        let ascii_character = int_stack.top().map(|x| (x.rem_euclid(128)) as u8 as char);
+        ascii_character.push_onto(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use test_strategy::proptest;
+
+    use super::*;
+    use crate::push_vm::push_state::PushState;
+
+    #[test]
+    fn ascii_from_wrapping_integer() {
+        let input = 65;
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_int_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = AsciiFromWrappingInteger.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), 'A');
+    }
+
+    #[test]
+    fn ascii_from_wrapping_integer_overflow() {
+        let input = 128;
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_int_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = AsciiFromWrappingInteger.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), '\0');
+    }
+
+    #[test]
+    fn ascii_from_wrapping_integer_underflow() {
+        let input = -1;
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_int_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = AsciiFromWrappingInteger.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), '\u{7f}');
+    }
+
+    #[expect(
+        clippy::as_conversions,
+        reason = "We know that the value is in the range 0..128 so these conversions are safe."
+    )]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "We know that after taking `.rem_euclid(128)`, the value will be in the range \
+                  0..128 and will fit in a `u8`."
+    )]
+    #[proptest]
+    fn ascii_from_wrapping_integer_proptest(x: i64) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_int_values(std::iter::once(x))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = AsciiFromWrappingInteger.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 1);
+        let top_char = *result.stack::<char>().top().unwrap();
+        let top_char_ascii = top_char as u8;
+        prop_assert_eq!(top_char_ascii, x.rem_euclid(128) as u8);
+    }
+}

--- a/packages/push/src/instruction/char/ascii_from_wrapping_integer.rs
+++ b/packages/push/src/instruction/char/ascii_from_wrapping_integer.rs
@@ -104,6 +104,7 @@ mod tests {
     fn ascii_from_wrapping_integer_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_char_values(['a', 'b', 'c'])
             .unwrap()
             .with_bool_values([true, false])
@@ -122,6 +123,7 @@ mod tests {
         let input = 65;
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_int_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -136,6 +138,7 @@ mod tests {
         let input = 128;
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_int_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -150,6 +153,7 @@ mod tests {
         let input = -1;
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_int_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -172,6 +176,7 @@ mod tests {
     fn ascii_from_wrapping_integer_proptest(x: i64) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_int_values(std::iter::once(x))
             .unwrap()
             .with_no_program()

--- a/packages/push/src/instruction/char/is_alphabetic.rs
+++ b/packages/push/src/instruction/char/is_alphabetic.rs
@@ -73,6 +73,71 @@ where
     }
 }
 
+/// An instruction that pushes a `bool` on the bool stack that is `true` if that
+/// character on top of the character stack is a alphabetic (as defined in
+/// [the Unicode standard](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt)),
+/// and `false` otherwise. This is *not* consuming in the sense that it leaves
+/// the character on top of the character stack unchanged.
+///
+/// # Inputs
+///
+/// The `CharInstruction::IsAlphabetic` instruction takes the
+/// following inputs:
+///    - `char` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::IsAlphabetic` pushes a `bool` onto the bool stack
+/// that is `true` if that character on top of the character stack is a
+/// alphabetic (as described in [the Unicode standard](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt)),
+/// and `false` if it isn't. This is *not* consuming in the sense that it leaves
+/// the character on top of the character stack unchanged.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "`bool` stack" column indicates the value of the top of the `bool`
+///      stack after the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `char` stack  | `bool` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists, remains unchanged | whether the `char` is alphabetic | ✅ | The top of the `char` stack remains unchanged |
+/// | missing | nothing is pushed onto the `bool` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `char` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct IsAlphabeticNonConsuming;
+
+impl<S> Instruction<S> for IsAlphabeticNonConsuming
+where
+    S: Clone + HasStack<char> + HasStack<bool>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+        state
+            .stack_mut::<char>()
+            .top()
+            .map(|x| x.is_alphabetic())
+            .push_onto(state)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use proptest::prop_assert_eq;
@@ -80,14 +145,14 @@ mod tests {
 
     use super::IsAlphabetic;
     use crate::{
-        instruction::Instruction,
+        instruction::{Instruction, char::is_alphabetic::IsAlphabeticNonConsuming},
         push_vm::{HasStack, push_state::PushState},
     };
 
     /// Performing `IsAlphabetic` when the `char` stack is empty should
     /// return a recoverable error with the state unchanged.
     #[test]
-    fn is_letter_empty_stack() {
+    fn is_alphabetic_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
             .with_int_values([5, 8, 9])
@@ -97,6 +162,25 @@ mod tests {
             .with_no_program()
             .build();
         let result = IsAlphabetic.perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        let result_state = result.state();
+        assert_eq!(result_state.stack::<i64>().size(), 3);
+        assert_eq!(result_state.stack::<bool>().size(), 2);
+    }
+
+    /// Performing `IsAlphabetic` when the `char` stack is empty should
+    /// return a recoverable error with the state unchanged.
+    #[test]
+    fn is_alphabetic_non_consuming_empty_stack() {
+        let state = PushState::builder()
+            .with_max_stack_size(3)
+            .with_int_values([5, 8, 9])
+            .unwrap()
+            .with_bool_values([true, false])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAlphabeticNonConsuming.perform(state).unwrap_err();
         assert!(result.is_recoverable());
         let result_state = result.state();
         assert_eq!(result_state.stack::<i64>().size(), 3);
@@ -116,6 +200,24 @@ mod tests {
             .build();
         let result = IsAlphabetic.perform(state).unwrap();
         prop_assert_eq!(result.stack::<char>().size(), 0);
+        prop_assert_eq!(result.stack::<bool>().size(), 1);
+        prop_assert_eq!(*result.stack::<bool>().top().unwrap(), c.is_alphabetic());
+    }
+
+    #[proptest]
+    // We need to make sure that `x` is greater than `i64::MIN` since
+    // we handle that case differently. This is described in the documentation
+    // for `Abs`, and handled in the preceding test.
+    fn is_alphabetic_non_consuming(c: char) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(c))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAlphabeticNonConsuming.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 1);
+        prop_assert_eq!(*result.stack::<char>().top().unwrap(), c);
         prop_assert_eq!(result.stack::<bool>().size(), 1);
         prop_assert_eq!(*result.stack::<bool>().top().unwrap(), c.is_alphabetic());
     }

--- a/packages/push/src/instruction/char/is_alphabetic.rs
+++ b/packages/push/src/instruction/char/is_alphabetic.rs
@@ -63,9 +63,9 @@ where
 {
     type Error = PushInstructionError;
 
-    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
         state
-            .stack_mut::<char>()
+            .stack::<char>()
             .top()
             .map(|x| x.is_alphabetic())
             .push_onto(state)
@@ -129,9 +129,9 @@ where
 {
     type Error = PushInstructionError;
 
-    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
         state
-            .stack_mut::<char>()
+            .stack::<char>()
             .top()
             .map(|x| x.is_alphabetic())
             .push_onto(state)

--- a/packages/push/src/instruction/char/is_alphabetic.rs
+++ b/packages/push/src/instruction/char/is_alphabetic.rs
@@ -1,0 +1,122 @@
+use crate::{
+    error::InstructionResult,
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{
+        HasStack,
+        stack::{PushOnto, StackDiscard},
+    },
+};
+
+/// An instruction that takes the top value from the `char` stack and
+/// pushes a `bool` on the bool stack that is `true` if that character
+/// is a alphabetic (as defined in
+/// [the Unicode standard](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt)),
+/// and `false` otherwise.
+///
+/// # Inputs
+///
+/// The `CharInstruction::IsAlphabetic` instruction takes the
+/// following inputs:
+///    - `char` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::IsAlphabetic` instruction takes the top
+/// value of the `char` stack and pushes a `bool` onto the bool stack
+/// that is `true` if that character is a alphabetic (as described in
+/// [the Unicode standard](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt)),
+/// and `false` if it isn't.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "`bool` stack" column indicates the value of the top of the `bool`
+///      stack after the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `char` stack  | `bool` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists | whether the `char` is alphabetic | ✅ | |
+/// | missing | nothing is pushed onto the `bool` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `char` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct IsAlphabetic;
+
+impl<S> Instruction<S> for IsAlphabetic
+where
+    S: Clone + HasStack<char> + HasStack<bool>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+        state
+            .stack_mut::<char>()
+            .top()
+            .map(|x| x.is_alphabetic())
+            .push_onto(state)
+            .with_stack_discard::<char>(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use test_strategy::proptest;
+
+    use super::IsAlphabetic;
+    use crate::{
+        instruction::Instruction,
+        push_vm::{HasStack, push_state::PushState},
+    };
+
+    /// Performing `IsAlphabetic` when the `char` stack is empty should
+    /// return a recoverable error with the state unchanged.
+    #[test]
+    fn is_letter_empty_stack() {
+        let state = PushState::builder()
+            .with_max_stack_size(3)
+            .with_int_values([5, 8, 9])
+            .unwrap()
+            .with_bool_values([true, false])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAlphabetic.perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        let result_state = result.state();
+        assert_eq!(result_state.stack::<i64>().size(), 3);
+        assert_eq!(result_state.stack::<bool>().size(), 2);
+    }
+
+    #[proptest]
+    // We need to make sure that `x` is greater than `i64::MIN` since
+    // we handle that case differently. This is described in the documentation
+    // for `Abs`, and handled in the preceding test.
+    fn is_alphabetic(c: char) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(c))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAlphabetic.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 0);
+        prop_assert_eq!(result.stack::<bool>().size(), 1);
+        prop_assert_eq!(*result.stack::<bool>().top().unwrap(), c.is_alphabetic());
+    }
+}

--- a/packages/push/src/instruction/char/is_alphabetic.rs
+++ b/packages/push/src/instruction/char/is_alphabetic.rs
@@ -155,6 +155,7 @@ mod tests {
     fn is_alphabetic_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_int_values([5, 8, 9])
             .unwrap()
             .with_bool_values([true, false])
@@ -174,6 +175,7 @@ mod tests {
     fn is_alphabetic_non_consuming_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_int_values([5, 8, 9])
             .unwrap()
             .with_bool_values([true, false])
@@ -194,6 +196,7 @@ mod tests {
     fn is_alphabetic(c: char) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(c))
             .unwrap()
             .with_no_program()
@@ -211,6 +214,7 @@ mod tests {
     fn is_alphabetic_non_consuming(c: char) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(c))
             .unwrap()
             .with_no_program()

--- a/packages/push/src/instruction/char/is_ascii_digit.rs
+++ b/packages/push/src/instruction/char/is_ascii_digit.rs
@@ -59,9 +59,9 @@ where
 {
     type Error = PushInstructionError;
 
-    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
         state
-            .stack_mut::<char>()
+            .stack::<char>()
             .top()
             .map(char::is_ascii_digit)
             .push_onto(state)
@@ -123,9 +123,9 @@ where
 {
     type Error = PushInstructionError;
 
-    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
         state
-            .stack_mut::<char>()
+            .stack::<char>()
             .top()
             .map(char::is_ascii_digit)
             .push_onto(state)

--- a/packages/push/src/instruction/char/is_ascii_digit.rs
+++ b/packages/push/src/instruction/char/is_ascii_digit.rs
@@ -1,0 +1,218 @@
+use crate::{
+    error::InstructionResult,
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{
+        HasStack,
+        stack::{PushOnto, StackDiscard},
+    },
+};
+
+/// An instruction that takes the top value from the `char` stack and
+/// pushes a `bool` on the bool stack that is `true` if that character
+/// is an ASCII digit, and `false` otherwise.
+///
+/// # Inputs
+///
+/// The `CharInstruction::IsAsciiDigit` instruction takes the
+/// following inputs:
+///    - `char` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::IsAsciiDigit` instruction takes the top
+/// value of the `char` stack and pushes a `bool` onto the bool stack
+/// that is `true` if that character is an ASCII digit, and `false` if it isn't.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "`bool` stack" column indicates the value of the top of the `bool`
+///      stack after the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `char` stack  | `bool` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists | whether the `char` is an ASCII digit | ✅ | |
+/// | missing | nothing is pushed onto the `bool` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `char` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct IsAsciiDigit;
+
+impl<S> Instruction<S> for IsAsciiDigit
+where
+    S: Clone + HasStack<char> + HasStack<bool>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+        state
+            .stack_mut::<char>()
+            .top()
+            .map(char::is_ascii_digit)
+            .push_onto(state)
+            .with_stack_discard::<char>(1)
+    }
+}
+
+/// An instruction that pushes a `bool` on the bool stack that is `true` if that
+/// character on top of the character stack is an ASCII digit,
+/// and `false` otherwise. This is *not* consuming in the sense that it leaves
+/// the character on top of the character stack unchanged.
+///
+/// # Inputs
+///
+/// The `CharInstruction::IsAsciiDigitNonConsuming` instruction takes the
+/// following inputs:
+///    - `char` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::IsAsciiDigitNonConsuming` pushes a `bool` onto the
+/// bool stack that is `true` if that character on top of the character stack is
+/// an ASCII digit, and `false` if it isn't. This is *not* consuming in the
+/// sense that it leaves the character on top of the character stack unchanged.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "`bool` stack" column indicates the value of the top of the `bool`
+///      stack after the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `char` stack  | `bool` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists, remains unchanged | whether the `char` is an ASCII digit | ✅ | The top of the `char` stack remains unchanged |
+/// | missing | nothing is pushed onto the `bool` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `char` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct IsAsciiDigitNonConsuming;
+
+impl<S> Instruction<S> for IsAsciiDigitNonConsuming
+where
+    S: Clone + HasStack<char> + HasStack<bool>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+        state
+            .stack_mut::<char>()
+            .top()
+            .map(char::is_ascii_digit)
+            .push_onto(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use test_strategy::proptest;
+
+    use super::{IsAsciiDigit, IsAsciiDigitNonConsuming};
+    use crate::{
+        instruction::Instruction,
+        push_vm::{HasStack, push_state::PushState},
+    };
+
+    /// Performing `IsAsciiDigit` when the `char` stack is empty should
+    /// return a recoverable error with the state unchanged.
+    #[test]
+    fn is_ascii_digit_empty_stack() {
+        let state = PushState::builder()
+            .with_max_stack_size(3)
+            .with_int_values([5, 8, 9])
+            .unwrap()
+            .with_bool_values([true, false])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAsciiDigit.perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        let result_state = result.state();
+        assert_eq!(result_state.stack::<i64>().size(), 3);
+        assert_eq!(result_state.stack::<bool>().size(), 2);
+    }
+
+    /// Performing `IsAsciiDigit` when the `char` stack is empty should
+    /// return a recoverable error with the state unchanged.
+    #[test]
+    fn is_ascii_digit_non_consuming_empty_stack() {
+        let state = PushState::builder()
+            .with_max_stack_size(3)
+            .with_int_values([5, 8, 9])
+            .unwrap()
+            .with_bool_values([true, false])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAsciiDigitNonConsuming.perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        let result_state = result.state();
+        assert_eq!(result_state.stack::<i64>().size(), 3);
+        assert_eq!(result_state.stack::<bool>().size(), 2);
+    }
+
+    #[proptest]
+    // We need to make sure that `x` is greater than `i64::MIN` since
+    // we handle that case differently. This is described in the documentation
+    // for `Abs`, and handled in the preceding test.
+    fn is_ascii_digit(c: char) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(c))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAsciiDigit.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 0);
+        prop_assert_eq!(result.stack::<bool>().size(), 1);
+        prop_assert_eq!(*result.stack::<bool>().top().unwrap(), c.is_ascii_digit());
+    }
+
+    #[proptest]
+    // We need to make sure that `x` is greater than `i64::MIN` since
+    // we handle that case differently. This is described in the documentation
+    // for `Abs`, and handled in the preceding test.
+    fn is_ascii_digit_non_consuming(c: char) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(c))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAsciiDigitNonConsuming.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 1);
+        prop_assert_eq!(*result.stack::<char>().top().unwrap(), c);
+        prop_assert_eq!(result.stack::<bool>().size(), 1);
+        prop_assert_eq!(*result.stack::<bool>().top().unwrap(), c.is_ascii_digit());
+    }
+}

--- a/packages/push/src/instruction/char/is_ascii_digit.rs
+++ b/packages/push/src/instruction/char/is_ascii_digit.rs
@@ -149,6 +149,7 @@ mod tests {
     fn is_ascii_digit_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_int_values([5, 8, 9])
             .unwrap()
             .with_bool_values([true, false])
@@ -168,6 +169,7 @@ mod tests {
     fn is_ascii_digit_non_consuming_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_int_values([5, 8, 9])
             .unwrap()
             .with_bool_values([true, false])
@@ -188,6 +190,7 @@ mod tests {
     fn is_ascii_digit(c: char) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(c))
             .unwrap()
             .with_no_program()
@@ -205,6 +208,7 @@ mod tests {
     fn is_ascii_digit_non_consuming(c: char) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(c))
             .unwrap()
             .with_no_program()

--- a/packages/push/src/instruction/char/is_whitespace.rs
+++ b/packages/push/src/instruction/char/is_whitespace.rs
@@ -63,9 +63,9 @@ where
 {
     type Error = PushInstructionError;
 
-    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
         state
-            .stack_mut::<char>()
+            .stack::<char>()
             .top()
             .map(|x| x.is_alphabetic())
             .push_onto(state)
@@ -129,9 +129,9 @@ where
 {
     type Error = PushInstructionError;
 
-    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
         state
-            .stack_mut::<char>()
+            .stack::<char>()
             .top()
             .map(|x| x.is_alphabetic())
             .push_onto(state)

--- a/packages/push/src/instruction/char/is_whitespace.rs
+++ b/packages/push/src/instruction/char/is_whitespace.rs
@@ -1,0 +1,224 @@
+use crate::{
+    error::InstructionResult,
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{
+        HasStack,
+        stack::{PushOnto, StackDiscard},
+    },
+};
+
+/// An instruction that takes the top value from the `char` stack and
+/// pushes a `bool` on the bool stack that is `true` if that character
+/// is a alphabetic (as defined in
+/// [the Unicode standard](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt)),
+/// and `false` otherwise.
+///
+/// # Inputs
+///
+/// The `CharInstruction::IsAlphabetic` instruction takes the
+/// following inputs:
+///    - `char` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::IsAlphabetic` instruction takes the top
+/// value of the `char` stack and pushes a `bool` onto the bool stack
+/// that is `true` if that character is a alphabetic (as described in
+/// [the Unicode standard](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt)),
+/// and `false` if it isn't.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "`bool` stack" column indicates the value of the top of the `bool`
+///      stack after the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `char` stack  | `bool` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists | whether the `char` is alphabetic | ✅ | |
+/// | missing | nothing is pushed onto the `bool` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `char` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct IsAlphabetic;
+
+impl<S> Instruction<S> for IsAlphabetic
+where
+    S: Clone + HasStack<char> + HasStack<bool>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+        state
+            .stack_mut::<char>()
+            .top()
+            .map(|x| x.is_alphabetic())
+            .push_onto(state)
+            .with_stack_discard::<char>(1)
+    }
+}
+
+/// An instruction that pushes a `bool` on the bool stack that is `true` if that
+/// character on top of the character stack is a alphabetic (as defined in
+/// [the Unicode standard](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt)),
+/// and `false` otherwise. This is *not* consuming in the sense that it leaves
+/// the character on top of the character stack unchanged.
+///
+/// # Inputs
+///
+/// The `CharInstruction::IsAlphabetic` instruction takes the
+/// following inputs:
+///    - `char` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::IsAlphabetic` pushes a `bool` onto the bool stack
+/// that is `true` if that character on top of the character stack is a
+/// alphabetic (as described in [the Unicode standard](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt)),
+/// and `false` if it isn't. This is *not* consuming in the sense that it leaves
+/// the character on top of the character stack unchanged.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "`bool` stack" column indicates the value of the top of the `bool`
+///      stack after the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `char` stack  | `bool` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists, remains unchanged | whether the `char` is alphabetic | ✅ | The top of the `char` stack remains unchanged |
+/// | missing | nothing is pushed onto the `bool` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `char` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct IsAlphabeticNonConsuming;
+
+impl<S> Instruction<S> for IsAlphabeticNonConsuming
+where
+    S: Clone + HasStack<char> + HasStack<bool>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+        state
+            .stack_mut::<char>()
+            .top()
+            .map(|x| x.is_alphabetic())
+            .push_onto(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use test_strategy::proptest;
+
+    use super::IsAlphabetic;
+    use crate::{
+        instruction::{Instruction, char::is_alphabetic::IsAlphabeticNonConsuming},
+        push_vm::{HasStack, push_state::PushState},
+    };
+
+    /// Performing `IsAlphabetic` when the `char` stack is empty should
+    /// return a recoverable error with the state unchanged.
+    #[test]
+    fn is_alphabetic_empty_stack() {
+        let state = PushState::builder()
+            .with_max_stack_size(3)
+            .with_int_values([5, 8, 9])
+            .unwrap()
+            .with_bool_values([true, false])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAlphabetic.perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        let result_state = result.state();
+        assert_eq!(result_state.stack::<i64>().size(), 3);
+        assert_eq!(result_state.stack::<bool>().size(), 2);
+    }
+
+    /// Performing `IsAlphabetic` when the `char` stack is empty should
+    /// return a recoverable error with the state unchanged.
+    #[test]
+    fn is_alphabetic_non_consuming_empty_stack() {
+        let state = PushState::builder()
+            .with_max_stack_size(3)
+            .with_int_values([5, 8, 9])
+            .unwrap()
+            .with_bool_values([true, false])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAlphabeticNonConsuming.perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        let result_state = result.state();
+        assert_eq!(result_state.stack::<i64>().size(), 3);
+        assert_eq!(result_state.stack::<bool>().size(), 2);
+    }
+
+    #[proptest]
+    // We need to make sure that `x` is greater than `i64::MIN` since
+    // we handle that case differently. This is described in the documentation
+    // for `Abs`, and handled in the preceding test.
+    fn is_alphabetic(c: char) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(c))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAlphabetic.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 0);
+        prop_assert_eq!(result.stack::<bool>().size(), 1);
+        prop_assert_eq!(*result.stack::<bool>().top().unwrap(), c.is_alphabetic());
+    }
+
+    #[proptest]
+    // We need to make sure that `x` is greater than `i64::MIN` since
+    // we handle that case differently. This is described in the documentation
+    // for `Abs`, and handled in the preceding test.
+    fn is_alphabetic_non_consuming(c: char) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(c))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = IsAlphabeticNonConsuming.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 1);
+        prop_assert_eq!(*result.stack::<char>().top().unwrap(), c);
+        prop_assert_eq!(result.stack::<bool>().size(), 1);
+        prop_assert_eq!(*result.stack::<bool>().top().unwrap(), c.is_alphabetic());
+    }
+}

--- a/packages/push/src/instruction/char/is_whitespace.rs
+++ b/packages/push/src/instruction/char/is_whitespace.rs
@@ -155,6 +155,7 @@ mod tests {
     fn is_alphabetic_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_int_values([5, 8, 9])
             .unwrap()
             .with_bool_values([true, false])
@@ -174,6 +175,7 @@ mod tests {
     fn is_alphabetic_non_consuming_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_int_values([5, 8, 9])
             .unwrap()
             .with_bool_values([true, false])
@@ -194,6 +196,7 @@ mod tests {
     fn is_alphabetic(c: char) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(c))
             .unwrap()
             .with_no_program()
@@ -211,6 +214,7 @@ mod tests {
     fn is_alphabetic_non_consuming(c: char) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(c))
             .unwrap()
             .with_no_program()

--- a/packages/push/src/instruction/char/mod.rs
+++ b/packages/push/src/instruction/char/mod.rs
@@ -4,7 +4,7 @@ mod is_alphabetic;
 
 use ascii_from_wrapping_float::AsciiFromWrappingFloat;
 use ascii_from_wrapping_integer::AsciiFromWrappingInteger;
-use is_alphabetic::IsAlphabetic;
+use is_alphabetic::{IsAlphabetic, IsAlphabeticNonConsuming};
 use ordered_float::OrderedFloat;
 use strum_macros::EnumIter;
 
@@ -44,9 +44,16 @@ pub enum CharInstruction {
     AsciiFromWrappingFloat(AsciiFromWrappingFloat),
 
     /// Take the top of the character stack, and push a boolean
-    /// onto the bool stack that is true if that character was a
-    /// letter, and false otherwise.
+    /// onto the bool stack that is true if that character was
+    /// alphabetic, and false otherwise.
     IsAlphabetic(IsAlphabetic),
+
+    /// Push a boolean onto the bool stack that is `true` if the
+    /// character at the top of the character stack is alphabetic,
+    /// and `false` otherwise. This does *not* consumer the value
+    /// at the top of the character stack, i.e., it is still there
+    /// unchanged after this instruction is performed.
+    IsAlphabeticNonConsuming(IsAlphabeticNonConsuming),
 }
 
 impl From<CharInstruction> for PushInstruction {
@@ -67,6 +74,9 @@ where
             Self::AsciiFromWrappingInteger(ascii_wrap) => ascii_wrap.perform(state),
             Self::AsciiFromWrappingFloat(ascii_wrap) => ascii_wrap.perform(state),
             Self::IsAlphabetic(is_alphabetic) => is_alphabetic.perform(state),
+            Self::IsAlphabeticNonConsuming(is_alphabetic_non_consuming) => {
+                is_alphabetic_non_consuming.perform(state)
+            }
         }
     }
 }

--- a/packages/push/src/instruction/char/mod.rs
+++ b/packages/push/src/instruction/char/mod.rs
@@ -1,10 +1,13 @@
 mod ascii_from_wrapping_float;
 mod ascii_from_wrapping_integer;
 mod is_alphabetic;
+mod is_ascii_digit;
+mod is_whitespace;
 
 use ascii_from_wrapping_float::AsciiFromWrappingFloat;
 use ascii_from_wrapping_integer::AsciiFromWrappingInteger;
 use is_alphabetic::{IsAlphabetic, IsAlphabeticNonConsuming};
+use is_ascii_digit::{IsAsciiDigit, IsAsciiDigitNonConsuming};
 use ordered_float::OrderedFloat;
 use strum_macros::EnumIter;
 
@@ -54,6 +57,31 @@ pub enum CharInstruction {
     /// at the top of the character stack, i.e., it is still there
     /// unchanged after this instruction is performed.
     IsAlphabeticNonConsuming(IsAlphabeticNonConsuming),
+
+    /// Take the top of the character stack, and push a boolean
+    /// onto the bool stack that is true if that character was
+    /// a digit, and false otherwise.
+    IsAsciiDigit(IsAsciiDigit),
+
+    /// Push a boolean onto the bool stack that is `true` if the
+    /// character at the top of the character stack is a digit,
+    /// and `false` otherwise. This does *not* consumer the value
+    /// at the top of the character stack, i.e., it is still there
+    /// unchanged after this instruction is performed.
+    IsAsciiDigitNonConsuming(IsAsciiDigitNonConsuming),
+
+    /// Take the top of the character stack, and push a boolean
+    /// onto the bool stack that is true if that character was
+    /// whitespace, and false otherwise.
+    // IsWhitespace(IsWhitespace),
+
+    /// Push a boolean onto the bool stack that is `true` if the
+    /// character at the top of the character stack is whitespace,
+    /// and `false` otherwise. This does *not* consumer the value
+    /// at the top of the character stack, i.e., it is still there
+    /// unchanged after this instruction is performed.
+    // IsWhitespaceNonConsuming(IsWhitespaceNonConsuming),
+    Frog,
 }
 
 impl From<CharInstruction> for PushInstruction {
@@ -77,6 +105,15 @@ where
             Self::IsAlphabeticNonConsuming(is_alphabetic_non_consuming) => {
                 is_alphabetic_non_consuming.perform(state)
             }
+            Self::IsAsciiDigit(is_ascii_digit) => is_ascii_digit.perform(state),
+            Self::IsAsciiDigitNonConsuming(is_ascii_digit_non_consuming) => {
+                is_ascii_digit_non_consuming.perform(state)
+            }
+            // Self::IsWhitespace(is_whitespace) => is_whitespace.perform(state),
+            // Self::IsWhitespaceNonConsuming(is_whitespace_non_consuming) => {
+            //     is_whitespace_non_consuming.perform(state)
+            // }
+            Self::Frog => todo!(),
         }
     }
 }

--- a/packages/push/src/instruction/char/mod.rs
+++ b/packages/push/src/instruction/char/mod.rs
@@ -1,3 +1,6 @@
+mod ascii_from_wrapping_integer;
+
+use ascii_from_wrapping_integer::AsciiFromWrappingInteger;
 use strum_macros::EnumIter;
 
 use super::{Instruction, PushInstruction, instruction_error::PushInstructionError};
@@ -18,6 +21,14 @@ pub enum CharInstruction {
     /// onto the character stack.
     #[strum(to_string = "Push({0})")]
     Push(char),
+
+    /// Convert the top of the integer stack to a character,
+    /// and push that character to the top of the character stack.
+    /// To ensure that the integer is a legal ASCII code, we'll
+    /// take it mod 128 before converting it to a character.
+    /// Note that this does *not* support more complex Unicode
+    /// characters.
+    AsciiFromWrappingInteger(AsciiFromWrappingInteger),
 }
 
 impl From<CharInstruction> for PushInstruction {
@@ -28,12 +39,15 @@ impl From<CharInstruction> for PushInstruction {
 
 impl<S> Instruction<S> for CharInstruction
 where
-    S: Clone + HasStack<char> + HasStack<bool>,
+    S: Clone + HasStack<char> + HasStack<bool> + HasStack<i64>,
 {
     type Error = PushInstructionError;
 
-    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
-        todo!()
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
+        match self {
+            Self::Push(c) => state.with_push(*c).map_err_into(),
+            Self::AsciiFromWrappingInteger(ascii_wrap) => ascii_wrap.perform(state),
+        }
     }
 }
 

--- a/packages/push/src/instruction/char/mod.rs
+++ b/packages/push/src/instruction/char/mod.rs
@@ -1,8 +1,10 @@
 mod ascii_from_wrapping_float;
 mod ascii_from_wrapping_integer;
+mod is_alphabetic;
 
 use ascii_from_wrapping_float::AsciiFromWrappingFloat;
 use ascii_from_wrapping_integer::AsciiFromWrappingInteger;
+use is_alphabetic::IsAlphabetic;
 use ordered_float::OrderedFloat;
 use strum_macros::EnumIter;
 
@@ -40,6 +42,11 @@ pub enum CharInstruction {
     /// Note that this does *not* support more complex Unicode
     /// characters.
     AsciiFromWrappingFloat(AsciiFromWrappingFloat),
+
+    /// Take the top of the character stack, and push a boolean
+    /// onto the bool stack that is true if that character was a
+    /// letter, and false otherwise.
+    IsAlphabetic(IsAlphabetic),
 }
 
 impl From<CharInstruction> for PushInstruction {
@@ -59,6 +66,7 @@ where
             Self::Push(c) => state.with_push(*c).map_err_into(),
             Self::AsciiFromWrappingInteger(ascii_wrap) => ascii_wrap.perform(state),
             Self::AsciiFromWrappingFloat(ascii_wrap) => ascii_wrap.perform(state),
+            Self::IsAlphabetic(is_alphabetic) => is_alphabetic.perform(state),
         }
     }
 }

--- a/packages/push/src/instruction/char/mod.rs
+++ b/packages/push/src/instruction/char/mod.rs
@@ -1,6 +1,9 @@
+mod ascii_from_wrapping_float;
 mod ascii_from_wrapping_integer;
 
+use ascii_from_wrapping_float::AsciiFromWrappingFloat;
 use ascii_from_wrapping_integer::AsciiFromWrappingInteger;
+use ordered_float::OrderedFloat;
 use strum_macros::EnumIter;
 
 use super::{Instruction, PushInstruction, instruction_error::PushInstructionError};
@@ -29,6 +32,14 @@ pub enum CharInstruction {
     /// Note that this does *not* support more complex Unicode
     /// characters.
     AsciiFromWrappingInteger(AsciiFromWrappingInteger),
+
+    /// Convert the top of the float stack to a character,
+    /// and push that character to the top of the character stack.
+    /// To ensure that the float is a legal ASCII code, we mod
+    /// it by 128 before converting it to a character.
+    /// Note that this does *not* support more complex Unicode
+    /// characters.
+    AsciiFromWrappingFloat(AsciiFromWrappingFloat),
 }
 
 impl From<CharInstruction> for PushInstruction {
@@ -39,7 +50,7 @@ impl From<CharInstruction> for PushInstruction {
 
 impl<S> Instruction<S> for CharInstruction
 where
-    S: Clone + HasStack<char> + HasStack<bool> + HasStack<i64>,
+    S: Clone + HasStack<char> + HasStack<bool> + HasStack<i64> + HasStack<OrderedFloat<f64>>,
 {
     type Error = PushInstructionError;
 
@@ -47,6 +58,7 @@ where
         match self {
             Self::Push(c) => state.with_push(*c).map_err_into(),
             Self::AsciiFromWrappingInteger(ascii_wrap) => ascii_wrap.perform(state),
+            Self::AsciiFromWrappingFloat(ascii_wrap) => ascii_wrap.perform(state),
         }
     }
 }

--- a/packages/push/src/instruction/char/mod.rs
+++ b/packages/push/src/instruction/char/mod.rs
@@ -3,6 +3,7 @@ mod ascii_from_wrapping_integer;
 mod is_alphabetic;
 mod is_ascii_digit;
 mod is_whitespace;
+mod to_ascii_lowercase;
 
 use ascii_from_wrapping_float::AsciiFromWrappingFloat;
 use ascii_from_wrapping_integer::AsciiFromWrappingInteger;
@@ -11,6 +12,7 @@ use is_ascii_digit::{IsAsciiDigit, IsAsciiDigitNonConsuming};
 use is_whitespace::{IsWhitespace, IsWhitespaceNonConsuming};
 use ordered_float::OrderedFloat;
 use strum_macros::EnumIter;
+use to_ascii_lowercase::ToAsciiLowercase;
 
 use super::{Instruction, PushInstruction, instruction_error::PushInstructionError};
 use crate::{
@@ -82,6 +84,10 @@ pub enum CharInstruction {
     /// at the top of the character stack, i.e., it is still there
     /// unchanged after this instruction is performed.
     IsWhitespaceNonConsuming(IsWhitespaceNonConsuming),
+
+    /// Convert the top of the character stack to ASCII lowercase
+    /// if it's an ASCII uppercase letter. Otherwise leave it unchanged.
+    ToAsciiLowercase(ToAsciiLowercase),
 }
 
 impl From<CharInstruction> for PushInstruction {
@@ -113,6 +119,7 @@ where
             Self::IsWhitespaceNonConsuming(is_whitespace_non_consuming) => {
                 is_whitespace_non_consuming.perform(state)
             }
+            Self::ToAsciiLowercase(to_ascii_lowercase) => to_ascii_lowercase.perform(state),
         }
     }
 }
@@ -132,6 +139,11 @@ https://github.com/lspector/Clojush/blob/master/src/clojush/instructions/char.cl
 - touppercase
 - tolowercase
    - Leave char alone if not a letter
+
+Must "common" instructions shared across all stacks:
+- eq
+- ord
+- eq_ignore_ascii_case
 
 (define-registered
   char_allfromstring

--- a/packages/push/src/instruction/char/mod.rs
+++ b/packages/push/src/instruction/char/mod.rs
@@ -1,0 +1,151 @@
+use strum_macros::EnumIter;
+
+use super::{Instruction, PushInstruction, instruction_error::PushInstructionError};
+use crate::{
+    error::{InstructionResult, MapInstructionError},
+    push_vm::HasStack,
+};
+
+/// The variants of `CharInstruction` represent all the instructions that are
+/// available the primarily act on the character stack.
+#[derive(Debug, strum_macros::Display, Copy, Clone, PartialEq, Eq, EnumIter)]
+#[non_exhaustive]
+#[must_use]
+pub enum CharInstruction {
+    /// Push a character onto the character stack
+    ///
+    /// This is typically used to push constant values or input values
+    /// onto the character stack.
+    #[strum(to_string = "Push({0})")]
+    Push(char),
+}
+
+impl From<CharInstruction> for PushInstruction {
+    fn from(instr: CharInstruction) -> Self {
+        Self::CharInstruction(instr)
+    }
+}
+
+impl<S> Instruction<S> for CharInstruction
+where
+    S: Clone + HasStack<char> + HasStack<bool>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+        todo!()
+    }
+}
+
+/*
+All the `char` instructions from Clojush:
+https://github.com/lspector/Clojush/blob/master/src/clojush/instructions/char.clj
+
+- allfromstring (push all the chars in a string on the char stack)
+- frominteger
+   - Mod by 128 to force an ASCII code
+- fromfloat
+   - Convert to int and mod by 128
+- isletter
+- isdigit
+- iswhitespace
+- touppercase
+- tolowercase
+   - Leave char alone if not a letter
+
+(define-registered
+  char_allfromstring
+  ^{:stack-types [:char :string]}
+  (fn [state]
+    (if (empty? (:string state))
+      state
+      (loop [char-list (reverse (top-item :string state))
+             loop-state (pop-item :string state)]
+        (if (empty? char-list)
+          loop-state
+          (recur (rest char-list)
+                 (push-item (first char-list) :char loop-state)))))))
+
+(define-registered
+  char_frominteger
+  ^{:stack-types [:char :integer]}
+  (fn [state]
+    (if (not (empty? (:integer state)))
+      (let [item (stack-ref :integer 0 state)]
+        (->> (pop-item :integer state)
+             (push-item (char (mod item 128)) :char)))
+      state)))
+
+(define-registered
+  char_fromfloat
+  ^{:stack-types [:char :float]}
+  (fn [state]
+    (if (not (empty? (:float state)))
+      (let [item (stack-ref :float 0 state)]
+        (->> (pop-item :float state)
+             (push-item (char (mod (long item) 128)) :char)))
+      state)))
+
+(define-registered
+  char_isletter
+  ^{:stack-types [:char :boolean]}
+  (fn [state]
+    (if (not (empty? (:char state)))
+      (let [item (stack-ref :char 0 state)]
+        (->> (pop-item :char state)
+             (push-item (Character/isLetter item)
+                        :boolean)))
+      state)))
+
+(define-registered
+  char_isdigit
+  ^{:stack-types [:char :boolean]}
+  (fn [state]
+    (if (not (empty? (:char state)))
+      (let [item (stack-ref :char 0 state)]
+        (->> (pop-item :char state)
+             (push-item (Character/isDigit item)
+                        :boolean)))
+      state)))
+
+(define-registered
+  char_iswhitespace
+  ^{:stack-types [:char :boolean]}
+  (fn [state]
+    (if (not (empty? (:char state)))
+      (let [item (stack-ref :char 0 state)]
+        (->> (pop-item :char state)
+             (push-item (or (= item \newline)
+                            (= item \space)
+                            (= item \tab))
+                        :boolean)))
+      state)))
+
+(define-registered
+  char_uppercase
+  ^{:stack-types [:char]}
+  (fn [state]
+    (if (not (empty? (:char state)))
+      (let [cha (stack-ref :char 0 state)]
+        (->> (pop-item :char state)
+             (push-item
+              (if (and (>= (int cha) 97) (<= (int cha) 122))
+                (char (- (int cha) 32))
+                cha)
+              :char)))
+      state)))
+
+(define-registered
+  char_lowercase
+  ^{:stack-types [:char]}
+  (fn [state]
+    (if (not (empty? (:char state)))
+      (let [cha (stack-ref :char 0 state)]
+        (->> (pop-item :char state)
+             (push-item
+              (if (and (>= (int cha) 65) (<= (int cha) 90))
+                (char (+ (int cha) 32))
+                cha)
+              :char)))
+      state)))
+ */

--- a/packages/push/src/instruction/char/mod.rs
+++ b/packages/push/src/instruction/char/mod.rs
@@ -4,6 +4,7 @@ mod is_alphabetic;
 mod is_ascii_digit;
 mod is_whitespace;
 mod to_ascii_lowercase;
+mod to_ascii_uppercase;
 
 use ascii_from_wrapping_float::AsciiFromWrappingFloat;
 use ascii_from_wrapping_integer::AsciiFromWrappingInteger;
@@ -13,6 +14,7 @@ use is_whitespace::{IsWhitespace, IsWhitespaceNonConsuming};
 use ordered_float::OrderedFloat;
 use strum_macros::EnumIter;
 use to_ascii_lowercase::ToAsciiLowercase;
+use to_ascii_uppercase::ToAsciiUppercase;
 
 use super::{Instruction, PushInstruction, instruction_error::PushInstructionError};
 use crate::{
@@ -88,6 +90,10 @@ pub enum CharInstruction {
     /// Convert the top of the character stack to ASCII lowercase
     /// if it's an ASCII uppercase letter. Otherwise leave it unchanged.
     ToAsciiLowercase(ToAsciiLowercase),
+
+    /// Convert the top of the character stack to ASCII uppercase
+    /// if it's an ASCII lowercase letter. Otherwise leave it unchanged.
+    ToAsciiUppercase(ToAsciiUppercase),
 }
 
 impl From<CharInstruction> for PushInstruction {
@@ -120,6 +126,7 @@ where
                 is_whitespace_non_consuming.perform(state)
             }
             Self::ToAsciiLowercase(to_ascii_lowercase) => to_ascii_lowercase.perform(state),
+            Self::ToAsciiUppercase(to_ascii_uppercase) => to_ascii_uppercase.perform(state),
         }
     }
 }
@@ -140,7 +147,7 @@ https://github.com/lspector/Clojush/blob/master/src/clojush/instructions/char.cl
 - tolowercase
    - Leave char alone if not a letter
 
-Must "common" instructions shared across all stacks:
+Must be "common" instructions shared across all stacks:
 - eq
 - ord
 - eq_ignore_ascii_case

--- a/packages/push/src/instruction/char/mod.rs
+++ b/packages/push/src/instruction/char/mod.rs
@@ -8,6 +8,7 @@ use ascii_from_wrapping_float::AsciiFromWrappingFloat;
 use ascii_from_wrapping_integer::AsciiFromWrappingInteger;
 use is_alphabetic::{IsAlphabetic, IsAlphabeticNonConsuming};
 use is_ascii_digit::{IsAsciiDigit, IsAsciiDigitNonConsuming};
+use is_whitespace::{IsWhitespace, IsWhitespaceNonConsuming};
 use ordered_float::OrderedFloat;
 use strum_macros::EnumIter;
 
@@ -73,15 +74,14 @@ pub enum CharInstruction {
     /// Take the top of the character stack, and push a boolean
     /// onto the bool stack that is true if that character was
     /// whitespace, and false otherwise.
-    // IsWhitespace(IsWhitespace),
+    IsWhitespace(IsWhitespace),
 
     /// Push a boolean onto the bool stack that is `true` if the
     /// character at the top of the character stack is whitespace,
     /// and `false` otherwise. This does *not* consumer the value
     /// at the top of the character stack, i.e., it is still there
     /// unchanged after this instruction is performed.
-    // IsWhitespaceNonConsuming(IsWhitespaceNonConsuming),
-    Frog,
+    IsWhitespaceNonConsuming(IsWhitespaceNonConsuming),
 }
 
 impl From<CharInstruction> for PushInstruction {
@@ -109,11 +109,10 @@ where
             Self::IsAsciiDigitNonConsuming(is_ascii_digit_non_consuming) => {
                 is_ascii_digit_non_consuming.perform(state)
             }
-            // Self::IsWhitespace(is_whitespace) => is_whitespace.perform(state),
-            // Self::IsWhitespaceNonConsuming(is_whitespace_non_consuming) => {
-            //     is_whitespace_non_consuming.perform(state)
-            // }
-            Self::Frog => todo!(),
+            Self::IsWhitespace(is_whitespace) => is_whitespace.perform(state),
+            Self::IsWhitespaceNonConsuming(is_whitespace_non_consuming) => {
+                is_whitespace_non_consuming.perform(state)
+            }
         }
     }
 }

--- a/packages/push/src/instruction/char/to_ascii_lowercase.rs
+++ b/packages/push/src/instruction/char/to_ascii_lowercase.rs
@@ -1,0 +1,166 @@
+use crate::{
+    error::InstructionResult,
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{HasStack, stack::PushOnto},
+};
+
+/// An instruction that takes the top value from the `char` stack and
+/// converts it to an ASCII lowercase `char` if it's an ASCII uppercase
+/// character, leaving it unchanged if it's not.
+///
+/// # Inputs
+///
+/// The `CharInstruction::ToAsciiLowercase` instruction takes the
+/// following inputs:
+///    - `char` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::ToAsciiLowercase` instruction takes the top
+/// value of the `char` stack and converts it to an ASCII lowercase character
+/// if it's an ASCII uppercase character, leaving it unchanged if it's not.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `char` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists | ✅ | Replaces the character with its ASCII lowercase value if it was an ASCII uppercase |
+/// | missing | nothing is pushed onto the `char` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `char` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct ToAsciiLowercase;
+
+impl<S> Instruction<S> for ToAsciiLowercase
+where
+    S: Clone + HasStack<char>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
+        let char_stack = state.stack::<char>();
+        let lowercase_ascii_character = char_stack.top().map(char::to_ascii_lowercase);
+        lowercase_ascii_character.replace_on(1, state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use test_strategy::proptest;
+
+    use super::*;
+    use crate::push_vm::push_state::PushState;
+
+    /// Performing `ToAsciiLowercase` when the `char` stack is empty
+    /// should return a recoverable error with the state unchanged.
+    #[test]
+    fn to_ascii_lowercase_empty_stack() {
+        let state = PushState::builder()
+            .with_max_stack_size(3)
+            .with_int_values([1, 2, 3])
+            .unwrap()
+            .with_bool_values([true, false])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiLowercase.perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        let result_state = result.state();
+        assert_eq!(result_state.stack::<i64>().size(), 3);
+        assert_eq!(result_state.stack::<bool>().size(), 2);
+    }
+
+    #[test]
+    fn convert_ascii_uppercase() {
+        let input = 'M';
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiLowercase.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), 'm');
+    }
+
+    // This should do nothing since the value on the character stack is already an
+    // ASCII lowercase character.
+    #[test]
+    fn convert_ascii_lowercase() {
+        let input = 'm';
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiLowercase.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), 'm');
+    }
+
+    // This should do nothing since the value on the character stack is an ASCII
+    // non-letter.
+    #[test]
+    fn convert_ascii_non_letter() {
+        let input = '7';
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiLowercase.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), '7');
+    }
+
+    // This should do nothing since the value on the character stack is a Unicode
+    // character outside the ASCII set.
+    #[test]
+    fn convert_unicode() {
+        let input = 'π';
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiLowercase.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), 'π');
+    }
+
+    #[proptest]
+    fn ascii_from_wrapping_integer_proptest(c: char) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(c))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiLowercase.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 1);
+        let top_char = *result.stack::<char>().top().unwrap();
+        prop_assert_eq!(top_char, c.to_ascii_lowercase());
+    }
+}

--- a/packages/push/src/instruction/char/to_ascii_lowercase.rs
+++ b/packages/push/src/instruction/char/to_ascii_lowercase.rs
@@ -75,6 +75,7 @@ mod tests {
     fn to_ascii_lowercase_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_int_values([1, 2, 3])
             .unwrap()
             .with_bool_values([true, false])
@@ -93,6 +94,7 @@ mod tests {
         let input = 'M';
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -109,6 +111,7 @@ mod tests {
         let input = 'm';
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -125,6 +128,7 @@ mod tests {
         let input = '7';
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -141,6 +145,7 @@ mod tests {
         let input = 'π';
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -154,6 +159,7 @@ mod tests {
     fn ascii_from_wrapping_integer_proptest(c: char) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(c))
             .unwrap()
             .with_no_program()

--- a/packages/push/src/instruction/char/to_ascii_uppercase.rs
+++ b/packages/push/src/instruction/char/to_ascii_uppercase.rs
@@ -1,0 +1,166 @@
+use crate::{
+    error::InstructionResult,
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{HasStack, stack::PushOnto},
+};
+
+/// An instruction that takes the top value from the `char` stack and
+/// converts it to an ASCII uppercase `char` if it's an ASCII lowercase
+/// character, leaving it unchanged if it's not.
+///
+/// # Inputs
+///
+/// The `CharInstruction::ToAsciiUppercase` instruction takes the
+/// following inputs:
+///    - `char` stack
+///      - One value
+///
+/// # Behavior
+///
+/// The `CharInstruction::ToAsciiUppercase` instruction takes the top
+/// value of the `char` stack and converts it to an ASCII uppercase character
+/// if it's an ASCII lowercase character, leaving it unchanged if it's not.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`char` stack" column indicates the value of the top of the `char`
+///      stack, or whether it exists, all before the instruction is executed.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `char` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- |
+/// | exists | ✅ | Replaces the character with its ASCII uppercase value if it was an ASCII lowercase |
+/// | missing | nothing is pushed onto the `char` stack | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `char` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct ToAsciiUppercase;
+
+impl<S> Instruction<S> for ToAsciiUppercase
+where
+    S: Clone + HasStack<char>,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, state: S) -> InstructionResult<S, Self::Error> {
+        let char_stack = state.stack::<char>();
+        let uppercase_ascii_character = char_stack.top().map(char::to_ascii_uppercase);
+        uppercase_ascii_character.replace_on(1, state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use test_strategy::proptest;
+
+    use super::*;
+    use crate::push_vm::push_state::PushState;
+
+    /// Performing `ToAsciiUppercase` when the `char` stack is empty
+    /// should return a recoverable error with the state unchanged.
+    #[test]
+    fn to_ascii_uppercase_empty_stack() {
+        let state = PushState::builder()
+            .with_max_stack_size(3)
+            .with_int_values([1, 2, 3])
+            .unwrap()
+            .with_bool_values([true, false])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiUppercase.perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        let result_state = result.state();
+        assert_eq!(result_state.stack::<i64>().size(), 3);
+        assert_eq!(result_state.stack::<bool>().size(), 2);
+    }
+
+    #[test]
+    fn convert_ascii_lowercase() {
+        let input = 'm';
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiUppercase.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), 'M');
+    }
+
+    // This should do nothing since the value on the character stack is already an
+    // ASCII uppercase character.
+    #[test]
+    fn convert_ascii_uppercase() {
+        let input = 'M';
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiUppercase.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), 'M');
+    }
+
+    // This should do nothing since the value on the character stack is an ASCII
+    // non-letter.
+    #[test]
+    fn convert_ascii_non_letter() {
+        let input = '7';
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiUppercase.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), '7');
+    }
+
+    // This should do nothing since the value on the character stack is a Unicode
+    // character outside the ASCII set.
+    #[test]
+    fn convert_unicode() {
+        let input = 'π';
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(input))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiUppercase.perform(state).unwrap();
+        assert_eq!(result.stack::<char>().size(), 1);
+        assert_eq!(*result.stack::<char>().top().unwrap(), 'π');
+    }
+
+    #[proptest]
+    fn ascii_from_wrapping_integer_proptest(c: char) {
+        let state = PushState::builder()
+            .with_max_stack_size(1)
+            .with_char_values(std::iter::once(c))
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = ToAsciiUppercase.perform(state).unwrap();
+        prop_assert_eq!(result.stack::<char>().size(), 1);
+        let top_char = *result.stack::<char>().top().unwrap();
+        prop_assert_eq!(top_char, c.to_ascii_uppercase());
+    }
+}

--- a/packages/push/src/instruction/char/to_ascii_uppercase.rs
+++ b/packages/push/src/instruction/char/to_ascii_uppercase.rs
@@ -75,6 +75,7 @@ mod tests {
     fn to_ascii_uppercase_empty_stack() {
         let state = PushState::builder()
             .with_max_stack_size(3)
+            .with_instruction_step_limit(1_000)
             .with_int_values([1, 2, 3])
             .unwrap()
             .with_bool_values([true, false])
@@ -93,6 +94,7 @@ mod tests {
         let input = 'm';
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -109,6 +111,7 @@ mod tests {
         let input = 'M';
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -125,6 +128,7 @@ mod tests {
         let input = '7';
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -141,6 +145,7 @@ mod tests {
         let input = 'π';
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(input))
             .unwrap()
             .with_no_program()
@@ -154,6 +159,7 @@ mod tests {
     fn ascii_from_wrapping_integer_proptest(c: char) {
         let state = PushState::builder()
             .with_max_stack_size(1)
+            .with_instruction_step_limit(1_000)
             .with_char_values(std::iter::once(c))
             .unwrap()
             .with_no_program()

--- a/packages/push/src/instruction/mod.rs
+++ b/packages/push/src/instruction/mod.rs
@@ -3,6 +3,7 @@ use printing::{PrintNewline, PrintPeriod, PrintSpace, PrintString};
 
 pub use self::{
     bool::BoolInstruction,
+    char::CharInstruction,
     exec::ExecInstruction,
     float::FloatInstruction,
     int::{IntInstruction, IntInstructionError},
@@ -19,6 +20,7 @@ pub mod printing;
 pub mod variable_name;
 
 mod bool;
+mod char;
 mod exec;
 mod float;
 mod int;
@@ -70,6 +72,7 @@ pub enum PushInstruction {
     InputVar(VariableName),
     Exec(ExecInstruction),
     BoolInstruction(BoolInstruction),
+    CharInstruction(CharInstruction),
     IntInstruction(IntInstruction),
     FloatInstruction(FloatInstruction),
     PrintSpace(PrintSpace),
@@ -79,24 +82,40 @@ pub enum PushInstruction {
 }
 
 impl PushInstruction {
+    /// Push a boolean value onto the bool stack
+    ///
+    /// This is typically used to push constant values
+    /// or argument values onto this stack.
     #[must_use]
     pub fn push_bool(b: bool) -> Self {
         BoolInstruction::push(b).into()
     }
 
+    /// Push an `i64` value onto the int stack
+    ///
+    /// This is typically used to push constant values
+    /// or argument values onto this stack.
     #[must_use]
     pub fn push_int(i: i64) -> Self {
         IntInstruction::push(i).into()
     }
 
-    // #[must_use]
-    // pub fn push_float(f: f64) -> Self {
-    //     FloatInstruction::push(f).into()
-    // }
-
+    /// Push an `OrderedFloat<f64>` value onto the float stack
+    ///
+    /// This is typically used to push constant values
+    /// or argument values onto this stack.
     #[must_use]
     pub fn push_float(f: OrderedFloat<f64>) -> Self {
         FloatInstruction::push_ordered_float(f).into()
+    }
+
+    /// Push a character onto the character stack
+    ///
+    /// This is typically used to push constant values
+    /// or argument values onto this stack.
+    #[must_use]
+    pub fn push_char(c: char) -> Self {
+        CharInstruction::Push(c).into()
     }
 }
 
@@ -112,6 +131,7 @@ impl Instruction<PushState> for PushInstruction {
             }
             Self::Exec(i) => i.perform(state),
             Self::BoolInstruction(i) => i.perform(state),
+            Self::CharInstruction(i) => i.perform(state),
             Self::IntInstruction(i) => i.perform(state),
             Self::FloatInstruction(i) => i.perform(state),
             Self::PrintString(i) => i.perform(state).map_err_into(),
@@ -145,6 +165,7 @@ impl std::fmt::Display for PushInstruction {
             Self::InputVar(instruction) => write!(f, "{instruction}"),
             Self::Exec(instruction) => write!(f, "Exec-{instruction}"),
             Self::BoolInstruction(instruction) => write!(f, "Bool-{instruction}"),
+            Self::CharInstruction(instruction) => write!(f, "Char-{instruction}"),
             Self::IntInstruction(instruction) => write!(f, "Int-{instruction}"),
             Self::FloatInstruction(instruction) => write!(f, "Float-{instruction}"),
             Self::PrintString(instruction) => write!(f, "PrintString({})", instruction.0),

--- a/packages/push/src/push_vm/push_state.rs
+++ b/packages/push/src/push_vm/push_state.rs
@@ -21,14 +21,36 @@ use crate::{
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 #[push_macros::push_state(builder)]
 pub struct PushState {
+    /// A stack of `PushProgram`s
+    ///
+    /// The execution of a Push program consists of running the
+    /// program at the top of the exec stack until the exec stack
+    /// is empty.
     #[stack(exec)]
     pub(crate) exec: Stack<PushProgram>,
+
+    /// A stack of `i64` values
     #[stack(sample_values = [4, 5, 7])]
     pub(crate) int: Stack<i64>,
+
+    /// A stack of `OrderedFloat<f64> values`
     #[stack(sample_values = [OrderedFloat(4.3), OrderedFloat(5.1), OrderedFloat(2.1)])]
     pub(crate) float: Stack<OrderedFloat<f64>>,
+
+    /// A stack of boolean values
     #[stack(sample_values = [true, false, true, true])]
     pub(crate) bool: Stack<bool>,
+
+    /// A stack of character values
+    #[stack(sample_values = ['a', 'b', 'c'])]
+    pub(crate) char: Stack<char>,
+
+    /// A map that maps from (input) variable names to their values.
+    ///
+    /// Thus if you have an input `x` which has the value 5 in this
+    /// training case, then you would add an entry to this mapping
+    /// with the key `VariableName::from("x")` and the value
+    /// `PushInstruction::IntInstruction(IntInstruction::Push(5))`.
     // The Internet suggests that when you have fewer than 15 entries,
     // linear search on `Vec` is faster than `HashMap`. I found that
     // using `HashMap` here did slow things down, mostly


### PR DESCRIPTION
This adds support for a character stack in our Push VM.

[The instructions for the character stack in Clojush](https://github.com/lspector/Clojush/blob/master/src/clojush/instructions/char.clj) are:

- [ ] allfromstring (push all the chars in a string on the char stack)
   - This requires having the `String` stack, which we don't have yet.
- [x] frominteger
   - Mod by 128 to force an ASCII code
- [x] fromfloat
   - Convert to int and mod by 128
- [x] isletter (actually, `IsAlphabetic`)
- [x] isdigit
- [x] iswhitespace
- [x] touppercase
   - Leave char alone if not a letter
- [x] tolowercase
   - Leave char alone if not a letter

Several of these (like `frominteger`) assume an ASCII character universe. Rust supports a much richer notion of characters (full Unicode), and it would be good to leverage that support. Based on discussion in the Twitch stream, I think the plan is to provide multiple versions of instructions that in Clojush are tied to ASCII. We can have one version that is ASCII-specific (and reflect that in the name), and have another version that acts on more general notions of characters.

As an example, We can have `AsciiFromWrappingInteger` for the conversion that mods by 128 and then converts to an ASCII character.

The "obvious" companion to this would be `FromInteger` that would use Rust's `char::from_u32`. There are two issues here, however:
- We have `i64`s on our integer stack. 
- `from_u32` returns `Option<char>` because not all `u32` values map to a legal character in Unicode.

The first issue is easily solvable by using `euclid_rem()` to map those to `u32`, where it's less obvious how to handle the second option. We likely can't push a character onto the character stack, because there's no character to push. (We could do some kind of linear search for the character with the `u32` value closest to the one we got from the integer stack, but I don't know how dense they are in Unicode and how expensive that might end up being.) If we can't push a character, then the question becomes whether we consume the integer or not, i.e., is it more "surprising/confusing" for evolution to (a) remove the integer and not push a character or (b) leave the integer when we were expecting it to go away. My inclination is to go with (a), but I'm open to other ideas/approaches.

I think that most of the other instructions will be fairly straightforward, although there might be some options to consider. I'm not sure, for example, if we want to have both `IsAsciiDigit` and `IsDigit`, or just use `IsDigit` (which will return `true` when it's an ASCII digit)? My inclination is to just have `IsDigit` in order to not clutter up the world too much, but I'm open to suggestions.

Closes #320 