### PR TITLE
Fix examples so they print useful error information on fatal errors

### DIFF
--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -77,13 +77,16 @@ fn score_program(
 ) -> Of64 {
     let state = build_push_state(program, input);
 
-    let Ok(state) = state.run_to_completion() else {
-        // Do some logging, perhaps?
-        return Of64::from(PENALTY_VALUE);
+    let state = match state.run_to_completion() {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!("FATAL: {error}\n");
+            return Of64::from(PENALTY_VALUE);
+        }
     };
 
     let Ok(&answer) = state.stack::<Of64>().top() else {
-        // Do some logging, perhaps?
+        eprintln!("INFO: Float stack was empty at end of program evaluation");
         return Of64::from(PENALTY_VALUE);
     };
 
@@ -183,6 +186,7 @@ fn main() -> miette::Result<()> {
         // TODO: Change 2 to be the smallest number of digits needed for
         // max_generations-1.
         println!("Generation {generation_number:2} best is {best}");
+        eprintln!("INFO: Completed generation {generation_number:2}");
 
         if best
             .test_results

--- a/packages/push/examples/complex_regression/main.rs
+++ b/packages/push/examples/complex_regression/main.rs
@@ -22,7 +22,7 @@ use ec_core::{
     uniform_distribution_of,
 };
 use ec_linear::mutator::umad::Umad;
-use miette::ensure;
+use miette::{Report, ensure};
 use num_traits::Float;
 use ordered_float::OrderedFloat;
 use push::{
@@ -43,7 +43,7 @@ use crate::args::{CliArgs, RunModel};
 
 // The penalty value to use when an evolved program doesn't have an expected
 // "return" value on the appropriate stack at the end of its execution.
-const PENALTY_VALUE: f64 = 1_000.0;
+const PENALTY_VALUE: f64 = 1_000_000.0;
 
 type Of64 = OrderedFloat<f64>;
 
@@ -63,7 +63,7 @@ fn build_push_state(
                   arguably should check that and return an error here."
     )]
     PushState::builder()
-        .with_max_stack_size(1000)
+        .with_max_stack_size(1_000)
         .with_program(program)
         .unwrap()
         .with_float_input("x", input)
@@ -71,6 +71,10 @@ fn build_push_state(
         .build()
 }
 
+#[expect(
+    clippy::use_debug,
+    reason = "We want to use the pretty miette-based debug formatting here"
+)]
 fn score_program(
     program: impl DoubleEndedIterator<Item = PushProgram> + ExactSizeIterator,
     Case { input, output }: Case<Of64>,
@@ -80,7 +84,7 @@ fn score_program(
     let state = match state.run_to_completion() {
         Ok(state) => state,
         Err(error) => {
-            eprintln!("FATAL: {error}\n");
+            eprintln!("FATAL: {:?}", Report::new(error));
             return Of64::from(PENALTY_VALUE);
         }
     };

--- a/packages/push/examples/median/main.rs
+++ b/packages/push/examples/median/main.rs
@@ -15,7 +15,7 @@ use ec_core::{
     performance::{error_value::ErrorValue, test_results::TestResults},
 };
 use ec_linear::mutator::umad::Umad;
-use miette::{IntoDiagnostic, ensure};
+use miette::{IntoDiagnostic, Report, ensure};
 use push::{
     evaluation::{Case, Cases, WithTargetFn},
     genome::plushy::{GeneGenerator, Plushy},
@@ -151,6 +151,10 @@ fn score_genome(
         .collect()
 }
 
+#[expect(
+    clippy::use_debug,
+    reason = "We want to use the pretty miette-based debug formatting here"
+)]
 fn run_case(
     Case {
         input,
@@ -159,17 +163,20 @@ fn run_case(
     program: &[PushProgram],
     penalty_value: i128,
 ) -> i128 {
-    build_state(program, input).map_or(penalty_value, |start_state| {
-        // I don't think we're properly handling things like exceeding maximum
-        // stack size. I think the "Push way" here would be to take whatever
-        // value is on top of the relevant stack and go with it, but we instead
-        // return the penalty value.
-        start_state
-            .run_to_completion()
-            .map_or(penalty_value, |final_state| {
-                compute_error(&final_state, penalty_value, expected)
-            })
-    })
+    let Ok(start_state) = build_state(program, input) else {
+        return penalty_value;
+    };
+    // I don't think we're properly handling things like exceeding maximum
+    // stack size. I think the "Push way" here would be to take whatever
+    // value is on top of the relevant stack and go with it, but we instead
+    // return the penalty value.
+    start_state.run_to_completion().map_or_else(
+        |error| {
+            eprintln!("FATAL: {:?}", Report::new(error));
+            penalty_value
+        },
+        |final_state| compute_error(&final_state, penalty_value, expected),
+    )
 }
 
 fn build_state(program: &[PushProgram], Input([a, b, c]): Input) -> Result<PushState, StackError> {
@@ -184,14 +191,19 @@ fn build_state(program: &[PushProgram], Input([a, b, c]): Input) -> Result<PushS
 }
 
 fn compute_error(final_state: &PushState, penalty_value: i128, expected: i64) -> i128 {
-    final_state
-        .stack::<i64>()
-        .top()
-        .map_or(penalty_value, |answer| {
+    final_state.stack::<i64>().top().map_or_else(
+        |_| {
+            // TODO: When we introduce proper logging, we probably want to bring this
+            // message back at some (generally ignored) log level.
+            // eprintln!("INFO: Int stack was empty at end of program evaluation");
+            penalty_value
+        },
+        |answer| {
             i128::from(*answer)
                 .saturating_sub(i128::from(expected))
                 .abs()
-        })
+        },
+    )
 }
 
 fn instructions() -> impl Iterator<Item = PushInstruction> {

--- a/packages/push/src/instruction/common/cmp/equal.rs
+++ b/packages/push/src/instruction/common/cmp/equal.rs
@@ -125,9 +125,13 @@ where
         if bool_stack.is_full()
             && ![TypeId::of::<First>(), TypeId::of::<Second>()].contains(&TypeId::of::<bool>())
         {
+            let max_size = bool_stack.max_stack_size();
             return Err(Error::fatal(
                 state,
-                StackError::Overflow { stack_type: "bool" },
+                StackError::Overflow {
+                    stack_type: "bool",
+                    max_size,
+                },
             ));
         }
 
@@ -267,7 +271,10 @@ mod test {
         assert!(!result.is_recoverable());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "bool" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "bool",
+                max_size: 2
+            })
         );
     }
 

--- a/packages/push/src/instruction/common/cmp/greater_than.rs
+++ b/packages/push/src/instruction/common/cmp/greater_than.rs
@@ -129,9 +129,13 @@ where
         if bool_stack.is_full()
             && ![TypeId::of::<Second>(), TypeId::of::<First>()].contains(&TypeId::of::<bool>())
         {
+            let max_size = bool_stack.max_stack_size();
             return Err(Error::fatal(
                 state,
-                StackError::Overflow { stack_type: "bool" },
+                StackError::Overflow {
+                    stack_type: "bool",
+                    max_size,
+                },
             ));
         }
 
@@ -285,7 +289,10 @@ mod test {
         assert!(!result.is_recoverable());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "bool" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "bool",
+                max_size: 2
+            })
         );
     }
 

--- a/packages/push/src/instruction/common/cmp/greater_than_equal.rs
+++ b/packages/push/src/instruction/common/cmp/greater_than_equal.rs
@@ -129,9 +129,13 @@ where
         if bool_stack.is_full()
             && ![TypeId::of::<Second>(), TypeId::of::<First>()].contains(&TypeId::of::<bool>())
         {
+            let max_size = bool_stack.max_stack_size();
             return Err(Error::fatal(
                 state,
-                StackError::Overflow { stack_type: "bool" },
+                StackError::Overflow {
+                    stack_type: "bool",
+                    max_size,
+                },
             ));
         }
 
@@ -291,7 +295,10 @@ mod test {
         assert!(!result.is_recoverable());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "bool" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "bool",
+                max_size: 2
+            })
         );
     }
 

--- a/packages/push/src/instruction/common/cmp/less_than.rs
+++ b/packages/push/src/instruction/common/cmp/less_than.rs
@@ -129,9 +129,13 @@ where
         if bool_stack.is_full()
             && ![TypeId::of::<Second>(), TypeId::of::<First>()].contains(&TypeId::of::<bool>())
         {
+            let max_size = bool_stack.max_stack_size();
             return Err(Error::fatal(
                 state,
-                StackError::Overflow { stack_type: "bool" },
+                StackError::Overflow {
+                    stack_type: "bool",
+                    max_size,
+                },
             ));
         }
 
@@ -285,7 +289,10 @@ mod test {
         assert!(!result.is_recoverable());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "bool" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "bool",
+                max_size: 2
+            })
         );
     }
 

--- a/packages/push/src/instruction/common/cmp/less_than_equal.rs
+++ b/packages/push/src/instruction/common/cmp/less_than_equal.rs
@@ -129,9 +129,13 @@ where
         if bool_stack.is_full()
             && ![TypeId::of::<Second>(), TypeId::of::<First>()].contains(&TypeId::of::<bool>())
         {
+            let max_size = bool_stack.max_stack_size();
             return Err(Error::fatal(
                 state,
-                StackError::Overflow { stack_type: "bool" },
+                StackError::Overflow {
+                    stack_type: "bool",
+                    max_size,
+                },
             ));
         }
 
@@ -285,7 +289,10 @@ mod test {
         assert!(!result.is_recoverable());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "bool" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "bool",
+                max_size: 2
+            })
         );
     }
 

--- a/packages/push/src/instruction/common/cmp/not_equal.rs
+++ b/packages/push/src/instruction/common/cmp/not_equal.rs
@@ -126,9 +126,13 @@ where
         if bool_stack.is_full()
             && ![TypeId::of::<First>(), TypeId::of::<Second>()].contains(&TypeId::of::<bool>())
         {
+            let max_size = bool_stack.max_stack_size();
             return Err(Error::fatal(
                 state,
-                StackError::Overflow { stack_type: "bool" },
+                StackError::Overflow {
+                    stack_type: "bool",
+                    max_size,
+                },
             ));
         }
 
@@ -268,7 +272,10 @@ mod test {
         assert!(!result.is_recoverable());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "bool" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "bool",
+                max_size: 2
+            })
         );
     }
 

--- a/packages/push/src/instruction/common/dup.rs
+++ b/packages/push/src/instruction/common/dup.rs
@@ -154,7 +154,10 @@ mod tests {
         assert!(result.is_fatal());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "i64" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "i64",
+                max_size: 1
+            })
         );
     }
 

--- a/packages/push/src/instruction/common/is_empty.rs
+++ b/packages/push/src/instruction/common/is_empty.rs
@@ -167,7 +167,10 @@ mod tests {
         assert!(result.is_fatal());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "bool" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "bool",
+                max_size: 1
+            })
         );
     }
 }

--- a/packages/push/src/instruction/common/push_value.rs
+++ b/packages/push/src/instruction/common/push_value.rs
@@ -136,7 +136,10 @@ mod tests {
         assert!(result.is_fatal());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "i64" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "i64",
+                max_size: 0
+            })
         );
     }
 }

--- a/packages/push/src/instruction/common/stack_depth.rs
+++ b/packages/push/src/instruction/common/stack_depth.rs
@@ -198,7 +198,10 @@ mod tests {
         assert!(result.is_fatal());
         assert_eq!(
             result.error(),
-            &PushInstructionError::StackError(StackError::Overflow { stack_type: "i64" })
+            &PushInstructionError::StackError(StackError::Overflow {
+                stack_type: "i64",
+                max_size: 3
+            })
         );
     }
 }

--- a/packages/push/src/instruction/float.rs
+++ b/packages/push/src/instruction/float.rs
@@ -245,9 +245,13 @@ impl FloatInstruction {
         S: Clone + HasStack<OrderedFloat<f64>> + HasStack<bool>,
     {
         if state.stack::<bool>().is_full() {
+            let max_size = state.stack::<bool>().max_stack_size();
             return Err(Error::fatal(
                 state,
-                StackError::Overflow { stack_type: "bool" },
+                StackError::Overflow {
+                    stack_type: "bool",
+                    max_size,
+                },
             ));
         }
         let float_stack: &mut Stack<OrderedFloat<f64>> = state.stack_mut::<OrderedFloat<f64>>();

--- a/packages/push/src/instruction/instruction_error.rs
+++ b/packages/push/src/instruction/instruction_error.rs
@@ -8,14 +8,12 @@ use crate::push_vm::{stack::StackError, variables::UnknownVariableError};
 
 /// An error that can occur when performing a `PushInstruction`.
 #[derive(thiserror::Error, Debug, Eq, PartialEq, Diagnostic)]
+#[error("There was a error evaluating a `PushInstruction`")]
 pub enum PushInstructionError {
     /// Stack errors can be things like stack over- or underflows.
-    #[error(transparent)]
-    StackError(
-        #[from]
-        #[diagnostic_source]
-        StackError,
-    ),
+    // #[error("transparent")]
+    #[diagnostic(transparent)]
+    StackError(#[from] StackError),
     #[error("Exceeded the maximum step limit {step_limit}")]
     // The `StepLimitExceeded` variant is usually not seen by the user as it is
     // typically processed by the interpreter, and a value from the appropriate
@@ -27,26 +25,17 @@ pub enum PushInstructionError {
     StepLimitExceeded { step_limit: usize },
 
     /// Int errors can be things like integer overflows.
-    #[error(transparent)]
-    Int(
-        #[from]
-        #[diagnostic_source]
-        IntInstructionError,
-    ),
+    // #[error(transparent)]
+    #[diagnostic(transparent)]
+    Int(#[from] IntInstructionError),
 
-    #[error(transparent)]
-    Printing(
-        #[from]
-        #[diagnostic_source]
-        PrintingError,
-    ),
+    // #[error(transparent)]
+    #[diagnostic(transparent)]
+    Printing(#[from] PrintingError),
 
-    #[error(transparent)]
-    UnknownVariable(
-        #[from]
-        #[diagnostic_source]
-        UnknownVariableError,
-    ),
+    // #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnknownVariable(#[from] UnknownVariableError),
 }
 
 impl From<AppendStdoutError> for PushInstructionError {

--- a/packages/push/src/instruction/int/mod.rs
+++ b/packages/push/src/instruction/int/mod.rs
@@ -416,9 +416,13 @@ where
                 // the instruction, we need to check for the case that the boolean stack is
                 // already full, and return an `Overflow` error if it is.
                 if state.stack::<bool>().is_full() {
+                    let max_size = state.stack::<bool>().max_stack_size();
                     return Err(Error::fatal(
                         state,
-                        StackError::Overflow { stack_type: "bool" },
+                        StackError::Overflow {
+                            stack_type: "bool",
+                            max_size,
+                        },
                     ));
                 }
                 let int_stack: &mut Stack<i64> = state.stack_mut::<i64>();

--- a/packages/push/src/push_vm/stack.rs
+++ b/packages/push/src/push_vm/stack.rs
@@ -23,11 +23,13 @@ pub trait HasStack<T> {
         Self: Sized,
     {
         if self.stack::<U>().is_full() {
+            let max_size = self.stack::<U>().size();
             Err(Error::fatal(
                 self,
                 StackError::Overflow {
                     // TODO: Should make sure to overflow a stack so we know what this looks like.
                     stack_type: std::any::type_name::<T>(),
+                    max_size,
                 },
             ))
         } else {
@@ -95,15 +97,19 @@ pub enum StackError {
         num_requested: usize,
         num_present: usize,
     },
-    #[error("Pushed onto full stack of type {stack_type}.")]
+    #[error("Pushed onto full stack of type {stack_type} with max size {max_size}.")]
     // The `Overflow` variant is usually not seen by the user as it is
     // typically processed by the interpreter, and a value from the appropriate
     // stack is returned.
     #[diagnostic(
-        help = "You might want to increase your stack size if it seems to low",
+        help = "You might want to increase your stack size if the current size ({max_size}) seems \
+                too low",
         severity(Warning)
     )]
-    Overflow { stack_type: &'static str },
+    Overflow {
+        stack_type: &'static str,
+        max_size: usize,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -224,6 +230,7 @@ impl<A> TryExtend<A> for Stack<A> {
             self.values.shrink_to(current_capacity);
             return Err(StackError::Overflow {
                 stack_type: std::any::type_name::<A>(),
+                max_size: self.max_stack_size(),
             });
         }
 
@@ -459,6 +466,7 @@ impl<T> Stack<T> {
         if self.size() == self.max_stack_size {
             Err(StackError::Overflow {
                 stack_type: std::any::type_name::<T>(),
+                max_size: self.max_stack_size,
             })
         } else {
             self.values.push(value);
@@ -527,6 +535,7 @@ impl<T> Stack<T> {
         {
             return Err(StackError::Overflow {
                 stack_type: std::any::type_name::<T>(),
+                max_size: self.max_stack_size,
             });
         }
         self.values.extend(iter.rev());

--- a/packages/push/tests/float.rs
+++ b/packages/push/tests/float.rs
@@ -69,7 +69,11 @@ fn overflow_bool_stack() {
     let result = FloatInstruction::Equal.perform(state).unwrap_err();
     assert_eq!(
         result.error(),
-        &StackError::Overflow { stack_type: "bool" }.into()
+        &StackError::Overflow {
+            stack_type: "bool",
+            max_size: 2
+        }
+        .into()
     );
 }
 


### PR DESCRIPTION
The primary goal here was to update the various PushGP examples so they generated useful error information on fatal errors. Along the way, though, we also added the `max_size` field to `StackError::Overflow` so we could include information in error reporting.

Fixes: #499 