### PR TITLE
Add bacon config to simplify doc writing and updating

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -21,6 +21,8 @@ command = [
 ]
 on_success = "job:doc-watch"
 need_stdout = false
+allow_failures = true
+allow_warnings = true
 
 [jobs.private-doc-watch]
 command = [
@@ -43,6 +45,8 @@ command = [
 ]
 on_success = "job:private-doc-watch"
 need_stdout = false
+allow_failures = true
+allow_warnings = true
 
 [jobs.clippy]
 command = ["cargo", "clippy"]


### PR DESCRIPTION
This adds a `doc` and `private-doc` job to bacon which will automatically run cargo doc and open the docs, then switch to a `*-watch` task and update the docs as they are changed.

The keybinds `d` (and `alt-d` for private)  are also provided within bacon.

The difference between the `private-*` version and non-private version of the doc job is whether  they include the `--document-private-items` flag, the private job does, the non-private one doesn't.