### PR TITLE
Update several clippy errors in our packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,10 +410,10 @@ dependencies = [
 name = "ec_macros"
 version = "0.1.0"
 dependencies = [
- "manyhow 0.11.4",
+ "manyhow 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -337,7 +337,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -362,7 +362,7 @@ checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -410,10 +410,10 @@ dependencies = [
 name = "ec_macros"
 version = "0.1.0"
 dependencies = [
- "manyhow",
+ "manyhow 0.11.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -504,7 +504,7 @@ checksum = "6adcc45088fbcbe7963bdca7bda19ab4214ffd794c6ef88813a3cb983ba7d881"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -582,7 +582,7 @@ checksum = "1745158e5e753b78fdcbccc054dba9aeb6a8a0db7347d5c83689b2be8d6cbb21"
 dependencies = [
  "proc-macro2",
  "railroad",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -593,11 +593,11 @@ checksum = "76f08424c194edc05c0729c2686a8643ecf7ab05625962090ca018b773f856ed"
 dependencies = [
  "base64",
  "macro_railroad",
- "manyhow",
+ "manyhow 0.11.4",
  "proc-macro2",
  "quote",
  "rand",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -622,10 +622,22 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
 dependencies = [
- "manyhow-macros",
+ "manyhow-macros 0.11.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e480c047342e73ccc05fb821f0953512868b9257c2559b22a7e3efafc4aad85d"
+dependencies = [
+ "manyhow-macros 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -633,6 +645,17 @@ name = "manyhow-macros"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3330ca83c69fe1691d12126d522dda965e58735ac26052580f95f56e4169ec4"
 dependencies = [
  "proc-macro-utils",
  "proc-macro2",
@@ -672,7 +695,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -807,12 +830,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -887,11 +910,11 @@ dependencies = [
  "ident_case_conversions",
  "itertools 0.14.0",
  "macro_railroad_annotation",
- "manyhow",
+ "manyhow 0.13.0",
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1090,7 +1113,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1139,7 +1162,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1150,7 +1173,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1168,7 +1191,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1194,9 +1217,20 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1244,7 +1278,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1255,7 +1289,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "test-case-core",
 ]
 
@@ -1269,7 +1303,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1299,7 +1333,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1408,7 +1442,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -1574,7 +1608,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -13,7 +13,11 @@ allowed-duplicate-crates = [
   "windows_x86_64_gnullvm",
   "windows_x86_64_msvc",
   # miette dependency, already updated on main but not released yet.
-  "unicode-width"
+  "unicode-width",
+  # Various macros related crate duplications
+  "manyhow",
+  "manyhow-macros",
+  "syn",
 ]
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true

--- a/packages/ec-core/src/performance/test_results.rs
+++ b/packages/ec-core/src/performance/test_results.rs
@@ -149,7 +149,6 @@ impl<R> TestResults<R> {
     ///
     /// assert!(results.iter().eq([&ScoreValue(10), &ScoreValue(20)]));
     /// ```
-    #[must_use]
     pub fn iter(&self) -> <&'_ Self as IntoIterator>::IntoIter {
         self.into_iter()
     }

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -481,7 +481,7 @@ mod test {
         // Since we don't add genes to empty genomes, this should still be an empty
         // genome
         let Ok(child) = umad.mutate(parent, &mut rng);
-        assert!(child.is_empty());
+        assert_eq!(child, []);
     }
 
     #[test]

--- a/packages/ec-macros/Cargo.toml
+++ b/packages/ec-macros/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-manyhow = "0.11.4"
+manyhow = "0.13.0"
 proc-macro2 = "1.0.81"
 quote = "1.0.33"
-syn = { version = "2.0.58", features = ["full", "printing"] }
+syn = { version = "3.0.3", features = ["full", "printing"] }

--- a/packages/ec-macros/src/dyn_ref_impls/mod.rs
+++ b/packages/ec-macros/src/dyn_ref_impls/mod.rs
@@ -39,10 +39,11 @@ static SHARED_ALTERNATIVES: fn() -> Vec<Box<dyn Modification>> = || {
 pub fn dyn_ref_impls(a: proc_macro2::TokenStream, tokens: syn::ItemImpl) -> manyhow::Result {
     manyhow::ensure!(a.is_empty(), a, "Expected no inputs");
 
-    match tokens.trait_ {
-        Some((None, _, _)) => {}
-        _ => manyhow::bail!(tokens, "Only non-negative trait impls are supported"),
-    }
+    manyhow::ensure!(
+        tokens.modifiers.polarity.is_none(),
+        tokens,
+        "Only non-negative trait impls are supported"
+    );
 
     let ty = tokens.self_ty.clone();
 

--- a/packages/push-macros/Cargo.toml
+++ b/packages/push-macros/Cargo.toml
@@ -20,8 +20,8 @@ proc-macro = true
 ident_case_conversions = "1.0.0"
 itertools = { workspace = true }
 macro_railroad_annotation = { workspace = true }
-manyhow = "0.11.4"
-prettyplease = "0.2.15"
+manyhow = "0.13.0"
+prettyplease = "0.3.0"
 proc-macro2 = "1.0.81"
 quote = "1.0.33"
-syn = { version = "2.0.58", features = ["full", "printing"] }
+syn = { version = "3.0.3", features = ["full", "printing", "extra-traits"] }

--- a/packages/push-macros/Cargo.toml
+++ b/packages/push-macros/Cargo.toml
@@ -24,4 +24,4 @@ manyhow = "0.13.0"
 prettyplease = "0.3.0"
 proc-macro2 = "1.0.81"
 quote = "1.0.33"
-syn = { version = "3.0.3", features = ["full", "printing", "extra-traits"] }
+syn = { version = "3.0.3", features = ["extra-traits", "full", "printing"] }

--- a/packages/push-macros/src/doctest_tokenstream.rs
+++ b/packages/push-macros/src/doctest_tokenstream.rs
@@ -87,6 +87,7 @@ fn create_doc_attrs_from_string(input: String, tokens: &mut TokenStream, do_form
         let input_block = format!("fn main() {{ {input}  }}");
         let file_contents = vec![syn::Item::Fn(syn::parse_str(&input_block).unwrap())];
         let formatted = prettyplease::unparse(&syn::File {
+            frontmatter: None,
             shebang: None,
             attrs: vec![],
             items: file_contents,


### PR DESCRIPTION
This updates `manyhow`, `prettyplease` and `syn`, resolving a compiler error about an unnecessary semicolon.