### PR TITLE
Fix clippy issue with manyhow

### DIFF
--- a/packages/ec-macros/src/lib.rs
+++ b/packages/ec-macros/src/lib.rs
@@ -47,7 +47,7 @@ mod derive_composable;
 /// ```
 /// up to the generics of the type the derive is on, i.e. it will add the
 /// required generics and trait bounds as needed.
-#[expect(
+#[allow(
     unreachable_code,
     reason = "It appears that manyhow or clippy has a bug that leads to this warning"
 )]

--- a/packages/ec-macros/src/lib.rs
+++ b/packages/ec-macros/src/lib.rs
@@ -47,5 +47,9 @@ mod derive_composable;
 /// ```
 /// up to the generics of the type the derive is on, i.e. it will add the
 /// required generics and trait bounds as needed.
+#[expect(
+    unreachable_code,
+    reason = "It appears that manyhow or clippy has a bug that leads to this warning"
+)]
 #[manyhow::manyhow(proc_macro_derive(Composable))]
 pub use derive_composable::derive_composable;

--- a/packages/push/src/evaluation/cases/mod.rs
+++ b/packages/push/src/evaluation/cases/mod.rs
@@ -217,7 +217,7 @@ impl<Input, Output> Cases<Input, Output> {
     ///     *input = input.to_uppercase();
     /// }
     ///
-    /// assert!(cases.inputs().eq(&["THIS", "AND", "THOSE"]));
+    /// assert!(cases.inputs().eq(["THIS", "AND", "THOSE"]));
     /// assert!(cases.outputs().eq(&[4, 3, 5]));
     /// ```
     pub fn inputs_mut(&mut self) -> impl Iterator<Item = &mut Input> {

--- a/packages/push/src/evaluation/cases/mod.rs
+++ b/packages/push/src/evaluation/cases/mod.rs
@@ -413,7 +413,7 @@ mod tests {
             *input = input.to_uppercase();
         }
 
-        assert!(cases.inputs().eq(&["THIS", "AND", "THOSE"]));
+        assert!(cases.inputs().eq(["THIS", "AND", "THOSE"]));
         assert!(cases.outputs().eq(&[4, 3, 5]));
     }
 


### PR DESCRIPTION
We're not sure what the actual cause of the issue is, so we're currently using `expect` to hide it. Hopefully either `manyhow` or Clippy will fix the problem, and then the `expect` will fail and we'll have to remove it.