### PR TITLE
Bump rand and fix errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +272,15 @@ name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "criterion"
@@ -384,7 +404,7 @@ dependencies = [
  "num-traits",
  "polonius-the-crab",
  "proptest",
- "rand",
+ "rand 0.10.2",
  "rayon",
  "static_assertions",
  "test-strategy",
@@ -400,7 +420,7 @@ dependencies = [
  "ec-core",
  "miette",
  "num-traits",
- "rand",
+ "rand 0.10.2",
  "static_assertions",
  "test-case",
  "thiserror",
@@ -458,8 +478,20 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -596,7 +628,7 @@ dependencies = [
  "manyhow 0.11.4",
  "proc-macro2",
  "quote",
- "rand",
+ "rand 0.9.4",
  "syn 2.0.119",
 ]
 
@@ -868,7 +900,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -893,7 +925,7 @@ dependencies = [
  "ordered-float",
  "proptest",
  "push_macros",
- "rand",
+ "rand 0.10.2",
  "static_assertions",
  "strsim",
  "strum",
@@ -939,6 +971,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "railroad"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,7 +992,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -964,7 +1013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -973,8 +1022,14 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -982,7 +1037,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1244,7 +1299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ polonius-the-crab = "0.5.0"
 proptest = "1.11.0"
 push = { path = "packages/push" }
 push_macros = { path = "packages/push-macros" }
-rand = "0.9.3"
+rand = "0.10.2"
 static_assertions = "1.1.0"
 test-case = "3.3.1"
 test-strategy = "0.4.5"

--- a/clippy.toml
+++ b/clippy.toml
@@ -18,6 +18,10 @@ allowed-duplicate-crates = [
   "manyhow",
   "manyhow-macros",
   "syn",
+  "rand",
+  "rand_core",
+  "getrandom",
+  "r-efi"
 ]
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true

--- a/packages/ec-core/Cargo.toml
+++ b/packages/ec-core/Cargo.toml
@@ -41,7 +41,7 @@ criterion = { workspace = true }
 ec-linear = { path = "../ec-linear" }
 miette = { workspace = true, features = ["fancy"] }
 proptest = { workspace = true }
-rand = { workspace = true, features = ["alloc", "small_rng"] }
+rand = { workspace = true, features = ["alloc"] }
 test-strategy = { workspace = true }
 
 [features]

--- a/packages/ec-core/src/child_maker/erased.rs
+++ b/packages/ec-core/src/child_maker/erased.rs
@@ -1,4 +1,4 @@
-use rand::{Rng, RngCore};
+use rand::Rng;
 
 use super::ChildMaker;
 use crate::{operator::selector::Selector, population::Population};
@@ -61,7 +61,7 @@ where
     /// That can include constructing or scoring the genome.
     fn dyn_make_child(
         &self,
-        rng: &mut dyn RngCore,
+        rng: &mut dyn Rng,
         population: &P,
         selector: &S,
     ) -> Result<P::Individual, E>;
@@ -77,7 +77,7 @@ where
 {
     fn dyn_make_child(
         &self,
-        rng: &mut dyn RngCore,
+        rng: &mut dyn Rng,
         population: &P,
         selector: &S,
     ) -> Result<<P as Population>::Individual, E> {

--- a/packages/ec-core/src/operator/composable/repeat_with.rs
+++ b/packages/ec-core/src/operator/composable/repeat_with.rs
@@ -127,7 +127,7 @@ where
 mod tests {
     use std::{convert::Infallible, ops::Range};
 
-    use rand::{Rng, rng};
+    use rand::{Rng, RngExt, rng};
 
     use super::*;
 

--- a/packages/ec-core/src/operator/erased.rs
+++ b/packages/ec-core/src/operator/erased.rs
@@ -1,6 +1,6 @@
 use std::error::Error as StdError;
 
-use rand::{Rng, RngCore};
+use rand::Rng;
 
 use super::{Composable, Operator};
 
@@ -60,7 +60,7 @@ pub trait DynOperator<Input, Error = Box<dyn StdError + Send + Sync>>: Composabl
     /// This will return an error if there's some problem applying the operator.
     /// Given how general this concept is, there's no good way of saying here
     /// what that might be.
-    fn dyn_apply(&self, input: Input, rng: &mut dyn RngCore) -> Result<Self::Output, Error>;
+    fn dyn_apply(&self, input: Input, rng: &mut dyn Rng) -> Result<Self::Output, Error>;
 }
 
 impl<T, I, E> DynOperator<I, E> for T
@@ -69,7 +69,7 @@ where
 {
     type Output = T::Output;
 
-    fn dyn_apply(&self, input: I, rng: &mut dyn RngCore) -> Result<Self::Output, E> {
+    fn dyn_apply(&self, input: I, rng: &mut dyn Rng) -> Result<Self::Output, E> {
         self.apply(input, rng).map_err(Into::into)
     }
 }

--- a/packages/ec-core/src/operator/genome_extractor.rs
+++ b/packages/ec-core/src/operator/genome_extractor.rs
@@ -18,7 +18,7 @@ use crate::individual::Individual;
 /// extract the genome from an individual and mutate it.
 ///
 /// ```
-/// # use rand::{rng, Rng};
+/// # use rand::{rng, Rng, RngExt};
 /// # use ec_core::{
 /// #     individual::ec::EcIndividual,
 /// #     operator::{
@@ -91,7 +91,7 @@ where
 mod tests {
     use std::convert::Infallible;
 
-    use rand::{Rng, rng};
+    use rand::{Rng, RngExt, rng};
 
     use super::GenomeExtractor;
     use crate::{

--- a/packages/ec-core/src/operator/mutator/erased.rs
+++ b/packages/ec-core/src/operator/mutator/erased.rs
@@ -1,4 +1,4 @@
-use rand::{Rng, RngCore};
+use rand::Rng;
 
 use super::Mutator;
 
@@ -54,7 +54,7 @@ pub trait DynMutator<G, E = Box<dyn std::error::Error + Send + Sync>> {
     /// This will return an error if there is an error mutating the given
     /// genome. This will usually be because the given `genome` is invalid in
     /// some way, thus making the mutation impossible.
-    fn dyn_mutate(&self, genome: G, rng: &mut dyn RngCore) -> Result<G, E>;
+    fn dyn_mutate(&self, genome: G, rng: &mut dyn Rng) -> Result<G, E>;
 }
 
 static_assertions::assert_obj_safe!(DynMutator<()>);
@@ -63,7 +63,7 @@ impl<T, G, E> DynMutator<G, E> for T
 where
     T: Mutator<G, Error: Into<E>>,
 {
-    fn dyn_mutate(&self, genome: G, rng: &mut dyn RngCore) -> Result<G, E> {
+    fn dyn_mutate(&self, genome: G, rng: &mut dyn Rng) -> Result<G, E> {
         self.mutate(genome, rng).map_err(Into::into)
     }
 }

--- a/packages/ec-core/src/operator/mutator/mod.rs
+++ b/packages/ec-core/src/operator/mutator/mod.rs
@@ -37,7 +37,7 @@ pub use erased::*;
 /// that exactly one bit has changed.
 ///
 /// ```
-/// # use rand::{rng, Rng};
+/// # use rand::{rng, Rng, RngExt};
 /// # use ec_core::operator::mutator::Mutator;
 /// # use std::convert::Infallible;
 /// #
@@ -151,7 +151,7 @@ pub trait Mutator<G> {
 /// #     mutator::{Mutate, Mutator},
 /// #     Composable, Operator,
 /// # };
-/// # use rand::{Rng, rng};
+/// # use rand::{Rng, RngExt, rng};
 /// #
 /// type Genome<T> = [T; 4];
 ///
@@ -208,7 +208,7 @@ pub trait Mutator<G> {
 /// #     mutator::{Mutate, Mutator},
 /// #     Composable, Operator,
 /// # };
-/// # use rand::{Rng, rng};
+/// # use rand::{Rng, RngExt, rng};
 /// # use std::convert::Infallible;
 /// #
 /// # type Genome<T> = [T; 4];
@@ -266,7 +266,7 @@ impl<M> Mutate<M> {
     /// #     mutator::{Mutate, Mutator},
     /// #     Composable, Operator,
     /// # };
-    /// # use rand::{Rng, rng};
+    /// # use rand::{Rng, RngExt, rng};
     /// # use std::convert::Infallible;
     /// #
     /// type Genome<T> = [T; 4];
@@ -331,7 +331,7 @@ where
     /// #     mutator::{Mutate, Mutator},
     /// #     Composable, Operator,
     /// # };
-    /// # use rand::{Rng, rng};
+    /// # use rand::{Rng, RngExt, rng};
     /// # use std::convert::Infallible;
     /// #
     /// # type Genome<T> = [T; 4];
@@ -411,7 +411,7 @@ where
 mod tests {
     use std::convert::Infallible;
 
-    use rand::{Rng, rng};
+    use rand::{Rng, RngExt, rng};
 
     use super::Mutator;
     use crate::operator::{Composable, Operator, mutator::Mutate};

--- a/packages/ec-core/src/operator/recombinator/erased.rs
+++ b/packages/ec-core/src/operator/recombinator/erased.rs
@@ -1,4 +1,4 @@
-use rand::{Rng, RngCore};
+use rand::Rng;
 
 use super::Recombinator;
 
@@ -59,7 +59,7 @@ pub trait DynRecombinator<GS, E = Box<dyn std::error::Error + Send + Sync>> {
     /// This will return an error if there is an error recombining the given
     /// parent genomes. This will usually be because the given `genomes` are
     /// invalid in some way, thus making recombination impossible.
-    fn dyn_recombine(&self, genomes: GS, rng: &mut dyn RngCore) -> Result<Self::Output, E>;
+    fn dyn_recombine(&self, genomes: GS, rng: &mut dyn Rng) -> Result<Self::Output, E>;
 }
 
 static_assertions::assert_obj_safe!(DynRecombinator<(), Output = ()>);
@@ -70,7 +70,7 @@ where
 {
     type Output = T::Output;
 
-    fn dyn_recombine(&self, genomes: GS, rng: &mut dyn RngCore) -> Result<Self::Output, E> {
+    fn dyn_recombine(&self, genomes: GS, rng: &mut dyn Rng) -> Result<Self::Output, E> {
         self.recombine(genomes, rng).map_err(Into::into)
     }
 }

--- a/packages/ec-core/src/operator/recombinator/mod.rs
+++ b/packages/ec-core/src/operator/recombinator/mod.rs
@@ -50,7 +50,7 @@ pub use erased::*;
 /// second parent.
 ///
 /// ```
-/// # use rand::{rng, Rng};
+/// # use rand::{rng, Rng, RngExt};
 /// # use ec_core::operator::recombinator::Recombinator;
 /// # use std::convert::Infallible;
 /// #
@@ -178,7 +178,7 @@ pub trait Recombinator<GS> {
 ///
 /// ```
 /// # use std::convert::Infallible;
-/// # use rand::{rng, Rng};
+/// # use rand::{rng, Rng, RngExt};
 /// #
 /// # use ec_core::operator::{recombinator::{Recombinator, Recombine}, Composable, Operator};
 /// #
@@ -242,7 +242,7 @@ pub trait Recombinator<GS> {
 /// ownership of the recombinator.
 ///
 /// ```
-/// # use rand::{ rng, Rng};
+/// # use rand::{rng, Rng, RngExt};
 /// # use std::convert::Infallible;
 /// #
 /// # use ec_core::operator::{recombinator::{Recombinator, Recombine}, Composable, Operator};
@@ -352,7 +352,7 @@ where
 mod tests {
     use std::convert::Infallible;
 
-    use rand::{Rng, rng};
+    use rand::{Rng, RngExt, rng};
 
     use super::{Recombinator, Recombine};
     use crate::operator::{Composable, Operator};

--- a/packages/ec-core/src/operator/selector/erased.rs
+++ b/packages/ec-core/src/operator/selector/erased.rs
@@ -1,4 +1,4 @@
-use rand::{Rng, RngCore};
+use rand::Rng;
 
 use super::Selector;
 use crate::population::Population;
@@ -68,7 +68,7 @@ where
     fn dyn_select<'pop>(
         &self,
         population: &'pop P,
-        rng: &mut dyn RngCore,
+        rng: &mut dyn Rng,
     ) -> Result<&'pop P::Individual, Error>;
 }
 
@@ -82,7 +82,7 @@ where
     fn dyn_select<'pop>(
         &self,
         population: &'pop P,
-        rng: &mut dyn RngCore,
+        rng: &mut dyn Rng,
     ) -> Result<&'pop <P as Population>::Individual, E> {
         self.select(population, rng).map_err(Into::into)
     }

--- a/packages/ec-core/src/operator/selector/tournament.rs
+++ b/packages/ec-core/src/operator/selector/tournament.rs
@@ -161,7 +161,7 @@ where
         }
         population
             .as_ref()
-            .choose_multiple(rng, self.size.into())
+            .sample(rng, self.size.into())
             .max()
             // This should never happen, because an empty population will cause the
             // `if` test test to return an `Err` since `self.size` is guaranteed to

--- a/packages/ec-core/src/population.rs
+++ b/packages/ec-core/src/population.rs
@@ -84,7 +84,7 @@ where
 mod tests {
     use core::ops::Range;
 
-    use rand::{Rng, prelude::Distribution, rng};
+    use rand::{Rng, RngExt, prelude::Distribution, rng};
 
     use crate::{
         distributions::collection::ConvertToCollectionDistribution, population::Population,

--- a/packages/ec-linear/src/genome/bitstring.rs
+++ b/packages/ec-linear/src/genome/bitstring.rs
@@ -4,7 +4,7 @@ use ec_core::{
     distributions::collection::{self, ConvertToCollectionDistribution},
     genome::Genome,
 };
-use rand::{Rng, distr::StandardUniform, prelude::Distribution};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution};
 
 use super::Linear;
 use crate::recombinator::{crossover::Crossover, errors::MultipleGeneAccess};

--- a/packages/ec-linear/src/mutator/umad.rs
+++ b/packages/ec-linear/src/mutator/umad.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 
 use ec_core::{genome::Genome, operator::mutator::Mutator};
-use rand::{Rng, prelude::Distribution};
+use rand::{Rng, RngExt, prelude::Distribution};
 
 use crate::genome::Linear;
 

--- a/packages/ec-linear/src/mutator/with_rate.rs
+++ b/packages/ec-linear/src/mutator/with_rate.rs
@@ -1,7 +1,7 @@
 use std::{convert::Infallible, ops::Not};
 
 use ec_core::operator::mutator::Mutator;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use crate::genome::Linear;
 

--- a/packages/ec-linear/src/recombinator/n_point_xo/sample_distinct_uniform.rs
+++ b/packages/ec-linear/src/recombinator/n_point_xo/sample_distinct_uniform.rs
@@ -1,6 +1,6 @@
 use std::ops::Not;
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 /// Sample `N` distinct values from range `start..end` returning
 /// sorted result

--- a/packages/ec-linear/src/recombinator/two_point_xo.rs
+++ b/packages/ec-linear/src/recombinator/two_point_xo.rs
@@ -1,5 +1,5 @@
 use ec_core::operator::recombinator::Recombinator;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use super::{
     crossover::Crossover,

--- a/packages/ec-linear/src/recombinator/uniform_xo.rs
+++ b/packages/ec-linear/src/recombinator/uniform_xo.rs
@@ -1,5 +1,5 @@
 use ec_core::operator::recombinator::Recombinator;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use super::{crossover::Crossover, errors::UniformCrossoverError};
 use crate::{genome::Linear, recombinator::errors::DifferentGenomeLength};

--- a/packages/push/src/genome/plushy.rs
+++ b/packages/push/src/genome/plushy.rs
@@ -6,7 +6,7 @@ use ec_core::{
     genome::Genome,
 };
 use ec_linear::genome::Linear;
-use rand::{Rng, prelude::Distribution};
+use rand::{Rng, RngExt, prelude::Distribution};
 
 use crate::instruction::{NumOpens, PushInstruction};
 


### PR DESCRIPTION
`RngCore` was renamed to `Rng` and `Rng` was renamed to `RngExt` so the `dyn RngCore` types became `dyn Rng` and we needed a bunch of `RngExt` imports.