### PR TITLE
Clean up bitstring impl of crossover

### DIFF
--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -7,10 +7,7 @@ use ec_core::{
 use rand::{Rng, distr::StandardUniform, prelude::Distribution};
 
 use super::Linear;
-use crate::recombinator::{
-    crossover::{Crossover, try_get_mut},
-    errors::MultipleGeneAccess,
-};
+use crate::recombinator::{crossover::Crossover, errors::MultipleGeneAccess};
 
 // TODO: Ought to have `LinearGenome<T>` so that `Bitstring` is just
 //   `LinearGenome<bool>`.
@@ -145,10 +142,9 @@ impl Crossover for Bitstring {
         other: &mut Self,
         index: usize,
     ) -> Result<(), Self::GeneCrossoverError> {
-        let (lhs, rhs) = try_get_mut(&mut self.bits, &mut other.bits, index)?;
-
-        std::mem::swap(lhs, rhs);
-        Ok(())
+        self.bits
+            .crossover_gene(&mut other.bits, index)
+            .map_err(MultipleGeneAccess::for_genome_type)
     }
 
     type SegmentCrossoverError = MultipleGeneAccess<Range<usize>, Self>;
@@ -158,8 +154,8 @@ impl Crossover for Bitstring {
         other: &mut Self,
         range: Range<usize>,
     ) -> Result<(), Self::SegmentCrossoverError> {
-        let (lhs, rhs) = try_get_mut(&mut self.bits, &mut other.bits, range)?;
-        lhs.swap_with_slice(rhs);
-        Ok(())
+        self.bits
+            .crossover_segment(&mut other.bits, range)
+            .map_err(MultipleGeneAccess::for_genome_type)
     }
 }

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -181,23 +181,6 @@ impl Crossover for Bitstring {
     ) -> Result<(), Self::GeneCrossoverError> {
         let (lhs, rhs) = try_get_mut(&mut self.bits, &mut other.bits, index)?;
 
-        // let Some(lhs) = self.gene_mut(index) else {
-        //     return Err(MultipleGeneAccess::Lhs(GeneAccess::new(index, self.size())));
-        // };
-        // let Some(rhs) = other.gene_mut(index) else {
-        //     return Err(MultipleGeneAccess::Rhs(GeneAccess::new(
-        //         index,
-        //         other.size(),
-        //     )));
-        // };
-        // let Some(rhs) = other.gene_mut(index) else {
-        //     return Err(GeneAccess {
-        //         index,
-        //         bitstring_size: other.size(),
-        //         error_source: ErrorSource::Rhs,
-        //     });
-        // };
-
         std::mem::swap(lhs, rhs);
         Ok(())
     }

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -135,7 +135,7 @@ impl Linear for Bitstring {
 }
 
 impl Crossover for Bitstring {
-    type GeneCrossoverError = MultipleGeneAccess<usize, Self>;
+    type GeneCrossoverError = MultipleGeneAccess<usize>;
 
     fn crossover_gene(
         &mut self,
@@ -144,10 +144,10 @@ impl Crossover for Bitstring {
     ) -> Result<(), Self::GeneCrossoverError> {
         self.bits
             .crossover_gene(&mut other.bits, index)
-            .map_err(MultipleGeneAccess::for_genome_type)
+            .map_err(MultipleGeneAccess::for_genome_type::<Self>)
     }
 
-    type SegmentCrossoverError = MultipleGeneAccess<Range<usize>, Self>;
+    type SegmentCrossoverError = MultipleGeneAccess<Range<usize>>;
 
     fn crossover_segment(
         &mut self,
@@ -156,6 +156,6 @@ impl Crossover for Bitstring {
     ) -> Result<(), Self::SegmentCrossoverError> {
         self.bits
             .crossover_segment(&mut other.bits, range)
-            .map_err(MultipleGeneAccess::for_genome_type)
+            .map_err(MultipleGeneAccess::for_genome_type::<Self>)
     }
 }

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -159,3 +159,60 @@ impl Crossover for Bitstring {
             .map_err(MultipleGeneAccess::for_genome_type::<Self>)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        genome::bitstring::Bitstring,
+        recombinator::{crossover::Crossover, errors::MultipleGeneAccess},
+    };
+
+    #[test]
+    fn gene_access_error_both() {
+        let mut rng = rand::rng();
+        let size = 20;
+        let mut first = Bitstring::random(size, &mut rng);
+        let mut second = Bitstring::random(size, &mut rng);
+        let MultipleGeneAccess::Both { lhs, rhs } =
+            first.crossover_gene(&mut second, size).unwrap_err()
+        else {
+            panic!("Didn't get `MultipleGeneAccess::Both` as expected");
+        };
+        assert_eq!(lhs.index, size);
+        assert_eq!(lhs.size, size);
+        assert_eq!(rhs.index, size);
+        assert_eq!(rhs.size, size);
+    }
+
+    #[test]
+    fn gene_access_error_lhs() {
+        let mut rng = rand::rng();
+        let first_size = 20;
+        let second_size = 30;
+        let mut first = Bitstring::random(first_size, &mut rng);
+        let mut second = Bitstring::random(second_size, &mut rng);
+        let MultipleGeneAccess::Lhs(lhs) =
+            first.crossover_gene(&mut second, first_size).unwrap_err()
+        else {
+            panic!("Didn't get `MultipleGeneAccess::Lhs` as expected");
+        };
+        assert_eq!(lhs.index, first_size);
+        assert_eq!(lhs.size, first_size);
+    }
+
+    #[test]
+    fn gene_access_error_rhs() {
+        let mut rng = rand::rng();
+        let first_size = 30;
+        let second_size = 20;
+        let mut first = Bitstring::random(first_size, &mut rng);
+        let mut second = Bitstring::random(second_size, &mut rng);
+        let MultipleGeneAccess::Rhs(rhs) =
+            first.crossover_gene(&mut second, second_size).unwrap_err()
+        else {
+            panic!("Didn't get `MultipleGeneAccess::Rhs` as expected");
+        };
+        assert_eq!(rhs.index, second_size);
+        assert_eq!(rhs.size, second_size);
+    }
+}

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -243,19 +243,18 @@ mod tests {
         let mut first = Bitstring::from_iter(vec![false; size]);
         let mut second = Bitstring::from_iter(vec![false; size]);
 
-        let MultipleGeneAccess::Both { lhs, rhs } =
-            first.crossover_gene(&mut second, size).unwrap_err()
-        else {
-            panic!("Didn't get `MultipleGeneAccess::Both` as expected");
-        };
+        let err = first.crossover_gene(&mut second, size).unwrap_err();
+        if let MultipleGeneAccess::Both { lhs, rhs } = err {
+            assert_eq!(lhs.index, size);
+            assert_eq!(lhs.size, size);
+            assert!(format!("{lhs}").contains("Bitstring"));
 
-        assert_eq!(lhs.index, size);
-        assert_eq!(lhs.size, size);
-        assert!(format!("{lhs}").contains("Bitstring"));
-
-        assert_eq!(rhs.index, size);
-        assert_eq!(rhs.size, size);
-        assert!(format!("{rhs}").contains("Bitstring"));
+            assert_eq!(rhs.index, size);
+            assert_eq!(rhs.size, size);
+            assert!(format!("{rhs}").contains("Bitstring"));
+        } else {
+            panic!("Expected `MultipleGeneAccess::Both`, got {err:?}");
+        }
     }
 
     #[test]
@@ -265,15 +264,14 @@ mod tests {
         let mut first = Bitstring::from_iter(vec![false; first_size]);
         let mut second = Bitstring::from_iter(vec![false; second_size]);
 
-        let MultipleGeneAccess::Lhs(lhs) =
-            first.crossover_gene(&mut second, first_size).unwrap_err()
-        else {
-            panic!("Didn't get `MultipleGeneAccess::Lhs` as expected");
-        };
-
-        assert_eq!(lhs.index, first_size);
-        assert_eq!(lhs.size, first_size);
-        assert!(format!("{lhs}").contains("Bitstring"));
+        let err = first.crossover_gene(&mut second, first_size).unwrap_err();
+        if let MultipleGeneAccess::Lhs(lhs) = err {
+            assert_eq!(lhs.index, first_size);
+            assert_eq!(lhs.size, first_size);
+            assert!(format!("{lhs}").contains("Bitstring"));
+        } else {
+            panic!("Expected `MultipleGeneAccess::Lhs`, got {err:?}");
+        }
     }
 
     #[test]
@@ -283,15 +281,14 @@ mod tests {
         let mut first = Bitstring::from_iter(vec![false; first_size]);
         let mut second = Bitstring::from_iter(vec![false; second_size]);
 
-        let MultipleGeneAccess::Rhs(rhs) =
-            first.crossover_gene(&mut second, second_size).unwrap_err()
-        else {
-            panic!("Didn't get `MultipleGeneAccess::Rhs` as expected");
-        };
-
-        assert_eq!(rhs.index, second_size);
-        assert_eq!(rhs.size, second_size);
-        assert!(format!("{rhs}").contains("Bitstring"));
+        let err = first.crossover_gene(&mut second, second_size).unwrap_err();
+        if let MultipleGeneAccess::Rhs(rhs) = err {
+            assert_eq!(rhs.index, second_size);
+            assert_eq!(rhs.size, second_size);
+            assert!(format!("{rhs}").contains("Bitstring"));
+        } else {
+            panic!("Expected `MultipleGeneAccess::Rhs`, got {err:?}");
+        }
     }
 
     #[test]

--- a/packages/ec-linear/src/recombinator/crossover.rs
+++ b/packages/ec-linear/src/recombinator/crossover.rs
@@ -82,3 +82,154 @@ impl<T: 'static> Crossover for Vec<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recombinator::errors::MultipleGeneAccess;
+
+    // --- crossover_gene ---
+
+    #[test]
+    fn crossover_gene_success() {
+        let mut v1 = vec![1, 2, 3, 4, 5];
+        let mut v2 = vec![6, 7, 8, 9, 10];
+        let original_v1 = v1.clone();
+        let original_v2 = v2.clone();
+
+        let result = v1.crossover_gene(&mut v2, 2);
+
+        assert!(result.is_ok());
+        assert_eq!(v1[2], original_v2[2]); // 8
+        assert_eq!(v2[2], original_v1[2]); // 3
+
+        // Check that other elements are untouched
+        assert_eq!(&v1[0..2], &original_v1[0..2]);
+        assert_eq!(&v1[3..], &original_v1[3..]);
+        assert_eq!(&v2[0..2], &original_v2[0..2]);
+        assert_eq!(&v2[3..], &original_v2[3..]);
+    }
+
+    #[test]
+    fn crossover_gene_fails_lhs() {
+        let mut v1 = vec![1, 2, 3];
+        let mut v2 = vec![4, 5, 6, 7, 8];
+        let index = 4;
+
+        let err = v1.crossover_gene(&mut v2, index).unwrap_err();
+
+        if let MultipleGeneAccess::Lhs(access) = err {
+            assert_eq!(access.index, index);
+            assert_eq!(access.size, v1.len());
+        } else {
+            panic!("Expected MultipleGeneAccess::Lhs, got {err:?}");
+        }
+    }
+
+    #[test]
+    fn crossover_gene_fails_rhs() {
+        let mut v1 = vec![1, 2, 3, 4, 5];
+        let mut v2 = vec![6, 7, 8];
+        let index = 4;
+
+        let err = v1.crossover_gene(&mut v2, index).unwrap_err();
+
+        if let MultipleGeneAccess::Rhs(access) = err {
+            assert_eq!(access.index, index);
+            assert_eq!(access.size, v2.len());
+        } else {
+            panic!("Expected MultipleGeneAccess::Rhs, got {err:?}");
+        }
+    }
+
+    #[test]
+    fn crossover_gene_fails_both() {
+        let mut v1 = vec![1, 2, 3];
+        let mut v2 = vec![4, 5, 6];
+        let index = 5;
+
+        let err = v1.crossover_gene(&mut v2, index).unwrap_err();
+
+        if let MultipleGeneAccess::Both { lhs, rhs } = err {
+            assert_eq!(lhs.index, index);
+            assert_eq!(lhs.size, v1.len());
+            assert_eq!(rhs.index, index);
+            assert_eq!(rhs.size, v2.len());
+        } else {
+            panic!("Expected MultipleGeneAccess::Both, got {err:?}");
+        }
+    }
+
+    // --- crossover_segment ---
+
+    #[test]
+    fn crossover_segment_success() {
+        let mut v1 = vec![1, 2, 3, 4, 5];
+        let mut v2 = vec![6, 7, 8, 9, 10];
+        let original_v1 = v1.clone();
+        let original_v2 = v2.clone();
+        let range = 1..4; // Swaps [2, 3, 4] with [7, 8, 9]
+
+        let result = v1.crossover_segment(&mut v2, range.clone());
+
+        assert!(result.is_ok());
+        assert_eq!(&v1[range.clone()], &original_v2[range.clone()]);
+        assert_eq!(&v2[range.clone()], &original_v1[range]);
+
+        // Check that other elements are untouched
+        assert_eq!(v1[0], original_v1[0]);
+        assert_eq!(v1[4], original_v1[4]);
+        assert_eq!(v2[0], original_v2[0]);
+        assert_eq!(v2[4], original_v2[4]);
+    }
+
+    #[test]
+    fn crossover_segment_fails_lhs() {
+        let mut v1 = vec![1, 2, 3];
+        let mut v2 = vec![4, 5, 6, 7, 8, 9];
+        let range = 2..5;
+
+        let err = v1.crossover_segment(&mut v2, range.clone()).unwrap_err();
+
+        if let MultipleGeneAccess::Lhs(access) = err {
+            assert_eq!(access.index, range);
+            assert_eq!(access.size, v1.len());
+        } else {
+            panic!("Expected MultipleGeneAccess::Lhs, got {err:?}");
+        }
+    }
+
+    #[test]
+    fn crossover_segment_fails_rhs() {
+        let mut v1 = vec![1, 2, 3, 4, 5, 6];
+        let mut v2 = vec![7, 8, 9];
+        let range = 2..5;
+
+        let err = v1.crossover_segment(&mut v2, range.clone()).unwrap_err();
+
+        if let MultipleGeneAccess::Rhs(access) = err {
+            assert_eq!(access.index, range);
+            assert_eq!(access.size, v2.len());
+        } else {
+            panic!("Expected MultipleGeneAccess::Rhs, got {err:?}");
+        }
+    }
+
+    #[test]
+    fn crossover_segment_fails_both() {
+        let mut v1 = vec![1, 2, 3];
+        let mut v2 = vec![4, 5, 6];
+        let range = 2..5;
+
+        let err = v1.crossover_segment(&mut v2, range.clone()).unwrap_err();
+
+        if let MultipleGeneAccess::Both { lhs, rhs } = err {
+            assert_eq!(lhs.index, range);
+            assert_eq!(lhs.size, v1.len());
+            assert_eq!(rhs.index, range);
+            assert_eq!(rhs.size, v2.len());
+        } else {
+            panic!("Expected MultipleGeneAccess::Both, got {err:?}");
+        }
+    }
+}

--- a/packages/ec-linear/src/recombinator/crossover.rs
+++ b/packages/ec-linear/src/recombinator/crossover.rs
@@ -1,6 +1,15 @@
-use std::ops::Range;
+use std::{
+    fmt::Debug,
+    ops::{Index, IndexMut, Range},
+    slice::SliceIndex,
+};
 
-use crate::genome::Linear;
+use miette::Diagnostic;
+
+use crate::{
+    genome::Linear,
+    recombinator::errors::{GeneAccess, MultipleGeneAccess},
+};
 
 // TODO: Does `Crossover` need to be visible outside
 //   this module? If not, should `pub` be replaced/removed?
@@ -36,3 +45,63 @@ pub trait Crossover: Linear {
         range: Range<usize>,
     ) -> Result<(), Self::SegmentCrossoverError>;
 }
+
+pub(crate) fn try_get_mut<'a, 'b, I, Genome, Gene>(
+    lhs: &'a mut Genome,
+    rhs: &'b mut Genome,
+    index: I,
+) -> Result<(&'a mut I::Output, &'b mut I::Output), MultipleGeneAccess<I, Genome>>
+where
+    I: SliceIndex<[Gene]> + Debug + Clone,
+    Genome: AsMut<[Gene]>,
+    Gene: 'a + 'b,
+{
+    let (lhs, rhs) = (lhs.as_mut(), rhs.as_mut());
+    let (lhs_size, rhs_size) = (lhs.len(), rhs.len());
+    match (lhs.get_mut(index.clone()), rhs.get_mut(index.clone())) {
+        (Some(lhs), Some(rhs)) => Ok((lhs, rhs)),
+        (None, Some(_)) => Err(MultipleGeneAccess::Lhs(GeneAccess::new(index, lhs_size))),
+        (Some(_), None) => Err(MultipleGeneAccess::Rhs(GeneAccess::new(index, rhs_size))),
+        (None, None) => Err(MultipleGeneAccess::Both {
+            lhs: GeneAccess::new(index.clone(), lhs_size),
+            rhs: GeneAccess::new(index, rhs_size),
+        }),
+    }
+
+    // let Some(lhs) = self.gene_mut(index) else {
+    //     return Err(MultipleGeneAccess::Lhs(GeneAccess::new(index,
+    // self.size()))); };
+    // let Some(rhs) = other.gene_mut(index) else {
+    //     return Err(MultipleGeneAccess::Rhs(GeneAccess::new(
+    //         index,
+    //         other.size(),
+    //     )));
+    // };
+}
+
+// impl<T> Crossover for Vec<T> {
+//     type GeneCrossoverError = GeneAccess<usize, Self>;
+
+//     type SegmentCrossoverError = GeneAccess<Range<usize>, Self>;
+
+//     fn crossover_gene(
+//         &mut self,
+//         other: &mut Self,
+//         index: usize,
+//     ) -> Result<(), Self::GeneCrossoverError> {
+//         todo!()
+//     }
+
+//     fn crossover_segment(
+//         &mut self,
+//         other: &mut Self,
+//         range: Range<usize>,
+//     ) -> Result<(), Self::SegmentCrossoverError> {
+//         self.get_mut(range)
+//             .ok_or_else(|| GeneAccessRange {
+//                 range,
+//                 size: self.len(),
+//             })?
+//             .swap_with_slice(other.get_mut(range).ok_or(todo!())?);
+//     }
+// }

--- a/packages/ec-linear/src/recombinator/crossover.rs
+++ b/packages/ec-linear/src/recombinator/crossover.rs
@@ -41,7 +41,7 @@ pub trait Crossover: Linear {
 }
 
 impl<T: 'static> Crossover for Vec<T> {
-    type GeneCrossoverError = MultipleGeneAccess<usize, Self>;
+    type GeneCrossoverError = MultipleGeneAccess<usize>;
 
     fn crossover_gene(
         &mut self,
@@ -50,14 +50,17 @@ impl<T: 'static> Crossover for Vec<T> {
     ) -> Result<(), Self::GeneCrossoverError> {
         let (lhs, rhs) = match (self.gene_mut(index), other.gene_mut(index)) {
             (Some(lhs), Some(rhs)) => Ok((lhs, rhs)),
-            (None, Some(_)) => Err(MultipleGeneAccess::Lhs(GeneAccess::new(index, self.size()))),
-            (Some(_), None) => Err(MultipleGeneAccess::Rhs(GeneAccess::new(
+            (None, Some(_)) => Err(MultipleGeneAccess::Lhs(GeneAccess::new::<Self>(
+                index,
+                self.size(),
+            ))),
+            (Some(_), None) => Err(MultipleGeneAccess::Rhs(GeneAccess::new::<Self>(
                 index,
                 other.size(),
             ))),
             (None, None) => Err(MultipleGeneAccess::Both {
-                lhs: GeneAccess::new(index, self.size()),
-                rhs: GeneAccess::new(index, other.size()),
+                lhs: GeneAccess::new::<Self>(index, self.size()),
+                rhs: GeneAccess::new::<Self>(index, other.size()),
             }),
         }?;
 
@@ -65,7 +68,7 @@ impl<T: 'static> Crossover for Vec<T> {
         Ok(())
     }
 
-    type SegmentCrossoverError = MultipleGeneAccess<Range<usize>, Self>;
+    type SegmentCrossoverError = MultipleGeneAccess<Range<usize>>;
 
     fn crossover_segment(
         &mut self,
@@ -74,14 +77,17 @@ impl<T: 'static> Crossover for Vec<T> {
     ) -> Result<(), Self::SegmentCrossoverError> {
         let (lhs, rhs) = match (self.get_mut(range.clone()), other.get_mut(range.clone())) {
             (Some(lhs), Some(rhs)) => Ok((lhs, rhs)),
-            (None, Some(_)) => Err(MultipleGeneAccess::Lhs(GeneAccess::new(range, self.size()))),
-            (Some(_), None) => Err(MultipleGeneAccess::Rhs(GeneAccess::new(
+            (None, Some(_)) => Err(MultipleGeneAccess::Lhs(GeneAccess::new::<Self>(
+                range,
+                self.size(),
+            ))),
+            (Some(_), None) => Err(MultipleGeneAccess::Rhs(GeneAccess::new::<Self>(
                 range,
                 other.size(),
             ))),
             (None, None) => Err(MultipleGeneAccess::Both {
-                lhs: GeneAccess::new(range.clone(), self.size()),
-                rhs: GeneAccess::new(range, other.size()),
+                lhs: GeneAccess::new::<Self>(range.clone(), self.size()),
+                rhs: GeneAccess::new::<Self>(range, other.size()),
             }),
         }?;
 

--- a/packages/ec-linear/src/recombinator/crossover.rs
+++ b/packages/ec-linear/src/recombinator/crossover.rs
@@ -40,11 +40,17 @@ pub trait Crossover: Linear {
     ) -> Result<(), Self::SegmentCrossoverError>;
 }
 
+#[expect(type_alias_bounds, reason = "needed for type checking.")]
+type LhsRhsResult<'a, 'b, I, Gene>
+where
+    I: SliceIndex<[Gene]>,
+= (&'a mut I::Output, &'b mut I::Output);
+
 pub(crate) fn try_get_mut<'a, 'b, I, Genome, Gene, ErrorGenome>(
     lhs: &'a mut Genome,
     rhs: &'b mut Genome,
     index: I,
-) -> Result<(&'a mut I::Output, &'b mut I::Output), MultipleGeneAccess<I, ErrorGenome>>
+) -> Result<LhsRhsResult<'a, 'b, I, Gene>, MultipleGeneAccess<I, ErrorGenome>>
 where
     I: SliceIndex<[Gene]> + Debug + Clone,
     Genome: AsMut<[Gene]>,

--- a/packages/ec-linear/src/recombinator/crossover.rs
+++ b/packages/ec-linear/src/recombinator/crossover.rs
@@ -46,11 +46,11 @@ pub trait Crossover: Linear {
     ) -> Result<(), Self::SegmentCrossoverError>;
 }
 
-pub(crate) fn try_get_mut<'a, 'b, I, Genome, Gene>(
+pub(crate) fn try_get_mut<'a, 'b, I, Genome, Gene, ErrorGenome>(
     lhs: &'a mut Genome,
     rhs: &'b mut Genome,
     index: I,
-) -> Result<(&'a mut I::Output, &'b mut I::Output), MultipleGeneAccess<I, Genome>>
+) -> Result<(&'a mut I::Output, &'b mut I::Output), MultipleGeneAccess<I, ErrorGenome>>
 where
     I: SliceIndex<[Gene]> + Debug + Clone,
     Genome: AsMut<[Gene]>,
@@ -67,16 +67,6 @@ where
             rhs: GeneAccess::new(index, rhs_size),
         }),
     }
-
-    // let Some(lhs) = self.gene_mut(index) else {
-    //     return Err(MultipleGeneAccess::Lhs(GeneAccess::new(index,
-    // self.size()))); };
-    // let Some(rhs) = other.gene_mut(index) else {
-    //     return Err(MultipleGeneAccess::Rhs(GeneAccess::new(
-    //         index,
-    //         other.size(),
-    //     )));
-    // };
 }
 
 // impl<T> Crossover for Vec<T> {

--- a/packages/ec-linear/src/recombinator/crossover.rs
+++ b/packages/ec-linear/src/recombinator/crossover.rs
@@ -1,10 +1,4 @@
-use std::{
-    fmt::Debug,
-    ops::{Index, IndexMut, Range},
-    slice::SliceIndex,
-};
-
-use miette::Diagnostic;
+use std::{fmt::Debug, ops::Range, slice::SliceIndex};
 
 use crate::{
     genome::Linear,
@@ -69,29 +63,29 @@ where
     }
 }
 
-// impl<T> Crossover for Vec<T> {
-//     type GeneCrossoverError = GeneAccess<usize, Self>;
+impl<T: 'static> Crossover for Vec<T> {
+    type GeneCrossoverError = MultipleGeneAccess<usize, Self>;
 
-//     type SegmentCrossoverError = GeneAccess<Range<usize>, Self>;
+    fn crossover_gene(
+        &mut self,
+        other: &mut Self,
+        index: usize,
+    ) -> Result<(), Self::GeneCrossoverError> {
+        let (lhs, rhs) = try_get_mut(self, other, index)?;
 
-//     fn crossover_gene(
-//         &mut self,
-//         other: &mut Self,
-//         index: usize,
-//     ) -> Result<(), Self::GeneCrossoverError> {
-//         todo!()
-//     }
+        std::mem::swap(lhs, rhs);
+        Ok(())
+    }
 
-//     fn crossover_segment(
-//         &mut self,
-//         other: &mut Self,
-//         range: Range<usize>,
-//     ) -> Result<(), Self::SegmentCrossoverError> {
-//         self.get_mut(range)
-//             .ok_or_else(|| GeneAccessRange {
-//                 range,
-//                 size: self.len(),
-//             })?
-//             .swap_with_slice(other.get_mut(range).ok_or(todo!())?);
-//     }
-// }
+    type SegmentCrossoverError = MultipleGeneAccess<Range<usize>, Self>;
+
+    fn crossover_segment(
+        &mut self,
+        other: &mut Self,
+        range: Range<usize>,
+    ) -> Result<(), Self::SegmentCrossoverError> {
+        let (lhs, rhs) = try_get_mut(self, other, range)?;
+        lhs.swap_with_slice(rhs);
+        Ok(())
+    }
+}

--- a/packages/ec-linear/src/recombinator/errors.rs
+++ b/packages/ec-linear/src/recombinator/errors.rs
@@ -108,15 +108,18 @@ where
 #[diagnostic(
     help = "Ensure that your indices {index:?} are legal, i.e., within the range 0..{size}"
 )]
-pub struct GeneAccess<Index: Debug, Genome> {
+pub struct GeneAccess<Index, Genome>
+where
+    Index: Debug,
+{
     index: Index,
     size: usize,
     _p: PhantomData<Genome>,
 }
 
 impl<Index: Debug, Genome> GeneAccess<Index, Genome> {
-    pub fn new(index: Index, size: usize) -> Self {
-        GeneAccess {
+    pub const fn new(index: Index, size: usize) -> Self {
+        Self {
             index,
             size,
             _p: PhantomData,

--- a/packages/ec-linear/src/recombinator/errors.rs
+++ b/packages/ec-linear/src/recombinator/errors.rs
@@ -124,14 +124,14 @@ where
     /// error message to another genome type. This is necessary
     /// when the actual type being recombined (e.g., `Vec<bool>`)
     /// is wrapped in a container type like `Bitstring`.
-    pub(crate) fn for_genome_type<NewGenome>(mut self) -> Self {
+    pub(crate) fn for_genome_type<NewGenome: 'static>(mut self) -> Self {
         self.genome_type = std::any::type_name::<NewGenome>();
         self
     }
 }
 
 impl<Index: Debug> GeneAccess<Index> {
-    pub fn new<Genome>(index: Index, size: usize) -> Self {
+    pub fn new<Genome: 'static>(index: Index, size: usize) -> Self {
         Self {
             index,
             size,
@@ -167,15 +167,15 @@ impl<Index> MultipleGeneAccess<Index>
 where
     Index: Debug,
 {
-    pub(crate) fn lhs<Genome>(index: Index, size: usize) -> Self {
+    pub(crate) fn lhs<Genome: 'static>(index: Index, size: usize) -> Self {
         Self::Lhs(GeneAccess::new::<Genome>(index, size))
     }
 
-    pub(crate) fn rhs<Genome>(index: Index, size: usize) -> Self {
+    pub(crate) fn rhs<Genome: 'static>(index: Index, size: usize) -> Self {
         Self::Rhs(GeneAccess::new::<Genome>(index, size))
     }
 
-    pub(crate) fn both<Genome>(index: Index, lhs_size: usize, rhs_size: usize) -> Self
+    pub(crate) fn both<Genome: 'static>(index: Index, lhs_size: usize, rhs_size: usize) -> Self
     where
         Index: Clone,
     {
@@ -189,7 +189,7 @@ where
     /// error message to another genome type. This is necessary
     /// when the actual type being recombined (e.g., `Vec<bool>`)
     /// is wrapped in a container type like `Bitstring`.
-    pub(crate) fn for_genome_type<NewGenome>(self) -> Self {
+    pub(crate) fn for_genome_type<NewGenome: 'static>(self) -> Self {
         match self {
             Self::Lhs(gene_access) => Self::Lhs(gene_access.for_genome_type::<NewGenome>()),
             Self::Rhs(gene_access) => Self::Rhs(gene_access.for_genome_type::<NewGenome>()),

--- a/packages/ec-linear/src/recombinator/errors.rs
+++ b/packages/ec-linear/src/recombinator/errors.rs
@@ -117,6 +117,21 @@ where
     _p: PhantomData<Genome>,
 }
 
+impl<Index, Genome> GeneAccess<Index, Genome>
+where
+    Index: Debug,
+{
+    /// Changes the contained `PhantomData` genome type captured for the error
+    /// message to another one.
+    pub(crate) fn for_genome_type<NewGenome>(self) -> GeneAccess<Index, NewGenome> {
+        GeneAccess {
+            index: self.index,
+            size: self.size,
+            _p: PhantomData,
+        }
+    }
+}
+
 impl<Index: Debug, Genome> GeneAccess<Index, Genome> {
     pub const fn new(index: Index, size: usize) -> Self {
         Self {
@@ -170,6 +185,24 @@ impl<Index: Debug, Genome> Debug for MultipleGeneAccess<Index, Genome> {
                 .field("lhs", lhs)
                 .field("rhs", rhs)
                 .finish(),
+        }
+    }
+}
+
+impl<Index, Genome> MultipleGeneAccess<Index, Genome>
+where
+    Index: Debug,
+{
+    /// Changes the contained `PhantomData` genome type captured for the error
+    /// message to another one.
+    pub(crate) fn for_genome_type<NewGenome>(self) -> MultipleGeneAccess<Index, NewGenome> {
+        match self {
+            Self::Lhs(gene_access) => MultipleGeneAccess::Lhs(gene_access.for_genome_type()),
+            Self::Rhs(gene_access) => MultipleGeneAccess::Rhs(gene_access.for_genome_type()),
+            Self::Both { lhs, rhs } => MultipleGeneAccess::Both {
+                lhs: lhs.for_genome_type(),
+                rhs: rhs.for_genome_type(),
+            },
         }
     }
 }

--- a/packages/ec-linear/src/recombinator/errors.rs
+++ b/packages/ec-linear/src/recombinator/errors.rs
@@ -167,6 +167,24 @@ impl<Index> MultipleGeneAccess<Index>
 where
     Index: Debug,
 {
+    pub(crate) fn lhs<Genome>(index: Index, size: usize) -> Self {
+        Self::Lhs(GeneAccess::new::<Genome>(index, size))
+    }
+
+    pub(crate) fn rhs<Genome>(index: Index, size: usize) -> Self {
+        Self::Rhs(GeneAccess::new::<Genome>(index, size))
+    }
+
+    pub(crate) fn both<Genome>(index: Index, lhs_size: usize, rhs_size: usize) -> Self
+    where
+        Index: Clone,
+    {
+        Self::Both {
+            lhs: GeneAccess::new::<Genome>(index.clone(), lhs_size),
+            rhs: GeneAccess::new::<Genome>(index, rhs_size),
+        }
+    }
+
     /// Changes the contained `genome_type` captured for the
     /// error message to another genome type. This is necessary
     /// when the actual type being recombined (e.g., `Vec<bool>`)

--- a/packages/ec-linear/src/recombinator/two_point_xo.rs
+++ b/packages/ec-linear/src/recombinator/two_point_xo.rs
@@ -8,46 +8,6 @@ use super::{
 
 pub struct TwoPointXo;
 
-// TODO: Remove the `Vec<T>` versions when we're done migrating
-//   to the struct-based version of `Bitstring`.
-impl<T> Recombinator<[Vec<T>; 2]> for TwoPointXo {
-    type Output = Vec<T>;
-    type Error = DifferentGenomeLength;
-
-    fn recombine<R: Rng + ?Sized>(
-        &self,
-        [mut first_genome, mut second_genome]: [Vec<T>; 2],
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error> {
-        let len = first_genome.len();
-        if len != second_genome.len() {
-            return Err(DifferentGenomeLength(len, second_genome.len()));
-        }
-
-        let mut first = rng.random_range(0..len);
-        let mut second = rng.random_range(0..len);
-        if second < first {
-            (first, second) = (second, first);
-        }
-        // We now know that first <= second
-        first_genome[first..second].swap_with_slice(&mut second_genome[first..second]);
-        Ok(first_genome)
-    }
-}
-
-impl<T> Recombinator<(Vec<T>, Vec<T>)> for TwoPointXo {
-    type Output = Vec<T>;
-    type Error = <Self as Recombinator<[Vec<T>; 2]>>::Error;
-
-    fn recombine<R: Rng + ?Sized>(
-        &self,
-        genomes: (Vec<T>, Vec<T>),
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error> {
-        self.recombine(<[Vec<T>; 2]>::from(genomes), rng)
-    }
-}
-
 // TODO: Note that `TwoPointXo` doesn't strictly need
 //   the two vectors to have the same length, but the
 //   swapped regions need to "make sense" for both parent

--- a/packages/ec-linear/src/recombinator/uniform_xo.rs
+++ b/packages/ec-linear/src/recombinator/uniform_xo.rs
@@ -8,46 +8,6 @@ use super::{
 
 pub struct UniformXo;
 
-// TODO: We should get rid of the `Vec<T>` versions when
-//   we've completed the migration to a struct-based `Bitstring`.
-impl<T: Clone> Recombinator<[Vec<T>; 2]> for UniformXo {
-    type Output = Vec<T>;
-    type Error = DifferentGenomeLength;
-
-    fn recombine<R: Rng + ?Sized>(
-        &self,
-        [first_genome, second_genome]: [Vec<T>; 2],
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error> {
-        let len = first_genome.len();
-        if len != second_genome.len() {
-            return Err(DifferentGenomeLength(len, second_genome.len()));
-        }
-        Ok((0..len)
-            .map(|pos| {
-                if rng.random::<bool>() {
-                    first_genome[pos].clone()
-                } else {
-                    second_genome[pos].clone()
-                }
-            })
-            .collect())
-    }
-}
-
-impl<T: Clone> Recombinator<(Vec<T>, Vec<T>)> for UniformXo {
-    type Output = Vec<T>;
-    type Error = <Self as Recombinator<[Vec<T>; 2]>>::Error;
-
-    fn recombine<R: Rng + ?Sized>(
-        &self,
-        genomes: (Vec<T>, Vec<T>),
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error> {
-        self.recombine(<[Vec<T>; 2]>::from(genomes), rng)
-    }
-}
-
 impl<G> Recombinator<[G; 2]> for UniformXo
 where
     G: Crossover,


### PR DESCRIPTION
## Summary of Changes



This pull request focuses on cleaning up and generalizing the bitstring crossover implementation. The primary goal is to centralize and standardize error handling for gene and segment access during crossover operations by introducing new, more robust generic error types. This refactoring also involves removing outdated `Vec<T>`-specific crossover logic in favor of a more generalized `Crossover` trait implementation for `Vec<T>`, leading to a cleaner, more maintainable, and extensible codebase for genetic algorithms.

### Highlights

* **Standardized Crossover Error Handling**: The `Bitstring`'s `Crossover` trait implementation has been refactored to use a new, more generic `MultipleGeneAccess` error type, replacing the specific `GeneAccess` and `GeneAccessRange` structs. This change centralizes and standardizes error reporting for out-of-bounds gene or segment access during crossover operations.
* **Introduction of Generic Error Types**: New generic error types, `GeneAccess<Index>` and `MultipleGeneAccess<Index>`, have been introduced in `errors.rs`. These types provide a more robust and flexible way to report single or multiple gene access failures, complete with diagnostic information and context about the genome type.
* **Crossover Trait Implementation for Vec<T>**: The `Crossover` trait has now been implemented directly for `Vec<T>`, allowing `Vec` to be treated as a first-class genome type for crossover operations. This simplifies future implementations and promotes code reuse.
* **Removal of Legacy Vec<T> Recombinator Implementations**: Outdated `Recombinator` implementations for `Vec<T>` in `two_point_xo.rs` and `uniform_xo.rs` have been removed. This cleanup streamlines the codebase by eliminating redundant and less flexible legacy code, aligning with the new generic `Crossover` trait for `Vec<T>`.
* **Enhanced Error Handling Test Coverage**: New unit tests have been added to `bitstring.rs` to specifically verify the behavior and correctness of the new `MultipleGeneAccess` error handling for various scenarios (e.g., both genomes out of bounds, only left-hand side out of bounds, only right-hand side out of bounds).
* **Enhanced Test Coverage for `Bitstring` and `Crossover`**: This adds tests (mostly generated by Google Gemini) for `Bitstring` and `Crossover` so we have more complete coverage there.

<details>
<summary><b>Changelog</b></summary>

* **packages/ec-linear/src/genome/bitstring.rs**
    * Updated imports to include std::ops::Range and crate::recombinator::errors::MultipleGeneAccess.
    * Removed the miette::Diagnostic import.
    * Deleted the custom GeneAccess and GeneAccessRange error structs.
    * Refactored the crossover_gene and crossover_segment implementations to use the new MultipleGeneAccess error type and delegate the actual crossover logic to the underlying bits field.
    * Added new unit tests to verify the behavior of MultipleGeneAccess error cases (Both, Lhs, Rhs) for gene access.
* **packages/ec-linear/src/recombinator/crossover.rs**
    * Added import for crate::recombinator::errors::MultipleGeneAccess.
    * Implemented the Crossover trait for Vec<T>, providing generic gene and segment crossover functionality with robust error handling using MultipleGeneAccess.
* **packages/ec-linear/src/recombinator/errors.rs**
    * Introduced a new generic error struct, GeneAccess<Index>, which captures the index, size, and genome type for failed gene access.
    * Defined a new generic enum, MultipleGeneAccess<Index>, to represent different scenarios of gene access failures (Lhs, Rhs, Both) during crossover.
    * Added helper methods (lhs, rhs, both) to MultipleGeneAccess for convenient error creation.
    * Included a for_genome_type method in both GeneAccess and MultipleGeneAccess to allow re-typing the genome context for wrapped types like Bitstring.
* **packages/ec-linear/src/recombinator/two_point_xo.rs**
    * Removed the legacy Recombinator implementations for [Vec<T>; 2] and (Vec<T>, Vec<T>), streamlining the two-point crossover logic.
* **packages/ec-linear/src/recombinator/uniform_xo.rs**
    * Removed the legacy Recombinator implementations for [Vec<T>; 2] and (Vec<T>, Vec<T>), streamlining the uniform crossover logic.
</details>

<details>
<summary><b>Activity</b></summary>

* A bot, gemini-code-assist[bot], suggested deriving the Debug trait for MultipleGeneAccess in packages/ec-linear/src/recombinator/errors.rs. The author, JustusFluegel, responded that this is not possible due to bounds.
* A bot, gemini-code-assist[bot], identified a potential typo in the tests within packages/ec-linear/src/genome/bitstring.rs, suggesting the use of rand::thread_rng() instead of rand::rng(). NicMcPhee, a reviewer, corrected the bot, stating that rand::rng() is the more up-to-date usage.
* A bot, gemini-code-assist[bot], suggested removing the .clone() call for Range<usize> in packages/ec-linear/src/recombinator/crossover.rs, claiming Range<usize> implements Copy. NicMcPhee, a reviewer, corrected the bot, confirming that Range<usize> does not implement Copy and the .clone() is necessary.
</details>