### PR TITLE
Add push instructions for equality and comparison tests

### DIFF
--- a/packages/push/proptest-regressions/instruction/common/cmp/greater_than.txt
+++ b/packages/push/proptest-regressions/instruction/common/cmp/greater_than.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a5d334a4f15758f8f190a26bc01241d6a15e60b8f00bc186c5d5236abddb6244 # shrinks to input = _ProptestSameStackArgs { a: 0, b: -1 }

--- a/packages/push/src/instruction/common/cmp/equal.rs
+++ b/packages/push/src/instruction/common/cmp/equal.rs
@@ -175,7 +175,6 @@ where
 
 #[cfg(test)]
 mod test {
-    use ordered_float::OrderedFloat;
     use proptest::prelude::*;
     use test_strategy::proptest;
 
@@ -188,6 +187,7 @@ mod test {
     #[test]
     fn equal_same_stack_equal() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(2)
             .with_int_values([5, 5])
             .unwrap()
@@ -201,6 +201,7 @@ mod test {
     #[test]
     fn equal_same_stack_not_equal() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(2)
             .with_int_values([5, 10])
             .unwrap()
@@ -211,39 +212,10 @@ mod test {
         assert_eq!(result.stack::<bool>(), &[false]);
     }
 
-    // #[test]
-    // fn equal_different_stacks_equal() {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(1)
-    //         .with_int_values([5])
-    //         .unwrap()
-    //         .with_float_values([OrderedFloat(5.0)])
-    //         .unwrap()
-    //         .with_no_program()
-    //         .build();
-    //     let result = Equal::<i64, f64>::default().perform(state).unwrap();
-    //     assert_eq!(result.stack::<bool>().top().unwrap(), &true);
-    //     assert_eq!(result.stack::<bool>().size(), 1);
-    // }
-
-    // #[test]
-    // fn equal_different_stacks_not_equal() {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(1)
-    //         .with_int_values([5])
-    //         .unwrap()
-    //         .with_float_values([OrderedFloat(10.0)])
-    //         .unwrap()
-    //         .with_no_program()
-    //         .build();
-    //     let result = Equal::<i64, f64>::default().perform(state).unwrap();
-    //     assert_eq!(result.stack::<bool>().top().unwrap(), &false);
-    //     assert_eq!(result.stack::<bool>().size(), 1);
-    // }
-
     #[test]
-    fn equal_same_stack_underflow() {
+    fn equal_same_stack_empty_stack() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             // This has to be 1 to ensure that there's room on the bool stack for the result.
             .with_max_stack_size(1)
             .with_no_program()
@@ -260,8 +232,9 @@ mod test {
     }
 
     #[test]
-    fn equal_same_stack_underflow_one() {
+    fn equal_same_stack_singleton_stack() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(1)
             .with_int_values([5])
             .unwrap()
@@ -278,48 +251,10 @@ mod test {
         );
     }
 
-    // #[test]
-    // fn equal_different_stacks_underflow_first() {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(0)
-    //         .with_float_values([OrderedFloat(10.0)])
-    //         .unwrap()
-    //         .with_no_program()
-    //         .build();
-    //     let result = Equal::<i64, f64>::default().perform(state).unwrap_err();
-    //     assert!(result.is_recoverable());
-    //     assert_eq!(
-    //         result.error(),
-    //         &PushInstructionError::StackError(StackError::Underflow {
-    //             num_requested: 1,
-    //             num_present: 0
-    //         })
-    //     );
-    // }
-
-    // #[test]
-    // fn equal_different_stacks_underflow_second() {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(1)
-    //         .with_int_values([5])
-    //         .unwrap()
-    //         .with_max_stack_size(0)
-    //         .with_no_program()
-    //         .build();
-    //     let result = Equal::<i64, f64>::default().perform(state).unwrap_err();
-    //     assert!(result.is_recoverable());
-    //     assert_eq!(
-    //         result.error(),
-    //         &PushInstructionError::StackError(StackError::Underflow {
-    //             num_requested: 1,
-    //             num_present: 0
-    //         })
-    //     );
-    // }
-
     #[test]
     fn equal_bool_stack_overflow() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(2)
             .with_int_values([5, 5])
             .unwrap()
@@ -339,6 +274,7 @@ mod test {
     #[proptest]
     fn equal_proptest_same_stack(a: i64, b: i64) {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(2)
             .with_int_values([a, b])
             .unwrap()
@@ -348,19 +284,4 @@ mod test {
         prop_assert_eq!(result.stack::<bool>().top().unwrap(), &(a == b));
         prop_assert_eq!(result.stack::<bool>().size(), 1);
     }
-
-    // #[proptest]
-    // fn equal_proptest_different_stacks(a: i64, b: f64) {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(1)
-    //         .with_int_values([a])
-    //         .unwrap()
-    //         .with_float_values([b])
-    //         .unwrap()
-    //         .with_no_program()
-    //         .build();
-    //     let result = Equal::<i64, f64>::default().perform(state).unwrap();
-    //     prop_assert_eq!(result.stack::<bool>().top().unwrap(), &(a as f64 ==
-    // b));     prop_assert_eq!(result.stack::<bool>().size(), 1);
-    // }
 }

--- a/packages/push/src/instruction/common/cmp/equal.rs
+++ b/packages/push/src/instruction/common/cmp/equal.rs
@@ -1,0 +1,142 @@
+use std::{any::TypeId, marker::PhantomData};
+
+use crate::{
+    error::{Error, InstructionResult, MapInstructionError},
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{HasStack, stack::StackError},
+};
+
+/// An instruction that compares two stack values for equality.
+///
+/// This instruction works similarly to Rust's [`PartialEq`]. `Equal<T>` (which
+/// is just a shorthand for `Equal<T,T>`) compares the second value on the T
+/// stack with the first (top) value from the T
+/// stack, pushing the result onto the boolean stack.
+///
+/// If we instead use two different types, like in `Equal<T,U>`, this
+/// can compare across stacks as long as `T: PartialEq<U>`, comparing T == U
+/// using the top values of the respective stacks. Again the result is pushed
+/// onto the boolean stack.
+///
+/// # Inputs
+///
+/// ## `Equal<T, T>`
+///
+/// The `Equal<T, T>` instruction takes the following inputs:
+///    - `T` stack
+///      - Two values
+///
+/// ## `Equal<T, U>`
+///
+/// The `Equal<T, U>` instruction takes the following inputs:
+///    - `T` stack
+///       - One value
+///    - `U` stack
+///       - One value
+///
+/// # Behavior
+///
+/// The `Equal` instruction takes top two values from the `T`
+/// value of the `i64` stack. The one exception (as described above) is when
+/// the value is `i64::MIN`, where `Abs` removes it and pushes
+/// on `i64::MAX` in its place.
+///
+/// ## Action Table
+///
+/// The table below indicates the behavior in each of the different
+/// cases.
+///
+///    - The "`i64` stack" column indicates the value of the top of the `i64`
+///      stack, or whether it exists.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | `i64` stack  |  Success | Note |
+/// | ------------- | ------------- | ------------- |
+/// | `i64::MIN`    | ✅ | `i64::MIN` is replaced with `i64::MAX` |
+/// | exists, not `i64::MIN` | ✅ | Takes the absolute value of the top value of the `i64` stack |
+/// | missing | [❗..](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `i64` stack is empty.
+///
+/// # Differences
+/// Implementations of integer negation instructions in Clojure (e.g., Clojush
+/// or Propeller) or Python (e.g. `PyshGP`) won't have the wrapping issue
+/// because they act on arbitrary precision integers.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct Equal<T, U = T> {
+    _p: PhantomData<(T, U)>,
+}
+
+impl<S, First, Second> Instruction<S> for Equal<First, Second>
+where
+    S: Clone + HasStack<First> + HasStack<Second> + HasStack<bool>,
+    First: PartialEq<Second> + 'static,
+    Second: 'static,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+        // If the bool stack is full, then this would overflow that
+        // stack and we return a fatal error. If either of the stacks being
+        // compared, however, is the boolean stack, then that will free up at
+        // least the one space needed for the result.
+        let bool_stack = state.stack::<bool>();
+        if bool_stack.is_full()
+            && ![TypeId::of::<First>(), TypeId::of::<Second>()].contains(&TypeId::of::<bool>())
+        {
+            return Err(Error::fatal(
+                state,
+                StackError::Overflow { stack_type: "bool" },
+            ));
+        }
+
+        // If First=Second (i.e., we're comparing items from the same stack), then we
+        // will need to pop two values from that stack. If they are different we
+        // will need to pop one value from First. So we'll just check the size
+        // of First here, which will include the size of Second if First=Second.
+        let first_stack_required = if TypeId::of::<First>() == TypeId::of::<Second>() {
+            2
+        } else {
+            1
+        };
+
+        {
+            // Create a scope so we can't accidentally use `first_stack_size` after
+            // we might have modified the `First` stack.
+            let first_stack_size = state.stack::<First>().size();
+            // If the `First` stack doesn't have enough items, we want to return
+            // a recoverable error right away before we modify any stacks.
+            if first_stack_size < first_stack_required {
+                return Err(Error::recoverable(
+                    state,
+                    StackError::Underflow {
+                        num_requested: first_stack_required,
+                        num_present: first_stack_size,
+                    },
+                ));
+            }
+        }
+
+        let second = match state.stack_mut::<Second>().pop() {
+            Ok(value) => value,
+            Err(error) => return Err(Error::recoverable(state, error)),
+        };
+        let first = match state.stack_mut::<First>().pop() {
+            Ok(value) => value,
+            // Because of the size checks above, this should actually never fail, so we'll return a
+            // `Fatal` error if for some reason it does.
+            Err(error) => return Err(Error::fatal(state, error)),
+        };
+
+        state.with_push(first == second).map_err_into()
+    }
+}

--- a/packages/push/src/instruction/common/cmp/equal.rs
+++ b/packages/push/src/instruction/common/cmp/equal.rs
@@ -185,7 +185,7 @@ mod test {
     };
 
     #[test]
-    fn equal_same_stack_equal() {
+    fn equal() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(2)
@@ -199,7 +199,7 @@ mod test {
     }
 
     #[test]
-    fn equal_same_stack_not_equal() {
+    fn not_equal() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(2)
@@ -213,7 +213,7 @@ mod test {
     }
 
     #[test]
-    fn equal_same_stack_empty_stack() {
+    fn empty_stack() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             // This has to be 1 to ensure that there's room on the bool stack for the result.
@@ -232,7 +232,7 @@ mod test {
     }
 
     #[test]
-    fn equal_same_stack_singleton_stack() {
+    fn singleton_stack() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(1)
@@ -252,7 +252,7 @@ mod test {
     }
 
     #[test]
-    fn equal_bool_stack_overflow() {
+    fn bool_stack_overflow() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(2)
@@ -272,7 +272,7 @@ mod test {
     }
 
     #[proptest]
-    fn equal_proptest_same_stack(a: i64, b: i64) {
+    fn equal_proptest(a: i64, b: i64) {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(2)

--- a/packages/push/src/instruction/common/cmp/equal.rs
+++ b/packages/push/src/instruction/common/cmp/equal.rs
@@ -73,8 +73,8 @@ use crate::{
 /// cases where the two values being compared are being taken from _different_
 /// stacks.
 ///
-///    - The "Stack<T>" column indicates "X", the top of the `T` stack.
-///    - The "Stack<U>" column indicates "Y", the top of the `U` stack.
+///    - The `Stack<T>` column indicates "X", the top of the `T` stack.
+///    - The `Stack<U>` column indicates "Y", the top of the `U` stack.
 ///    - The "Result" column indicates the value left on the top of the boolean
 ///      stack.
 ///    - The "Success" column indicates whether the instruction succeeds, and if
@@ -95,13 +95,13 @@ use crate::{
 /// ## `Equal<T, T>`
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when the `T` stack contains fewer than two items.
 ///
 /// ## `Equal<T, U>` where T ≠ U
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when either the `T` stack or the `U` stack is empty.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct Equal<T, U = T> {

--- a/packages/push/src/instruction/common/cmp/greater_than.rs
+++ b/packages/push/src/instruction/common/cmp/greater_than.rs
@@ -77,8 +77,8 @@ use crate::{
 /// cases where the two values being compared are being taken from _different_
 /// stacks.
 ///
-///    - The "Stack<T>" column indicates "X", the top of the `T` stack.
-///    - The "Stack<U>" column indicates "Y", the top of the `U` stack.
+///    - The `Stack<T>` column indicates "X", the top of the `T` stack.
+///    - The `Stack<U>` column indicates "Y", the top of the `U` stack.
 ///    - The "Result" column indicates the value left on the top of the boolean
 ///      stack.
 ///    - The "Success" column indicates whether the instruction succeeds, and if
@@ -99,13 +99,13 @@ use crate::{
 /// ## `GreaterThan<T, T>`
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when the `T` stack contains fewer than two items.
 ///
 /// ## `GreaterThan<T, U>` where T ≠ U
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when either the `T` stack or the `U` stack is empty.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct GreaterThan<T, U = T> {

--- a/packages/push/src/instruction/common/cmp/greater_than.rs
+++ b/packages/push/src/instruction/common/cmp/greater_than.rs
@@ -1,0 +1,305 @@
+use std::{any::TypeId, marker::PhantomData};
+
+use crate::{
+    error::{Error, InstructionResult, MapInstructionError},
+    instruction::{Instruction, instruction_error::PushInstructionError},
+    push_vm::{HasStack, stack::StackError},
+};
+
+/// An instruction that check if one value is greater another.
+///
+/// This instruction works similarly to Rust's [`PartialOrd`].
+///
+/// `GreaterThan<T>` (which
+/// is just a shorthand for `GreaterThan<T,T>`) compares the top
+/// two values of `Stack<T>`, pushing the result onto the boolean
+/// stack. The comparison will be `x > y`, where `x` is the top value
+/// on the stack, and `y` is the second value on the stack.
+///
+/// If we instead use two different types, like in `GreaterThan<T,U>`, this
+/// can compare across stacks as long as `T: PartialOrd<U>`, comparing T > U
+/// using the top values of the respective stacks. Again the result is pushed
+/// onto the boolean stack.
+///
+/// # Inputs
+///
+/// ## `GreaterThan<T, T>`
+///
+/// The `GreaterThan<T, T>` instruction takes the following inputs:
+///    - `T` stack
+///      - Two values
+///
+/// ## `GreaterThan<T, U>`
+///
+/// The `GreaterThan<T, U>` instruction takes the following inputs:
+///    - `T` stack
+///       - One value
+///    - `U` stack
+///       - One value
+///
+/// # Behavior
+///
+/// The `GreaterThan` instruction takes top two values from the `T`
+/// stack (`x` from the top and `y` below it), or one from the `T` stack (`x`)
+/// and one from the `U` stack (`y`),
+/// compares those values, and pushes the result onto the boolean
+/// stack (`true` if `x > y`, and `false` otherwise).
+///
+/// ## Action Table
+///
+/// ### `GreaterThan<T, T>`
+///
+/// The table below indicates the behavior in each of the different
+/// cases where the two values being compared are being taken from the same
+/// stack.
+///
+///    - The "X" column indicates the top of the `T` stack.
+///    - The "Y" column indicates the second value on the `T` stack.
+///    - The "Result" column indicates the value left on the top of the boolean
+///      stack.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | X  | Y | Result | Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+/// | exists | exists | X = Y | ✅ | The value of X>Y is pushed onto the boolean stack |
+/// | missing | irrelevant | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+/// | present | missing | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// ### `GreaterThan<T, U>`, where T ≠ U
+///
+///
+/// The table below indicates the behavior in each of the different
+/// cases where the two values being compared are being taken from _different_
+/// stacks.
+///
+///    - The "Stack<T>" column indicates "X", the top of the `T` stack.
+///    - The "Stack<U>" column indicates "Y", the top of the `U` stack.
+///    - The "Result" column indicates the value left on the top of the boolean
+///      stack.
+///    - The "Success" column indicates whether the instruction succeeds, and if
+///      not what kind of error is returned:
+///       - ✅: success
+///       - ❗: recoverable error, with links to the error kind
+///       - ‼️: fatal error, with links to the error kind
+///    - The "Note" column briefly summarizes the action state in that case
+///
+/// | "X": `Stack<T>`  | "Y": `Stack<U>` | Result | Success | Note |
+/// | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+/// | exists | exists | X = Y | ✅ | The value of X>Y is pushed onto the boolean stack |
+/// | missing | irrelevant | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+/// | present | missing | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+///
+/// # Errors
+///
+/// ## `GreaterThan<T, T>`
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when the `T` stack contains fewer than two items.
+///
+/// ## `GreaterThan<T, U>` where T ≠ U
+///
+/// Returns a
+/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// error when either the `T` stack or the `U` stack is empty.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct GreaterThan<T, U = T> {
+    _p: PhantomData<(T, U)>,
+}
+
+impl<S, First, Second> Instruction<S> for GreaterThan<First, Second>
+where
+    S: Clone + HasStack<Second> + HasStack<First> + HasStack<bool>,
+    First: PartialOrd<Second> + 'static,
+    Second: 'static,
+{
+    type Error = PushInstructionError;
+
+    fn perform(&self, mut state: S) -> InstructionResult<S, Self::Error> {
+        // If the bool stack is full, then this would overflow that
+        // stack and we return a fatal error. If either of the stacks being
+        // compared, however, is the boolean stack, then that will free up at
+        // least the one space needed for the result.
+        let bool_stack = state.stack::<bool>();
+        if bool_stack.is_full()
+            && ![TypeId::of::<Second>(), TypeId::of::<First>()].contains(&TypeId::of::<bool>())
+        {
+            return Err(Error::fatal(
+                state,
+                StackError::Overflow { stack_type: "bool" },
+            ));
+        }
+
+        // If First=Second (i.e., we're comparing items from the same stack), then we
+        // will need to pop two values from that stack. If they are different we
+        // will need to pop one value from First. So we'll just check the size
+        // of First here, which will include the size of Second if First=Second.
+        let second_stack_required = if TypeId::of::<Second>() == TypeId::of::<First>() {
+            2
+        } else {
+            1
+        };
+
+        {
+            // Create a scope so we can't accidentally use `first_stack_size` after
+            // we might have modified the `First` stack.
+            let second_stack_size = state.stack::<Second>().size();
+            // If the `First` stack doesn't have enough items, we want to return
+            // a recoverable error right away before we modify any stacks.
+            if second_stack_size < second_stack_required {
+                return Err(Error::recoverable(
+                    state,
+                    StackError::Underflow {
+                        num_requested: second_stack_required,
+                        num_present: second_stack_size,
+                    },
+                ));
+            }
+        }
+
+        let first = match state.stack_mut::<First>().pop() {
+            Ok(value) => value,
+            Err(error) => return Err(Error::recoverable(state, error)),
+        };
+        let second = match state.stack_mut::<Second>().pop() {
+            Ok(value) => value,
+            // Because of the size checks above, this should actually never fail, so we'll return a
+            // `Fatal` error if for some reason it does.
+            Err(error) => return Err(Error::fatal(state, error)),
+        };
+
+        state.with_push(first > second).map_err_into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use proptest::prelude::*;
+    use test_strategy::proptest;
+
+    use super::GreaterThan;
+    use crate::{
+        instruction::{Instruction, instruction_error::PushInstructionError},
+        push_vm::{HasStack, push_state::PushState, stack::StackError},
+    };
+
+    #[test]
+    fn equal() {
+        let state = PushState::builder()
+            .with_instruction_step_limit(1)
+            .with_max_stack_size(2)
+            .with_int_values([5, 5])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = GreaterThan::<i64>::default().perform(state).unwrap();
+        assert!(result.stack::<i64>().is_empty());
+        assert_eq!(result.stack::<bool>(), &[false]);
+    }
+
+    #[test]
+    fn less_than() {
+        let state = PushState::builder()
+            .with_instruction_step_limit(1)
+            .with_max_stack_size(2)
+            .with_int_values([5, 10])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = GreaterThan::<i64>::default().perform(state).unwrap();
+        assert!(result.stack::<i64>().is_empty());
+        assert_eq!(result.stack::<bool>(), &[false]);
+    }
+
+    #[test]
+    fn greater_than() {
+        let state = PushState::builder()
+            .with_instruction_step_limit(1)
+            .with_max_stack_size(2)
+            .with_int_values([10, 5])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = GreaterThan::<i64>::default().perform(state).unwrap();
+        assert!(result.stack::<i64>().is_empty());
+        assert_eq!(result.stack::<bool>(), &[true]);
+    }
+
+    #[test]
+    fn empty_stack() {
+        let state = PushState::builder()
+            .with_instruction_step_limit(1)
+            // This has to be 1 to ensure that there's room on the bool stack for the result.
+            .with_max_stack_size(1)
+            .with_no_program()
+            .build();
+        let result = GreaterThan::<i64>::default().perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        assert_eq!(
+            result.error(),
+            &PushInstructionError::StackError(StackError::Underflow {
+                num_requested: 2,
+                num_present: 0
+            })
+        );
+    }
+
+    #[test]
+    fn singleton_stack() {
+        let state = PushState::builder()
+            .with_instruction_step_limit(1)
+            .with_max_stack_size(1)
+            .with_int_values([5])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = GreaterThan::<i64>::default().perform(state).unwrap_err();
+        assert!(result.is_recoverable());
+        assert_eq!(
+            result.error(),
+            &PushInstructionError::StackError(StackError::Underflow {
+                num_requested: 2,
+                num_present: 1
+            })
+        );
+    }
+
+    #[test]
+    fn bool_stack_overflow() {
+        let state = PushState::builder()
+            .with_instruction_step_limit(1)
+            .with_max_stack_size(2)
+            .with_int_values([5, 5])
+            .unwrap()
+            // Trying to push the result will overflow the boolean stack
+            .with_bool_values([false, false])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = GreaterThan::<i64>::default().perform(state).unwrap_err();
+        assert!(!result.is_recoverable());
+        assert_eq!(
+            result.error(),
+            &PushInstructionError::StackError(StackError::Overflow { stack_type: "bool" })
+        );
+    }
+
+    #[proptest]
+    fn proptest_same_stack(a: i64, b: i64) {
+        let state = PushState::builder()
+            .with_instruction_step_limit(1)
+            .with_max_stack_size(2)
+            .with_int_values([a, b])
+            .unwrap()
+            .with_no_program()
+            .build();
+        let result = GreaterThan::<i64>::default().perform(state).unwrap();
+        prop_assert_eq!(result.stack::<bool>().top().unwrap(), &(a > b));
+        prop_assert_eq!(result.stack::<bool>().size(), 1);
+    }
+}

--- a/packages/push/src/instruction/common/cmp/greater_than_equal.rs
+++ b/packages/push/src/instruction/common/cmp/greater_than_equal.rs
@@ -77,8 +77,8 @@ use crate::{
 /// cases where the two values being compared are being taken from _different_
 /// stacks.
 ///
-///    - The "Stack<T>" column indicates "X", the top of the `T` stack.
-///    - The "Stack<U>" column indicates "Y", the top of the `U` stack.
+///    - The `Stack<T>` column indicates "X", the top of the `T` stack.
+///    - The `Stack<U>` column indicates "Y", the top of the `U` stack.
 ///    - The "Result" column indicates the value left on the top of the boolean
 ///      stack.
 ///    - The "Success" column indicates whether the instruction succeeds, and if
@@ -99,13 +99,13 @@ use crate::{
 /// ## `GreaterThanEqual<T, T>`
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when the `T` stack contains fewer than two items.
 ///
 /// ## `GreaterThanEqual<T, U>` where T ≠ U
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when either the `T` stack or the `U` stack is empty.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct GreaterThanEqual<T, U = T> {

--- a/packages/push/src/instruction/common/cmp/less_than.rs
+++ b/packages/push/src/instruction/common/cmp/less_than.rs
@@ -77,8 +77,8 @@ use crate::{
 /// cases where the two values being compared are being taken from _different_
 /// stacks.
 ///
-///    - The "Stack<T>" column indicates "X", the top of the `T` stack.
-///    - The "Stack<U>" column indicates "Y", the top of the `U` stack.
+///    - The `Stack<T>` column indicates "X", the top of the `T` stack.
+///    - The `Stack<U>` column indicates "Y", the top of the `U` stack.
 ///    - The "Result" column indicates the value left on the top of the boolean
 ///      stack.
 ///    - The "Success" column indicates whether the instruction succeeds, and if
@@ -99,13 +99,13 @@ use crate::{
 /// ## `LessThan<T, T>`
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when the `T` stack contains fewer than two items.
 ///
 /// ## `LessThan<T, U>` where T ≠ U
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when either the `T` stack or the `U` stack is empty.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct LessThan<T, U = T> {

--- a/packages/push/src/instruction/common/cmp/less_than_equal.rs
+++ b/packages/push/src/instruction/common/cmp/less_than_equal.rs
@@ -77,8 +77,8 @@ use crate::{
 /// cases where the two values being compared are being taken from _different_
 /// stacks.
 ///
-///    - The "Stack<T>" column indicates "X", the top of the `T` stack.
-///    - The "Stack<U>" column indicates "Y", the top of the `U` stack.
+///    - The `Stack<T>` column indicates "X", the top of the `T` stack.
+///    - The `Stack<U>` column indicates "Y", the top of the `U` stack.
 ///    - The "Result" column indicates the value left on the top of the boolean
 ///      stack.
 ///    - The "Success" column indicates whether the instruction succeeds, and if
@@ -99,13 +99,13 @@ use crate::{
 /// ## `LessThanEqual<T, T>`
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when the `T` stack contains fewer than two items.
 ///
 /// ## `LessThanEqual<T, U>` where T ≠ U
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when either the `T` stack or the `U` stack is empty.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct LessThanEqual<T, U = T> {

--- a/packages/push/src/instruction/common/cmp/less_than_equal.rs
+++ b/packages/push/src/instruction/common/cmp/less_than_equal.rs
@@ -6,32 +6,32 @@ use crate::{
     push_vm::{HasStack, stack::StackError},
 };
 
-/// An instruction that check if one value is greater than another.
+/// An instruction that check if one value is less than or equal to another.
 ///
 /// This instruction works similarly to Rust's [`PartialOrd`].
 ///
-/// `GreaterThan<T>` (which
-/// is just a shorthand for `GreaterThan<T,T>`) compares the top
+/// `LessThanEqual<T>` (which
+/// is just a shorthand for `LessThanEqual<T,T>`) compares the top
 /// two values of `Stack<T>`, pushing the result onto the boolean
-/// stack. The comparison will be `x > y`, where `x` is the top value
+/// stack. The comparison will be `x <= y`, where `x` is the top value
 /// on the stack, and `y` is the second value on the stack.
 ///
-/// If we instead use two different types, like in `GreaterThan<T,U>`, this
-/// can compare across stacks as long as `T: PartialOrd<U>`, comparing T > U
+/// If we instead use two different types, like in `LessThanEqual<T,U>`, this
+/// can compare across stacks as long as `T: PartialOrd<U>`, comparing T <= U
 /// using the top values of the respective stacks. Again the result is pushed
 /// onto the boolean stack.
 ///
 /// # Inputs
 ///
-/// ## `GreaterThan<T, T>`
+/// ## `LessThanEqual<T, T>`
 ///
-/// The `GreaterThan<T, T>` instruction takes the following inputs:
+/// The `LessThanEqual<T, T>` instruction takes the following inputs:
 ///    - `T` stack
 ///      - Two values
 ///
-/// ## `GreaterThan<T, U>`
+/// ## `LessThanEqual<T, U>`
 ///
-/// The `GreaterThan<T, U>` instruction takes the following inputs:
+/// The `LessThanEqual<T, U>` instruction takes the following inputs:
 ///    - `T` stack
 ///       - One value
 ///    - `U` stack
@@ -39,15 +39,15 @@ use crate::{
 ///
 /// # Behavior
 ///
-/// The `GreaterThan` instruction takes top two values from the `T`
+/// The `LessThanEqual` instruction takes top two values from the `T`
 /// stack (`x` from the top and `y` below it), or one from the `T` stack (`x`)
 /// and one from the `U` stack (`y`),
 /// compares those values, and pushes the result onto the boolean
-/// stack (`true` if `x > y`, and `false` otherwise).
+/// stack (`true` if `x <= y`, and `false` otherwise).
 ///
 /// ## Action Table
 ///
-/// ### `GreaterThan<T, T>`
+/// ### `LessThanEqual<T, T>`
 ///
 /// The table below indicates the behavior in each of the different
 /// cases where the two values being compared are being taken from the same
@@ -66,11 +66,11 @@ use crate::{
 ///
 /// | X  | Y | Result | Success | Note |
 /// | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-/// | exists | exists | X = Y | ✅ | The value of X>Y is pushed onto the boolean stack |
+/// | exists | exists | X = Y | ✅ | The value of X<=Y is pushed onto the boolean stack |
 /// | missing | irrelevant | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
 /// | present | missing | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
 ///
-/// ### `GreaterThan<T, U>`, where T ≠ U
+/// ### `LessThanEqual<T, U>`, where T ≠ U
 ///
 ///
 /// The table below indicates the behavior in each of the different
@@ -90,29 +90,29 @@ use crate::{
 ///
 /// | "X": `Stack<T>`  | "Y": `Stack<U>` | Result | Success | Note |
 /// | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-/// | exists | exists | X = Y | ✅ | The value of X>Y is pushed onto the boolean stack |
+/// | exists | exists | X = Y | ✅ | The value of X<=Y is pushed onto the boolean stack |
 /// | missing | irrelevant | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
 /// | present | missing | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
 ///
 /// # Errors
 ///
-/// ## `GreaterThan<T, T>`
+/// ## `LessThanEqual<T, T>`
 ///
 /// Returns a
 /// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
 /// error when the `T` stack contains fewer than two items.
 ///
-/// ## `GreaterThan<T, U>` where T ≠ U
+/// ## `LessThanEqual<T, U>` where T ≠ U
 ///
 /// Returns a
 /// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
 /// error when either the `T` stack or the `U` stack is empty.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
-pub struct GreaterThan<T, U = T> {
+pub struct LessThanEqual<T, U = T> {
     _p: PhantomData<(T, U)>,
 }
 
-impl<S, First, Second> Instruction<S> for GreaterThan<First, Second>
+impl<S, First, Second> Instruction<S> for LessThanEqual<First, Second>
 where
     S: Clone + HasStack<Second> + HasStack<First> + HasStack<bool>,
     First: PartialOrd<Second> + 'static,
@@ -173,7 +173,7 @@ where
             Err(error) => return Err(Error::fatal(state, error)),
         };
 
-        state.with_push(first > second).map_err_into()
+        state.with_push(first <= second).map_err_into()
     }
 }
 
@@ -182,7 +182,7 @@ mod test {
     use proptest::prelude::*;
     use test_strategy::proptest;
 
-    use super::GreaterThan;
+    use super::LessThanEqual;
     use crate::{
         instruction::{Instruction, instruction_error::PushInstructionError},
         push_vm::{HasStack, push_state::PushState, stack::StackError},
@@ -197,9 +197,9 @@ mod test {
             .unwrap()
             .with_no_program()
             .build();
-        let result = GreaterThan::<i64>::default().perform(state).unwrap();
+        let result = LessThanEqual::<i64>::default().perform(state).unwrap();
         assert!(result.stack::<i64>().is_empty());
-        assert_eq!(result.stack::<bool>(), &[false]);
+        assert_eq!(result.stack::<bool>(), &[true]);
     }
 
     #[test]
@@ -211,9 +211,9 @@ mod test {
             .unwrap()
             .with_no_program()
             .build();
-        let result = GreaterThan::<i64>::default().perform(state).unwrap();
+        let result = LessThanEqual::<i64>::default().perform(state).unwrap();
         assert!(result.stack::<i64>().is_empty());
-        assert_eq!(result.stack::<bool>(), &[false]);
+        assert_eq!(result.stack::<bool>(), &[true]);
     }
 
     #[test]
@@ -225,9 +225,9 @@ mod test {
             .unwrap()
             .with_no_program()
             .build();
-        let result = GreaterThan::<i64>::default().perform(state).unwrap();
+        let result = LessThanEqual::<i64>::default().perform(state).unwrap();
         assert!(result.stack::<i64>().is_empty());
-        assert_eq!(result.stack::<bool>(), &[true]);
+        assert_eq!(result.stack::<bool>(), &[false]);
     }
 
     #[test]
@@ -238,7 +238,7 @@ mod test {
             .with_max_stack_size(1)
             .with_no_program()
             .build();
-        let result = GreaterThan::<i64>::default().perform(state).unwrap_err();
+        let result = LessThanEqual::<i64>::default().perform(state).unwrap_err();
         assert!(result.is_recoverable());
         assert_eq!(
             result.error(),
@@ -258,7 +258,7 @@ mod test {
             .unwrap()
             .with_no_program()
             .build();
-        let result = GreaterThan::<i64>::default().perform(state).unwrap_err();
+        let result = LessThanEqual::<i64>::default().perform(state).unwrap_err();
         assert!(result.is_recoverable());
         assert_eq!(
             result.error(),
@@ -281,7 +281,7 @@ mod test {
             .unwrap()
             .with_no_program()
             .build();
-        let result = GreaterThan::<i64>::default().perform(state).unwrap_err();
+        let result = LessThanEqual::<i64>::default().perform(state).unwrap_err();
         assert!(!result.is_recoverable());
         assert_eq!(
             result.error(),
@@ -298,8 +298,8 @@ mod test {
             .unwrap()
             .with_no_program()
             .build();
-        let result = GreaterThan::<i64>::default().perform(state).unwrap();
-        prop_assert_eq!(result.stack::<bool>().top().unwrap(), &(a > b));
+        let result = LessThanEqual::<i64>::default().perform(state).unwrap();
+        prop_assert_eq!(result.stack::<bool>().top().unwrap(), &(a <= b));
         prop_assert_eq!(result.stack::<bool>().size(), 1);
     }
 }

--- a/packages/push/src/instruction/common/cmp/mod.rs
+++ b/packages/push/src/instruction/common/cmp/mod.rs
@@ -1,6 +1,6 @@
 pub mod equal;
 pub mod greater_than;
-// pub mod greater_than_equal;
-// pub mod less_than;
-// pub mod less_than_equal;
+pub mod greater_than_equal;
+pub mod less_than;
+pub mod less_than_equal;
 pub mod not_equal;

--- a/packages/push/src/instruction/common/cmp/mod.rs
+++ b/packages/push/src/instruction/common/cmp/mod.rs
@@ -1,5 +1,5 @@
 pub mod equal;
-// pub mod greater_than;
+pub mod greater_than;
 // pub mod greater_than_equal;
 // pub mod less_than;
 // pub mod less_than_equal;

--- a/packages/push/src/instruction/common/cmp/mod.rs
+++ b/packages/push/src/instruction/common/cmp/mod.rs
@@ -3,4 +3,4 @@ pub mod equal;
 // pub mod greater_than_equal;
 // pub mod less_than;
 // pub mod less_than_equal;
-// pub mod not_equal;
+pub mod not_equal;

--- a/packages/push/src/instruction/common/cmp/mod.rs
+++ b/packages/push/src/instruction/common/cmp/mod.rs
@@ -1,0 +1,6 @@
+pub mod equal;
+// pub mod greater_than;
+// pub mod greater_than_equal;
+// pub mod less_than;
+// pub mod less_than_equal;
+// pub mod not_equal;

--- a/packages/push/src/instruction/common/cmp/not_equal.rs
+++ b/packages/push/src/instruction/common/cmp/not_equal.rs
@@ -74,8 +74,8 @@ use crate::{
 /// cases where the two values being compared are being taken from _different_
 /// stacks.
 ///
-///    - The "Stack<T>" column indicates "X", the top of the `T` stack.
-///    - The "Stack<U>" column indicates "Y", the top of the `U` stack.
+///    - The `Stack<T>` column indicates "X", the top of the `T` stack.
+///    - The `Stack<U>` column indicates "Y", the top of the `U` stack.
 ///    - The "Result" column indicates the value left on the top of the boolean
 ///      stack.
 ///    - The "Success" column indicates whether the instruction succeeds, and if
@@ -96,13 +96,13 @@ use crate::{
 /// ## `NotEqual<T, T>`
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when the `T` stack contains fewer than two items.
 ///
 /// ## `NotEqual<T, U>` where T ≠ U
 ///
 /// Returns a
-/// [`StackError::Underflow`](crate::push_vm::stack::StackError::Underflow)
+/// [`StackError::Underflow`]
 /// error when either the `T` stack or the `U` stack is empty.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct NotEqual<T, U = T> {

--- a/packages/push/src/instruction/common/cmp/not_equal.rs
+++ b/packages/push/src/instruction/common/cmp/not_equal.rs
@@ -186,7 +186,7 @@ mod test {
     };
 
     #[test]
-    fn not_equal_same_stack_equal() {
+    fn equal() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(2)
@@ -200,7 +200,7 @@ mod test {
     }
 
     #[test]
-    fn not_equal_same_stack_not_equal() {
+    fn not_equal() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(2)
@@ -214,7 +214,7 @@ mod test {
     }
 
     #[test]
-    fn not_equal_same_stack_empty_stack() {
+    fn empty_stack() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             // This has to be 1 to ensure that there's room on the bool stack for the result.
@@ -233,7 +233,7 @@ mod test {
     }
 
     #[test]
-    fn not_equal_same_stack_singleton_stack() {
+    fn singleton_stack() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(1)
@@ -253,7 +253,7 @@ mod test {
     }
 
     #[test]
-    fn not_equal_bool_stack_overflow() {
+    fn bool_stack_overflow() {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(2)
@@ -273,7 +273,7 @@ mod test {
     }
 
     #[proptest]
-    fn not_equal_proptest_same_stack(a: i64, b: i64) {
+    fn not_equal_proptest(a: i64, b: i64) {
         let state = PushState::builder()
             .with_instruction_step_limit(1)
             .with_max_stack_size(2)

--- a/packages/push/src/instruction/common/cmp/not_equal.rs
+++ b/packages/push/src/instruction/common/cmp/not_equal.rs
@@ -176,7 +176,6 @@ where
 
 #[cfg(test)]
 mod test {
-    use ordered_float::OrderedFloat;
     use proptest::prelude::*;
     use test_strategy::proptest;
 
@@ -189,6 +188,7 @@ mod test {
     #[test]
     fn not_equal_same_stack_equal() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(2)
             .with_int_values([5, 5])
             .unwrap()
@@ -202,6 +202,7 @@ mod test {
     #[test]
     fn not_equal_same_stack_not_equal() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(2)
             .with_int_values([5, 10])
             .unwrap()
@@ -212,43 +213,10 @@ mod test {
         assert_eq!(result.stack::<bool>(), &[true]);
     }
 
-    // #[test]
-    // fn not_equal_different_stacks_equal() {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(1)
-    //         .with_int_values([5])
-    //         .unwrap()
-    //         .with_float_values([OrderedFloat(5.0)])
-    //         .unwrap()
-    //         .with_no_program()
-    //         .build();
-    //     let result = NotEqual::<i64, OrderedFloat<f64>>::default()
-    //         .perform(state)
-    //         .unwrap();
-    //     assert_eq!(result.stack::<bool>().top().unwrap(), &false);
-    //     assert_eq!(result.stack::<bool>().size(), 1);
-    // }
-
-    // #[test]
-    // fn not_equal_different_stacks_not_equal() {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(1)
-    //         .with_int_values([5])
-    //         .unwrap()
-    //         .with_float_values([OrderedFloat(10.0)])
-    //         .unwrap()
-    //         .with_no_program()
-    //         .build();
-    //     let result = NotEqual::<i64, OrderedFloat<f64>>::default()
-    //         .perform(state)
-    //         .unwrap();
-    //     assert_eq!(result.stack::<bool>().top().unwrap(), &true);
-    //     assert_eq!(result.stack::<bool>().size(), 1);
-    // }
-
     #[test]
-    fn not_equal_same_stack_underflow() {
+    fn not_equal_same_stack_empty_stack() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             // This has to be 1 to ensure that there's room on the bool stack for the result.
             .with_max_stack_size(1)
             .with_no_program()
@@ -265,8 +233,9 @@ mod test {
     }
 
     #[test]
-    fn not_equal_same_stack_underflow_one() {
+    fn not_equal_same_stack_singleton_stack() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(1)
             .with_int_values([5])
             .unwrap()
@@ -283,52 +252,10 @@ mod test {
         );
     }
 
-    // #[test]
-    // fn not_equal_different_stacks_underflow_first() {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(0)
-    //         .with_float_values([OrderedFloat(10.0)])
-    //         .unwrap()
-    //         .with_no_program()
-    //         .build();
-    //     let result = NotEqual::<i64, OrderedFloat<f64>>::default()
-    //         .perform(state)
-    //         .unwrap_err();
-    //     assert!(result.is_recoverable());
-    //     assert_eq!(
-    //         result.error(),
-    //         &PushInstructionError::StackError(StackError::Underflow {
-    //             num_requested: 1,
-    //             num_present: 0
-    //         })
-    //     );
-    // }
-
-    // #[test]
-    // fn not_equal_different_stacks_underflow_second() {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(1)
-    //         .with_int_values([5])
-    //         .unwrap()
-    //         .with_max_stack_size(0)
-    //         .with_no_program()
-    //         .build();
-    //     let result = NotEqual::<i64, OrderedFloat<f64>>::default()
-    //         .perform(state)
-    //         .unwrap_err();
-    //     assert!(result.is_recoverable());
-    //     assert_eq!(
-    //         result.error(),
-    //         &PushInstructionError::StackError(StackError::Underflow {
-    //             num_requested: 1,
-    //             num_present: 0
-    //         })
-    //     );
-    // }
-
     #[test]
     fn not_equal_bool_stack_overflow() {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(2)
             .with_int_values([5, 5])
             .unwrap()
@@ -348,6 +275,7 @@ mod test {
     #[proptest]
     fn not_equal_proptest_same_stack(a: i64, b: i64) {
         let state = PushState::builder()
+            .with_instruction_step_limit(1)
             .with_max_stack_size(2)
             .with_int_values([a, b])
             .unwrap()
@@ -357,21 +285,4 @@ mod test {
         prop_assert_eq!(result.stack::<bool>().top().unwrap(), &(a != b));
         prop_assert_eq!(result.stack::<bool>().size(), 1);
     }
-
-    // #[proptest]
-    // fn not_equal_proptest_different_stacks(a: i64, b: f64) {
-    //     let state = PushState::builder()
-    //         .with_max_stack_size(1)
-    //         .with_int_values([a])
-    //         .unwrap()
-    //         .with_float_values([OrderedFloat(b)])
-    //         .unwrap()
-    //         .with_no_program()
-    //         .build();
-    //     let result = NotEqual::<i64, OrderedFloat<f64>>::default()
-    //         .perform(state)
-    //         .unwrap();
-    //     prop_assert_eq!(result.stack::<bool>().top().unwrap(), &(a as f64 !=
-    // b));     prop_assert_eq!(result.stack::<bool>().size(), 1);
-    // }
 }

--- a/packages/push/src/instruction/common/mod.rs
+++ b/packages/push/src/instruction/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod cmp;
 pub mod dup;
 pub mod flush;
 pub mod is_empty;

--- a/packages/push/src/instruction/int/clamp.rs
+++ b/packages/push/src/instruction/int/clamp.rs
@@ -33,9 +33,12 @@ use crate::{
 /// The table below indicates the behavior in each of the different
 /// cases.
 ///
-///    - The "Value" column indicates the value being clamped.
-///    - The "Min" column indicates the minimum value of the range.
-///    - The "Max" column indicates the maximum value of the range.
+///    - The "Value" column indicates the value being clamped, and is the top of
+///      the `i64` stack.
+///    - The "Min" column indicates the minimum value of the range and is the
+///      second value on the `i64` stack.
+///    - The "Max" column indicates the maximum value of the range and is the
+///      third value on the `i64` stack.
 ///    - The "Result" column indicates the value left on the top of the stack.
 ///    - The "Success" column indicates whether the instruction succeeds, and if
 ///      not what kind of error is returned:
@@ -49,7 +52,9 @@ use crate::{
 /// | Less than Min | exists | exists | Min | ✅ | Value is replaced by Min |
 /// | Greater than Max | exists | exists | Max | ✅ | Value is replaced by Max |
 /// | In range [Min, Max] | exists | exists | Value | ✅ | Value remains unchanged |
-/// | missing | irrelevant | irrelevant | irrelevant| [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+/// | missing | irrelevant | irrelevant | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+/// | present | missing | irrelevant | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
+/// | present | present | missing | irrelevant | [❗…](crate::push_vm::stack::StackError::Underflow) | State is unchanged |
 ///
 /// # Errors
 ///


### PR DESCRIPTION
This implements an `Equal` and `NotEqual` instructions on stacks with types that implement `Equal`, and all the standard comparison operators (`LessThan`, `LessThanEquals`, etc.) on stacks with types that implement `Ord`.

This is satisfying part of #350.