### PR TITLE
Fix unnecessary double reference; use `assert_ne!`

### DIFF
--- a/packages/ec-core/src/performance/test_result.rs
+++ b/packages/ec-core/src/performance/test_result.rs
@@ -171,7 +171,7 @@ pub(crate) mod test_result_tests {
         let first: TestResult<i32, i32> = TestResult::Score(ScoreValue(32));
         let second = TestResult::Score(ScoreValue(87));
         assert!(first < second);
-        assert!(first != second);
+        assert_ne!(first, second);
         assert!((first > second).not());
     }
 
@@ -180,7 +180,7 @@ pub(crate) mod test_result_tests {
         let first: TestResult<i32, i32> = TestResult::Error(ErrorValue(32));
         let second = TestResult::Error(ErrorValue(87));
         assert!(first > second);
-        assert!(first != second);
+        assert_ne!(first, second);
         assert!((first < second).not());
     }
 
@@ -189,7 +189,7 @@ pub(crate) mod test_result_tests {
         let first = TestResult::Score(ScoreValue(32));
         let second = TestResult::Error(ErrorValue(87));
         assert!((first > second).not());
-        assert!(first != second);
+        assert_ne!(first, second);
         assert!((first < second).not());
         assert!(first.partial_cmp(&second).is_none());
         assert!(second.partial_cmp(&first).is_none());

--- a/packages/push-macros/src/doctest_tokenstream.rs
+++ b/packages/push-macros/src/doctest_tokenstream.rs
@@ -94,7 +94,7 @@ fn create_doc_attrs_from_string(input: String, tokens: &mut TokenStream, do_form
         let mut without_lines: Vec<String> = formatted
             .lines()
             .skip(1)
-            .map(|l| format!(" {line}", line = &l.get(4..).unwrap_or_default()))
+            .map(|l| format!(" {line}", line = l.get(4..).unwrap_or_default()))
             .collect();
         if !without_lines.is_empty() {
             without_lines.swap_remove(without_lines.len() - 1);


### PR DESCRIPTION
Clippy was unhappy about a double reference (see #478), which this fixes. 

We also fixed a Clippy warning about using `assert!(x != y)` when we should use `assert_ne!(x, y)`.

Closes #478 