### PR TITLE
Further align our `Umad` implementation with the UMAD paper

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "doctest",
         "doctests",
         "esitsu",
+        "Freitag",
         "GECCO",
         "genericize",
         "Goues",

--- a/clippy.toml
+++ b/clippy.toml
@@ -17,3 +17,4 @@ allowed-duplicate-crates = [
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 allow-panic-in-tests = true
+doc-valid-idents = ["McPhee", ".."]

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -96,6 +96,7 @@ use crate::genome::Linear;
 ///   Proceedings of the Genetic and Evolutionary Computation Conference
 ///   (GECCO '18). Association for Computing Machinery, New York, NY, USA,
 ///   1127–1134. <https://doi.org/10.1145/3205455.3205603>
+#[must_use]
 pub struct Umad<GeneGenerator> {
     /// The likelihood of adding a new gene next to each gene in the original
     /// genome

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -50,7 +50,7 @@ impl<GeneGenerator> Umad<GeneGenerator> {
         Self::new(addition_rate, deletion_rate, gene_generator)
     }
 
-    pub const fn new_with_empty_rate(
+    pub const fn new_with_empty_addition_rate(
         addition_rate: f64,
         empty_addition_rate: f64,
         deletion_rate: f64,
@@ -64,7 +64,7 @@ impl<GeneGenerator> Umad<GeneGenerator> {
         }
     }
 
-    pub const fn new_without_empty(
+    pub const fn new_without_empty_addition_rate(
         addition_rate: f64,
         deletion_rate: f64,
         gene_generator: GeneGenerator,

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -114,13 +114,41 @@ pub struct Umad<GeneGenerator> {
 }
 
 impl<GeneGenerator> Umad<GeneGenerator> {
-    /// Construct an instance of `Umad` with empty addition rate the same as
-    /// addition rate.
-    pub const fn new(
-        addition_rate: f64,
-        deletion_rate: f64,
-        gene_generator: GeneGenerator,
-    ) -> Self {
+    /// Construct an instance of `Umad` with the empty addition rate set to be
+    /// the same as the addition rate.
+    ///
+    /// # Panics
+    ///
+    /// This panics if either the `addition_rate` or the `deletion_rate` isn't a
+    /// legal probability value (i.e., in range 0..=1).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use ec_core::operator::mutator::Mutator;
+    /// # use ec_linear::mutator::umad::Umad;
+    /// #
+    /// let addition_rate = 0.25;
+    /// let deletion_rate = 0.2;
+    /// let umad = Umad::new(addition_rate, deletion_rate, ());
+    ///
+    /// assert_eq!(
+    ///     umad.empty_addition_rate(),
+    ///     Some(addition_rate),
+    ///     "Expected the `new` constructor to set the default empty addition rate to be the same as \
+    ///      the given addition rate",
+    /// );
+    /// ```
+    pub fn new(addition_rate: f64, deletion_rate: f64, gene_generator: GeneGenerator) -> Self {
+        assert!(
+            matches!(addition_rate, 0.0..=1.0),
+            "`addition_rate` must be between 0.0 and 1.0 inclusive, but was {addition_rate}"
+        );
+        assert!(
+            matches!(deletion_rate, 0.0..=1.0),
+            "`deletion_rate` must be between 0.0 and 1.0 inclusive, but was {deletion_rate}"
+        );
+
         Self {
             addition_rate,
             deletion_rate,

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -503,8 +503,8 @@ mod test {
         // A parent with an empty genome
         let parent = Vector { genes: Vec::new() };
 
-        // Since we don't add genes to empty genomes, this should still be an empty
-        // genome
+        // With an empty_addition_rate of 1.0, a new gene should always be added to an
+        // empty genome.
         let Ok(child) = umad.mutate(parent, &mut rng);
         assert_eq!(child.genes, ['x']);
     }

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -184,6 +184,30 @@ impl<GeneGenerator> Umad<GeneGenerator> {
     {
         self.gene_generator.sample(rng)
     }
+
+    /// The probability (in the range 0..=1) of adding a new gene next to each
+    /// gene in the original genome
+    #[must_use]
+    pub const fn addition_rate(&self) -> f64 {
+        self.addition_rate
+    }
+
+    /// The probability (in the range 0..=1) of deleting each gene in the
+    /// genome, including newly added genes
+    #[must_use]
+    pub const fn deletion_rate(&self) -> f64 {
+        self.deletion_rate
+    }
+
+    /// The probability (in the range 0..=1) of adding a single new gene when
+    /// the initial genome is empty.
+    ///
+    /// This is optional, and if its value is
+    /// `None` then new genes will never be added to empty genomes.
+    #[must_use]
+    pub const fn empty_addition_rate(&self) -> Option<f64> {
+        self.empty_addition_rate
+    }
 }
 
 impl<G, GeneGenerator> Mutator<G> for Umad<GeneGenerator>

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -157,13 +157,17 @@ impl<GeneGenerator> Umad<GeneGenerator> {
         }
     }
 
-    /// Construct `Umad` with "balanced" deletion rate derived from addition
-    /// rate
+    /// Construct `Umad` with a "balanced" deletion rate derived from the
+    /// addition rate
     ///
-    /// If the deletion rate is set to `addition_rate / (1 + addition_rate)`
-    /// then on average the child genome will have the same length as the
-    /// parent genome. This constructor just takes an `addition_rate`
-    /// and computes the balanced deletion rate.
+    /// This constructor just takes an `addition_rate`
+    /// and computes a "balanced" deletion rate that ensures that on average
+    /// child genomes will have the same length as their parent genomes.
+    /// This is accomplished by setting the deletion rate to
+    /// `addition_rate / (1 + addition_rate)`.
+    ///
+    /// For more information see [the Balance section in the main `Umad`
+    /// docs](Umad#balance).
     ///
     /// # Panics
     ///

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -141,6 +141,23 @@ impl<GeneGenerator> Umad<GeneGenerator> {
     ///
     /// This panics if the `addition_rate` isn't a legal probability value
     /// (i.e., in range 0..=1).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use ec_core::operator::mutator::Mutator;
+    /// # use ec_linear::mutator::umad::Umad;
+    /// #
+    /// let addition_rate = 0.25;
+    /// let expected_deletion_rate = addition_rate / (1.0 + addition_rate);
+    /// let umad = Umad::new_with_balanced_deletion(addition_rate, ());
+    ///
+    /// assert!(
+    ///     (umad.deletion_rate() - expected_deletion_rate).abs() < f64::EPSILON,
+    ///     "Expected deletion rate {expected_deletion_rate} but got deletion rate {}",
+    ///     umad.deletion_rate()
+    /// );
+    /// ```
     pub fn new_with_balanced_deletion(addition_rate: f64, gene_generator: GeneGenerator) -> Self {
         assert!(
             matches!(addition_rate, 0.0..=1.0),
@@ -150,12 +167,52 @@ impl<GeneGenerator> Umad<GeneGenerator> {
         Self::new(addition_rate, deletion_rate, gene_generator)
     }
 
-    pub const fn new_with_empty_addition_rate(
+    /// Construct `Umad` with a given empty addition rate
+    ///
+    /// # Panics
+    ///
+    /// This panics if any of the `addition_rate`, `empty_addition_rate`, or
+    /// `deletion_rate` isn't a legal probability value (i.e., in range
+    /// 0..=1).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use ec_linear::mutator::umad::Umad;
+    /// #
+    /// let addition_rate = 0.25;
+    /// let empty_addition_rate = 0.1;
+    /// let deletion_rate = 0.2;
+    /// let umad =
+    ///     Umad::new_with_empty_addition_rate(addition_rate, empty_addition_rate, deletion_rate, ());
+    ///
+    /// assert_eq!(
+    ///     umad.empty_addition_rate(),
+    ///     Some(empty_addition_rate),
+    ///     "Expected the given empty addition rate since we used the new_with_empty_addition_rate() \
+    ///      constructor"
+    /// );
+    /// ```
+    pub fn new_with_empty_addition_rate(
         addition_rate: f64,
         empty_addition_rate: f64,
         deletion_rate: f64,
         gene_generator: GeneGenerator,
     ) -> Self {
+        assert!(
+            matches!(addition_rate, 0.0..=1.0),
+            "`addition_rate` must be between 0.0 and 1.0 inclusive, but was {addition_rate}"
+        );
+        assert!(
+            matches!(empty_addition_rate, 0.0..=1.0),
+            "`empty_addition_rate` must be between 0.0 and 1.0 inclusive, but was \
+             {empty_addition_rate}"
+        );
+        assert!(
+            matches!(deletion_rate, 0.0..=1.0),
+            "`deletion_rate` must be between 0.0 and 1.0 inclusive, but was {deletion_rate}"
+        );
+
         Self {
             addition_rate,
             deletion_rate,
@@ -164,11 +221,43 @@ impl<GeneGenerator> Umad<GeneGenerator> {
         }
     }
 
-    pub const fn new_without_empty_addition_rate(
+    /// Construct `Umad` without an empty addition rate
+    ///
+    /// # Panics
+    ///
+    /// This panics if any of the `addition_rate` or
+    /// `deletion_rate` isn't a legal probability value (i.e., in range
+    /// 0..=1).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use ec_linear::mutator::umad::Umad;
+    /// #
+    /// let addition_rate = 0.25;
+    /// let deletion_rate = 0.2;
+    /// let umad = Umad::new_without_empty_addition_rate(addition_rate, deletion_rate, ());
+    ///
+    /// assert!(
+    ///     umad.empty_addition_rate().is_none(),
+    ///     "Expected an empty addition rate since we used the new_without_empty_addition_rate() \
+    ///      constructor"
+    /// );
+    /// ```
+    pub fn new_without_empty_addition_rate(
         addition_rate: f64,
         deletion_rate: f64,
         gene_generator: GeneGenerator,
     ) -> Self {
+        assert!(
+            matches!(addition_rate, 0.0..=1.0),
+            "`addition_rate` must be between 0.0 and 1.0 inclusive, but was {addition_rate}"
+        );
+        assert!(
+            matches!(deletion_rate, 0.0..=1.0),
+            "`deletion_rate` must be between 0.0 and 1.0 inclusive, but was {deletion_rate}"
+        );
+
         Self {
             addition_rate,
             deletion_rate,
@@ -177,6 +266,7 @@ impl<GeneGenerator> Umad<GeneGenerator> {
         }
     }
 
+    #[must_use]
     fn new_gene<G, R>(&self, rng: &mut R) -> G::Gene
     where
         G: Genome,

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -5,17 +5,116 @@ use rand::{Rng, prelude::Distribution};
 
 use crate::genome::Linear;
 
-/// UMAD = Uniform Mutation through random Addition and Deletion
+/// The UMAD mutation operator as described in
+/// [the paper by T. Helmuth et al.](https://doi.org/10.1145/3205455.3205603)[^paper-ref]
+///
+/// The UMAD (Uniform Mutation by Addition and Deletion) operator acts
+/// on variable length linear genomes, inserting new genes and deleting existing
+/// genes in a random fashion.
+///
+/// New genes are generated using a user-provided `GeneGenerator`.
+///
+/// # Behavior
+///
+/// For each gene in the initial genome, a decision is made about
+///
+/// - Whether to keep or delete that gene, and
+/// - Whether to insert a new gene, either to the existing gene's left or right.
+///
+/// Note that this can change the length of the genome, with the child
+/// potentially being shorter or longer than the parent.
+///
+/// ## Parameters
+///
+/// There are several parameters which can be used to tune the mutation
+/// operator:
+///
+/// - The addition rate, i.e., the likelihood of adding a new gene next to each
+///   of the existing genes
+/// - The deletion rate, i.e., the likelihood of deleting each gene in the
+///   genome, including newly added genes
+/// - The empty addition rate, i.e., the likelihood of adding a new gene when
+///   the initial genome is empty. This is optional, and if it is not provided
+///   then new genes will never be added to empty genomes. See below for further
+///   discussion of this feature.
+///
+/// ## Balance
+///
+/// If the addition rate is much higher than the
+/// deletion rate then the new genome is likely to be considerably
+/// longer than the original genome. Similarly, if the deletion rate
+/// is much higher than the addition rate then the genome is likely
+/// to shrink.
+///
+/// If the deletion rate is set to `addition_rate / (1 + addition_rate)`,
+/// then the expected length of the new child genome is the same as that of the
+/// initial parent genome. The [`Umad::new_with_balanced_deletion`] constructor
+/// sets the deletion rate according to this formula.
+///
+/// ## Differences from published UMAD definition
+///
+/// The one difference between this implementation and the published definition
+/// is that we support the addition of a randomly generated gene if the initial
+/// genome is empty. In the published definition, an empty genome would remain
+/// empty. The likelihood of adding a gene to an empty genome is set by the
+/// `empty_addition_rate` parameter; setting this to `None` will effectively
+/// disable this feature, behaving the same as the published definition.
+///
+/// # Example
+///
+/// In this example we create an instance of `Umad` using [`Umad::new`] that
+/// mutates vectors of characters.
+///
+/// ```
+/// # use ec_core::{operator::mutator::Mutator, uniform_distribution_of};
+/// # use ec_linear::{genome::vector::Vector, mutator::umad::Umad};
+/// #
+/// // Use a 30% chance of inserting a gene at each location.
+/// let addition_rate = 0.3;
+/// // Use a 30% chance of deleting each gene.
+/// let deletion_rate = 0.3;
+/// // This is our `GeneGenerator`, which will always just produce
+/// // a character `x`.
+/// let gene_generator = uniform_distribution_of!['x'];
+///
+/// // Create an instance of `Umad` using these parameters.
+/// let umad = Umad::new(addition_rate, deletion_rate, gene_generator);
+///
+/// // Create a `Vec` of characters to use as a parent genome.
+/// let parent_chars = "Mutate first, ask questions later.".chars().collect();
+/// // Create a parent genome
+/// let parent_genome = Vector {
+///     genes: parent_chars,
+/// };
+///
+/// // Mutate the parent genome to create a child genome
+/// let child_genome = umad.mutate(parent_genome, &mut rand::rng()).unwrap();
+/// ```
+///
+/// [^paper-ref]: Thomas Helmuth, Nicholas Freitag McPhee, and Lee Spector. 2018.
+///   Program synthesis using uniform mutation by addition and deletion. In
+///   Proceedings of the Genetic and Evolutionary Computation Conference
+///   (GECCO '18). Association for Computing Machinery, New York, NY, USA,
+///   1127–1134. <https://doi.org/10.1145/3205455.3205603>
 pub struct Umad<GeneGenerator> {
+    /// The likelihood of adding a new gene next to each gene in the original
+    /// genome
     addition_rate: f64,
+    /// The likelihood of deleting each gene in the genome, including newly
+    /// added genes
     deletion_rate: f64,
+    /// The likelihood of adding a single new gene when the initial genome is
+    /// empty. This is optional, and if its value is `None` then new genes
+    /// will never be added to empty genomes.
     empty_addition_rate: Option<f64>,
-    // Provides the generator needed to generate a new, random gene
-    // during the addition phase.
+    /// The generator used to generate new, random genes
+    /// during the addition phase.
     gene_generator: GeneGenerator,
 }
 
 impl<GeneGenerator> Umad<GeneGenerator> {
+    /// Construct an instance of `Umad` with empty addition rate the same as
+    /// addition rate.
     pub const fn new(
         addition_rate: f64,
         deletion_rate: f64,
@@ -32,7 +131,7 @@ impl<GeneGenerator> Umad<GeneGenerator> {
     /// Construct `Umad` with "balanced" deletion rate derived from addition
     /// rate
     ///
-    /// If the deletion rate is set to `addition_rate` / (1 + `addition_rate`)
+    /// If the deletion rate is set to `addition_rate / (1 + addition_rate)`
     /// then on average the child genome will have the same length as the
     /// parent genome. This constructor just takes an `addition_rate`
     /// and computes the balanced deletion rate.

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -355,4 +355,34 @@ mod test {
             umad.deletion_rate
         );
     }
+
+    #[test]
+    fn test_no_empty_addition_rate() {
+        let mut rng = rng();
+        // This generates "genes" that are always the character 'x'.
+        let char_options = uniform_distribution_of!['x'];
+        let umad = Umad::new_without_empty_addition_rate(0.1, 0.1, char_options);
+        // A parent with an empty genome
+        let parent = Vector { genes: Vec::new() };
+
+        // Since we don't add genes to empty genomes, this should still be an empty
+        // genome
+        let Ok(child) = umad.mutate(parent, &mut rng);
+        assert!(child.genes.is_empty());
+    }
+
+    #[test]
+    fn test_always_add_to_empty_genome() {
+        let mut rng = rng();
+        // This generates "genes" that are always the character 'x'.
+        let char_options = uniform_distribution_of!['x'];
+        let umad = Umad::new_with_empty_addition_rate(0.1, 1.0, 0.1, char_options);
+        // A parent with an empty genome
+        let parent = Vector { genes: Vec::new() };
+
+        // Since we don't add genes to empty genomes, this should still be an empty
+        // genome
+        let Ok(child) = umad.mutate(parent, &mut rng);
+        assert_eq!(child.genes, ['x']);
+    }
 }

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -122,7 +122,14 @@ where
                     _ => None,
                 };
 
-                [old_gene, new_gene]
+                // This randomly decides with a 50/50 probability which side of the old gene
+                // to place the new gene. This provides consistency with the definition of UMAD
+                // in Helmuth et al, lines 6-10 of Algorithm 1.
+                if rng.random::<bool>() {
+                    [old_gene, new_gene]
+                } else {
+                    [new_gene, old_gene]
+                }
             })
             .flatten()
             .collect::<G>())


### PR DESCRIPTION
[The original UMAD paper](https://doi.org/10.1145/3205455.3205603) randomly decides whether to put a newly added gene on the left or right side of the current gene. We didn't actually provide that functionality, and this fixes that.

Hopefully our UMAD implementation now matches (or can match with the correct parameters) the published definition.

While we were here, we also added documentation and examples for `Umad`.